### PR TITLE
SteamVR performance fix (part 2)

### DIFF
--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -3093,7 +3093,7 @@ HRESULT DeviceResources::LoadMainResources()
 	if (FAILED(hr = this->_d3dDevice->CreateVertexShader(g_ShadowMapVS, sizeof(g_ShadowMapVS), nullptr, &_shadowMapVS)))
 		return hr;
 
-	if (FAILED(hr = this->_d3dDevice->CreatePixelShader(g_EdgeDetector, sizeof(g_EdgeDetector), nullptr, &_edgeDetector)))
+	if (FAILED(hr = this->_d3dDevice->CreatePixelShader(g_EdgeDetector, sizeof(g_EdgeDetector), nullptr, &_edgeDetectorPS)))
 		return hr;
 
 	if (g_bBloomEnabled) {
@@ -3386,7 +3386,7 @@ HRESULT DeviceResources::LoadResources()
 	if (FAILED(hr = this->_d3dDevice->CreateVertexShader(g_ShadowMapVS, sizeof(g_ShadowMapVS), nullptr, &_shadowMapVS)))
 		return hr;
 
-	if (FAILED(hr = this->_d3dDevice->CreatePixelShader(g_EdgeDetector, sizeof(g_EdgeDetector), nullptr, &_edgeDetector)))
+	if (FAILED(hr = this->_d3dDevice->CreatePixelShader(g_EdgeDetector, sizeof(g_EdgeDetector), nullptr, &_edgeDetectorPS)))
 		return hr;
 
 	if (g_bBloomEnabled) {

--- a/impl11/ddraw/DeviceResources.h
+++ b/impl11/ddraw/DeviceResources.h
@@ -989,7 +989,7 @@ public:
 	ComPtr<ID3D11PixelShader> _sunShaderPS;
 	ComPtr<ID3D11PixelShader> _sunFlareShaderPS;
 	ComPtr<ID3D11PixelShader> _sunFlareComposeShaderPS;
-	ComPtr<ID3D11PixelShader> _edgeDetector;
+	ComPtr<ID3D11PixelShader> _edgeDetectorPS;
 	
 	ComPtr<ID3D11PixelShader> _speedEffectPS;
 	ComPtr<ID3D11PixelShader> _speedEffectComposePS;

--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -12,13 +12,13 @@
 /*
 TODO:
 	VR metric reconstruction -- In progress
-	Fix the FOV in the mirror Window in SteamVR
-	DC texture names should be case-insenstive
+	
+	DC texture names should be case-insensitive
 	What's wrong with the map in VR?
 
 	Fixed, To Verify (Check again in SteamVR mode):
-		Triangle Pointer -- TO CHECK
-		Finalize the reticle in VR -- TO CHECK
+		Fix the FOV in the mirror Window in SteamVR -- approximate fix
+		Triangle Pointer -- visible, but may need more work
 		Check that the Tech Room is rendering properly in VR.
 
 	Auto-turn on headlights in the last mission.

--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -13,6 +13,7 @@
 TODO:
 	VR metric reconstruction -- In progress
 	
+	Triangle pointer: see https://www.shadertoy.com/view/MldcD7
 	DC texture names should be case-insensitive
 	What's wrong with the map in VR?
 
@@ -630,7 +631,7 @@ XWALightInfo g_XWALightInfo[MAX_XWA_LIGHTS];
 //Matrix4 GetCurrentHeadingMatrix(Vector4 &Rs, Vector4 &Us, Vector4 &Fs, bool invert, bool debug);
 Matrix4 GetCurrentHeadingViewMatrix();
 Matrix4 GetSimpleDirectionMatrix(Vector4 Fs, bool invert);
-float g_fDebugFOVscale = 2.2f;
+float g_fDebugFOVscale = 1.0f;
 float g_fDebugYCenter = 0.0f;
 
 // Bloom
@@ -2801,6 +2802,9 @@ bool LoadDCParams() {
 				g_fDCBrightness = fValue;
 			}
 
+			else if (_stricmp(param, "enable_wireframe_CMD") == 0) {
+				g_bEdgeDetectorEnabled = (bool)fValue;
+			}
 			else if (_stricmp(param, "wireframe_IFF_color_0") == 0) {
 				float x, y, z;
 				if (LoadGeneric3DCoords(buf, &x, &y, &z)) {
@@ -3868,9 +3872,6 @@ bool LoadSSAOParams() {
 				g_ShadertoyBuffer.preserveAspectRatioComp[1] = fValue;
 			}
 
-			else if (_stricmp(param, "enable_wireframe_CMD") == 0) {
-				g_bEdgeDetectorEnabled = (bool)fValue;
-			}
 		}
 	}
 	fclose(file);

--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -9617,12 +9617,6 @@ HRESULT Direct3DDevice::BeginScene()
 	g_ReticleCenterLimits.y1 = -10000;
 	//log_debug("[DBG] GetCurrentHeadingViewMatrix()");
 
-	/* Get the pose and calculate the full view matrix.
-	In SteamVR mode, this function will run WaitGetPoses() and block until ~3ms before the HMD vsync
-	to optimize tracker latency ("running start" algorithm).
-	*/
-	CalculateViewMatrix();
-
 	if (!this->_deviceResources->_renderTargetView)
 	{
 #if LOGGER

--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -317,7 +317,7 @@ const float DEFAULT_FLOATING_GUI_PARALLAX = 0.495f;
 const float DEFAULT_FLOATING_OBJ_PARALLAX = -0.025f;
 
 const float DEFAULT_TECH_LIB_PARALLAX = -2.0f;
-const float DEFAULT_TRIANGLE_POINTER_SCALE = 0.25f;
+const float DEFAULT_TRIANGLE_POINTER_DIST = 0.120f;
 const float DEFAULT_GUI_ELEM_PZ_THRESHOLD = 0.0008f;
 const float DEFAULT_ZOOM_OUT_SCALE = 1.0f;
 const bool DEFAULT_ZOOM_OUT_INITIAL_STATE = false;
@@ -406,7 +406,7 @@ const char *DYNAMIC_COCKPIT_ENABLED_VRPARAM = "dynamic_cockpit_enabled";
 const char *FIXED_GUI_VRPARAM = "fixed_GUI";
 const char *STICKY_ARROW_KEYS_VRPARAM = "sticky_arrow_keys";
 const char *RETICLE_SCALE_VRPARAM = "reticle_scale";
-const char *TRIANGLE_POINTER_SCALE_VRPARAM = "triangle_pointer_scale";
+const char *TRIANGLE_POINTER_DIST_VRPARAM = "triangle_pointer_distance";
 // 6dof vrparams
 const char *ROLL_MULTIPLIER_VRPARAM = "roll_multiplier";
 const char *FREEPIE_SLOT_VRPARAM = "freepie_slot";
@@ -595,6 +595,8 @@ float g_DCWireframeContrast = 3.0f;
 float g_fReticleScale = DEFAULT_RETICLE_SCALE;
 extern Vector2 g_SubCMDBracket; // Populated in XwaDrawBracketHook for the sub-CMD bracket when the enhanced 2D renderer is on
 
+Vector2 g_TriangleCentroid;
+
 /*********************************************************/
 // SHADOW MAPPING
 ShadowMappingData g_ShadowMapping;
@@ -631,7 +633,7 @@ XWALightInfo g_XWALightInfo[MAX_XWA_LIGHTS];
 //Matrix4 GetCurrentHeadingMatrix(Vector4 &Rs, Vector4 &Us, Vector4 &Fs, bool invert, bool debug);
 Matrix4 GetCurrentHeadingViewMatrix();
 Matrix4 GetSimpleDirectionMatrix(Vector4 Fs, bool invert);
-float g_fDebugFOVscale = 1.0f;
+float g_fDebugFOVscale = 0.06f;
 float g_fDebugYCenter = 0.0f;
 
 // Bloom
@@ -696,7 +698,7 @@ float g_fLensK3 = DEFAULT_LENS_K3;
 
 // GUI elements seem to be in the range 0..0.0005, so 0.0008 sounds like a good threshold:
 float g_fGUIElemPZThreshold = DEFAULT_GUI_ELEM_PZ_THRESHOLD;
-float g_fTrianglePointerScale = DEFAULT_TRIANGLE_POINTER_SCALE;
+float g_fTrianglePointerDist = DEFAULT_TRIANGLE_POINTER_DIST;
 float g_fGlobalScale = DEFAULT_GLOBAL_SCALE;
 //float g_fPostProjScale = 1.0f;
 float g_fGlobalScaleZoomOut = DEFAULT_ZOOM_OUT_SCALE;
@@ -987,7 +989,7 @@ void ResetVRParams() {
 	EvaluateIPD(DEFAULT_IPD);
 	g_bCockpitPZHackEnabled = true;
 	g_fGUIElemPZThreshold = DEFAULT_GUI_ELEM_PZ_THRESHOLD;
-	g_fTrianglePointerScale = DEFAULT_TRIANGLE_POINTER_SCALE;
+	g_fTrianglePointerDist = DEFAULT_TRIANGLE_POINTER_DIST;
 	//g_fGlobalScale = g_bSteamVREnabled ? DEFAULT_GLOBAL_SCALE_STEAMVR : DEFAULT_GLOBAL_SCALE;
 	g_fGlobalScale = DEFAULT_GLOBAL_SCALE;
 	//g_fPostProjScale = 1.0f;
@@ -1197,10 +1199,10 @@ void SaveVRParams() {
 	// using it because the PSMoveServiceSteamVRBridge is a bit tricky to setup and why would
 	// I do that when my current FreePIEBridgeLite is working properly -- and faster.
 
-	fprintf(file, "; The triangle pointer is placed at the edge of the screen in non-VR mode.To\n");
-	fprintf(file, "; make it visible in VR mode, we need to scale it down so that it moves closer\n");
-	fprintf(file, "; to the center of the screen.This setting controls that distance\n");
-	fprintf(file, "%s = %0.3f\n\n", TRIANGLE_POINTER_SCALE_VRPARAM, g_fTrianglePointerScale);
+	fprintf(file, "; Places the triangle pointer at the specified distance from the center of the\n");
+	fprintf(file, "; screen. A value of 0 places it right at the center, a value of 0.5 puts it\n");
+	fprintf(file, "; near the edge of the screen.\n");
+	fprintf(file, "%s = %0.3f\n\n", TRIANGLE_POINTER_DIST_VRPARAM, g_fTrianglePointerDist);
 
 	fclose(file);
 	log_debug("[DBG] vrparams.cfg saved");
@@ -4251,8 +4253,8 @@ void LoadVRParams() {
 			else if (_stricmp(param, RETICLE_SCALE_VRPARAM) == 0) {
 				g_fReticleScale = fValue;
 			}
-			else if (_stricmp(param, TRIANGLE_POINTER_SCALE_VRPARAM) == 0) {
-				g_fTrianglePointerScale = fValue;
+			else if (_stricmp(param, TRIANGLE_POINTER_DIST_VRPARAM) == 0) {
+				g_fTrianglePointerDist = fValue;
 			}
 			
 			param_read_count++;
@@ -8809,9 +8811,14 @@ HRESULT Direct3DDevice::Execute(
 				// and let's put it at text depth so that it doesn't cause visual contention against the
 				// cockpit
 				if (g_bIsTrianglePointer) {
-					bModifiedShaders = true;
-					g_VSCBuffer.scale_override = g_fTrianglePointerScale;
-					g_VSCBuffer.z_override = g_fTextDepth;
+					/*bModifiedShaders = true;
+					g_VSCBuffer.scale_override = 0.25f;
+					g_VSCBuffer.z_override = g_fTextDepth;*/
+					
+					(void)ComputeCentroid2D(instruction, currentIndexLocation, &g_TriangleCentroid);
+					// Don't render the triangle pointer anymore, we'll do it later, when rendering the
+					// reticle
+					goto out;
 				}
 
 				// Add extra depth to Floating GUI elements and Lens Flare
@@ -9502,7 +9509,7 @@ void Direct3DDevice::RenderEdgeDetector()
 	g_ShadertoyBuffer.SunColor[0].w = g_DCWireframeContrast;
 	resources->InitPSConstantBufferHyperspace(resources->_hyperspaceConstantBuffer.GetAddressOf(), &g_ShadertoyBuffer);
 
-	resources->InitPixelShader(resources->_edgeDetector);
+	resources->InitPixelShader(resources->_edgeDetectorPS);
 	if (g_bDumpSSAOBuffers) {
 		DirectX::SaveWICTextureToFile(context, resources->_offscreenAsInputDynCockpit, GUID_ContainerFormatJpeg,
 			L"C:\\Temp\\_edgeDetectorInput.jpg");

--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -6758,6 +6758,11 @@ HRESULT Direct3DDevice::Execute(
 	float displayWidth  = (float)resources->_displayWidth;
 	float displayHeight = (float)resources->_displayHeight;
 
+	// Synchronization point to wait for vsync before we start to send work to the GPU
+	// This avoids blocking the CPU while the compositor waits for the pixel shader effects to run in the GPU
+	// (that's what happens if we sync after Submit+Present)
+	vr::EVRCompositorError error = g_pVRCompositor->WaitGetPoses(&g_rTrackedDevicePose,	0, NULL, 0);
+
 	// Constant Buffer step (and aspect ratio)
 	if (SUCCEEDED(hr))
 	{

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -698,11 +698,9 @@ void GetSteamVRPositionalData(float* yaw, float* pitch, float* roll, float* x, f
 		vr::HmdQuaternionf_t q;
 		vr::ETrackedDeviceClass trackedDeviceClass = vr::VRSystem()->GetTrackedDeviceClass(unDevice);
 
-		vr::EVRCompositorError error = g_pVRCompositor->WaitGetPoses(&trackedDevicePose, 0, NULL, 0);
-		if (error) {
-			log_debug("SteamVR WaitGetPoses() error: %d", error);
-		}
-		//vr::VRSystem()->GetDeviceToAbsoluteTrackingPose(vr::TrackingUniverseSeated, 0, &trackedDevicePose, 1);
+		// 0.027 (~2.5 frames) is the estimated time it will take for the next frame to be displayed.
+		// TODO: calculate predicted seconds to photons from now dynamically
+		vr::VRSystem()->GetDeviceToAbsoluteTrackingPose(vr::TrackingUniverseSeated, 0.027, &trackedDevicePose, 1);
 		poseMatrix = trackedDevicePose.mDeviceToAbsoluteTracking; // This matrix contains all positional and rotational data.
 		q = rotationToQuaternion(trackedDevicePose.mDeviceToAbsoluteTracking);
 		quatToEuler(q, yaw, pitch, roll);
@@ -9409,6 +9407,7 @@ HRESULT PrimarySurface::Flip(
 			}
 			*/
 
+			CalculateViewMatrix();
 
 #ifdef DBG_VR
 			if (g_bStart3DCapture && !g_bDo3DCapture) {
@@ -9497,17 +9496,6 @@ HRESULT PrimarySurface::Flip(
 				}
 				messageShown = true;
 				hr = DDERR_SURFACELOST;
-			}
-			if (g_bUseSteamVR) {
-				//g_pVRCompositor->PostPresentHandoff();
-
-				//g_pHMD->GetTimeSinceLastVsync(&seconds, &frame);
-				//if (seconds > 0.008)
-
-				//float timeRemaining = g_pVRCompositor->GetFrameTimeRemaining();
-				//log_debug("[DBG] Time remaining: %0.3f", timeRemaining);
-				//if (timeRemaining < g_fFrameTimeRemaining) WaitGetPoses();
-				//WaitGetPoses();
 			}
 		}
 		else

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -9516,7 +9516,7 @@ HRESULT PrimarySurface::Flip(
 				hr = DDERR_SURFACELOST;
 			}
 			if (g_bUseSteamVR) {
-				g_pVRCompositor->PostPresentHandoff();
+				//g_pVRCompositor->PostPresentHandoff();
 
 				//g_pHMD->GetTimeSinceLastVsync(&seconds, &frame);
 				//if (seconds > 0.008)
@@ -9524,7 +9524,7 @@ HRESULT PrimarySurface::Flip(
 				//float timeRemaining = g_pVRCompositor->GetFrameTimeRemaining();
 				//log_debug("[DBG] Time remaining: %0.3f", timeRemaining);
 				//if (timeRemaining < g_fFrameTimeRemaining) WaitGetPoses();
-				WaitGetPoses();
+				//WaitGetPoses();
 			}
 		}
 		else

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -9499,9 +9499,6 @@ HRESULT PrimarySurface::Flip(
 				hr = DDERR_SURFACELOST;
 			}
 			if (g_bUseSteamVR) {
-<<<<<<< HEAD
-				g_pVRCompositor->PostPresentHandoff();
-=======
 				//g_pVRCompositor->PostPresentHandoff();
 
 				//g_pHMD->GetTimeSinceLastVsync(&seconds, &frame);
@@ -9511,7 +9508,6 @@ HRESULT PrimarySurface::Flip(
 				//log_debug("[DBG] Time remaining: %0.3f", timeRemaining);
 				//if (timeRemaining < g_fFrameTimeRemaining) WaitGetPoses();
 				//WaitGetPoses();
->>>>>>> Release_1_1_4
 			}
 		}
 		else

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -700,7 +700,7 @@ void GetSteamVRPositionalData(float* yaw, float* pitch, float* roll, float* x, f
 
 		// 0.027 (~2.5 frames) is the estimated time it will take for the next frame to be displayed.
 		// TODO: calculate predicted seconds to photons from now dynamically
-		vr::VRSystem()->GetDeviceToAbsoluteTrackingPose(vr::TrackingUniverseSeated, 0.027, &trackedDevicePose, 1);
+		vr::VRSystem()->GetDeviceToAbsoluteTrackingPose(vr::TrackingUniverseSeated, 0.027f, &trackedDevicePose, 1);
 		poseMatrix = trackedDevicePose.mDeviceToAbsoluteTracking; // This matrix contains all positional and rotational data.
 		q = rotationToQuaternion(trackedDevicePose.mDeviceToAbsoluteTracking);
 		quatToEuler(q, yaw, pitch, roll);

--- a/impl11/ddraw/dllmain.cpp
+++ b/impl11/ddraw/dllmain.cpp
@@ -27,7 +27,7 @@ extern float *g_hudScale;
 
 extern float g_fDefaultFOVDist;
 extern float g_fDebugFOVscale, g_fDebugYCenter;
-extern float g_fCurrentShipFocalLength, g_fReticleScale, g_fReticleOfsX, g_fReticleOfsY;
+extern float g_fCurrentShipFocalLength, g_fReticleScale;
 extern bool g_bYCenterHasBeenFixed;
 // Current window width and height
 int g_WindowWidth, g_WindowHeight;
@@ -529,10 +529,10 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 					/*g_fLightMapDistance += 1.0f;
 					log_debug("[DBG] [SHW] g_fLightMapDistance: %0.3f", g_fLightMapDistance);
 					break;*/
-				case 9:
+				/*case 9:
 					g_fReticleOfsY -= 0.1f;
 					log_debug("[DBG] g_fReticleOfsY: %0.3f", g_fReticleOfsY);
-					break;
+					break;*/
 				}
 
 				//g_contOriginWorldSpace.y += 0.02f;
@@ -565,10 +565,10 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 					/*g_fLightMapDistance -= 1.0f;
 					log_debug("[DBG] [SHW] g_fLightMapDistance: %0.3f", g_fLightMapDistance);
 					break;*/
-				case 9:
+				/*case 9:
 					g_fReticleOfsY += 0.1f;
 					log_debug("[DBG] g_fReticleOfsY: %0.3f", g_fReticleOfsY);
-					break;
+					break;*/
 				}
 
 				//g_contOriginWorldSpace.y -= 0.02f;

--- a/impl11/ddraw/dllmain.cpp
+++ b/impl11/ddraw/dllmain.cpp
@@ -398,7 +398,7 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 				case 4:
 					g_fDebugFOVscale += 0.01f;
 					log_debug("[DBG] g_fDebugFOVscale: %0.3f", g_fDebugFOVscale);
-					ComputeHyperFOVParams();
+					//ComputeHyperFOVParams();
 					//(*g_hudScale) += 0.1f;
 					//log_debug("[DBG] g_hudScale: %0.3f", *g_hudScale);
 					break;
@@ -458,7 +458,7 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 				case 4:
 					g_fDebugFOVscale -= 0.01f;
 					log_debug("[DBG] g_fDebugFOVscale: %0.3f", g_fDebugFOVscale);
-					ComputeHyperFOVParams();
+					//ComputeHyperFOVParams();
 					//(*g_hudScale) -= 0.1f;
 					//log_debug("[DBG] g_hudScale: %0.3f", *g_hudScale);
 					break;

--- a/impl11/shaders/ExternalHUDShader.hlsl
+++ b/impl11/shaders/ExternalHUDShader.hlsl
@@ -113,10 +113,7 @@ PixelShaderOutput main(PixelShaderInput input) {
 	if (VRmode == 0) output.color = bgTex.Sample(bgSampler, input.uv);
 	
 	vec2 p = (2.0 * fragCoord.xy - iResolution.xy) / min(iResolution.x, iResolution.y);
-	//vec2 q = (2.0 * texCoord.xy  - iResolution.xy) / min(iResolution.x, iResolution.y);
-	//vec2 q = p;
 	p *= preserveAspectRatioComp;
-	//q *= preserveAspectRatioComp;
 	p += vec2(0, y_center); // In XWA the aiming HUD is not at the screen's center in cockpit view
 	vec3 v = vec3(p, -FOVscale);
 	v = mul(viewMat, vec4(v, 0.0)).xyz;
@@ -150,16 +147,17 @@ PixelShaderOutput main(PixelShaderInput input) {
 
 	// This shader is not intended to be run outside VR anymore
 	//if (VRmode == 0) {
+		//float2 reticleUV = ((input.uv - reticleCentroid.xy) * reticleCentroid.z) + reticleCentroid.xy;
 		//output.color.rgb = lerp(output.color.rgb, col, 0.8 * dm);
 	//}
 	//else { 
 		float3 reticleCentroid = SunCoords[0].xyz;
-		// The following line renders the flat reticle, without distortion due to FOV
+		// The following line renders the flat reticle, without distortion due to FOV.
 		//float2 reticleUV = ((input.uv - reticleCentroid.xy) * reticleCentroid.z) + reticleCentroid.xy;
 		float2 reticleScale = reticleCentroid.z;
 		//if (VRmode == 1) reticleScale.x *= 0.5;
 		reticleScale.x *= 0.5;
-		float2 reticleUV = (v.xy * reticleScale + reticleCentroid.xy); // / preserveAspectRatioComp
+		float2 reticleUV = (v.xy * reticleScale / preserveAspectRatioComp + reticleCentroid.xy); // / preserveAspectRatioComp
 		float4 reticle = reticleTex.Sample(reticleSampler, reticleUV);
 		float alpha = 3.0 * dot(0.333, reticle);
 		// DEBUG


### PR DESCRIPTION
SteamVR performance fix, this time for real!

Moved WaitGetPoses() to Direct3DDevice::Execute(), just before starting to send work to the GPU for calculating the views.
This allows the CPU to start calculating the next frame after the Submit+Present, while the GPU works on the postprocessing effects.

Also removed PostPresentHandoff() from the Flip(), as this was blocking the CPU (instead of WaitGetPoses), at least with the Oculus driver.

The trace in GPUView shows the CPU only blocks in WaitGetPoses a short time waiting for vsync, but the GPU continues working. It is busy almost all the time now (no GPU bubbles!).