### PR TITLE
SteamVR performance fix

### DIFF
--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -617,6 +617,8 @@ Matrix4 GetSimpleDirectionMatrix(Vector4 Fs, bool invert);
 float g_fDebugFOVscale = 2.2f;
 float g_fDebugYCenter = 0.0f;
 
+void CalculateViewMatrix();
+
 // Bloom
 const int MAX_BLOOM_PASSES = 9;
 const int DEFAULT_BLOOM_PASSES = 5;
@@ -9524,6 +9526,12 @@ HRESULT Direct3DDevice::BeginScene()
 	g_ReticleCenterLimits.x1 = -10000;
 	g_ReticleCenterLimits.y1 = -10000;
 	//log_debug("[DBG] GetCurrentHeadingViewMatrix()");
+
+	/* Get the pose and calculate the full view matrix.
+	In SteamVR mode, this function will run WaitGetPoses() and block until ~3ms before the HMD vsync
+	to optimize tracker latency ("running start" algorithm).
+	*/
+	CalculateViewMatrix();
 
 	if (!this->_deviceResources->_renderTargetView)
 	{

--- a/impl11/ddraw/PrimarySurface.h
+++ b/impl11/ddraw/PrimarySurface.h
@@ -11,6 +11,9 @@ class Direct3DTexture;
 void InitHeadingMatrix();
 Matrix4 GetCurrentHeadingMatrix(Vector4 &Rs, Vector4 &Us, Vector4 &Fs, bool invert, bool debug);
 Matrix4 GetCurrentHeadingViewMatrix();
+void CalculateViewMatrix();
+void ProcessFreePIEGamePad(uint32_t axis0, uint32_t axis1, uint32_t buttonsPressed);
+void ACRunAction(WORD* action);
 
 class PrimarySurface : public IDirectDrawSurface
 {
@@ -125,11 +128,7 @@ public:
 
 	void RenderSunFlare();
 
-	void ACRunAction(WORD * action);
-
 	void RenderLaserPointer(D3D11_VIEWPORT * lastViewport, ID3D11PixelShader * lastPixelShader, Direct3DTexture * lastTextureSelected, ID3D11Buffer * lastVertexBuffer, UINT * lastVertexBufStride, UINT * lastVertexBufOffset);
-
-	void ProcessFreePIEGamePad(uint32_t axis0, uint32_t axis1, uint32_t buttonsPressed);
 
 	STDMETHOD(Flip)(THIS_ LPDIRECTDRAWSURFACE, DWORD);
 


### PR DESCRIPTION
First attempt at fixing SteamVR performance

    - View matrix calculation for rot+position extracted into CalculateViewMatrix()
    - CalculateViewMatrix() invocation moved into beginning of Direct3DDevice::BeginScene()

This improves performance, but breaks roll and position tracking.
Also, 2D content is not shown in the HMD (WaitGetPoses is never calledin that codepath. To be fixed).

Let me know if you want me to target another branch.