### PR TITLE
Use SteamVR tracking returned by WaitGetPoses()

### DIFF
--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -6645,11 +6645,13 @@ HRESULT Direct3DDevice::Execute(
 	str << this << " " << __FUNCTION__;
 	LogText(str.str());
 #endif
-	// Synchronization point to wait for vsync before we start to send work to the GPU
-	// This avoids blocking the CPU while the compositor waits for the pixel shader effects to run in the GPU
-	// (that's what happens if we sync after Submit+Present)
-	if (g_ExecuteCount == 0) { //only wait once per frame
+
+	if (g_bUseSteamVR && g_ExecuteCount==0) {//only wait once per frame
+		// Synchronization point to wait for vsync before we start to send work to the GPU
+		// This avoids blocking the CPU while the compositor waits for the pixel shader effects to run in the GPU
+		// (that's what happens if we sync after Submit+Present)
 		vr::EVRCompositorError error = g_pVRCompositor->WaitGetPoses(&g_rTrackedDevicePose, 0, NULL, 0);
+		g_bRunningStartAppliedOnThisFrame = true;
 	}
 	g_ExecuteCount++;
 
@@ -6757,14 +6759,6 @@ HRESULT Direct3DDevice::Execute(
 
 	float displayWidth  = (float)resources->_displayWidth;
 	float displayHeight = (float)resources->_displayHeight;
-
-	if (g_bUseSteamVR && !g_bRunningStartAppliedOnThisFrame) {
-		// Synchronization point to wait for vsync before we start to send work to the GPU
-		// This avoids blocking the CPU while the compositor waits for the pixel shader effects to run in the GPU
-		// (that's what happens if we sync after Submit+Present)
-		vr::EVRCompositorError error = g_pVRCompositor->WaitGetPoses(&g_rTrackedDevicePose, 0, NULL, 0);
-		g_bRunningStartAppliedOnThisFrame = true;
-	}
 
 	// Constant Buffer step (and aspect ratio)
 	if (SUCCEEDED(hr))

--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -6645,7 +6645,12 @@ HRESULT Direct3DDevice::Execute(
 	str << this << " " << __FUNCTION__;
 	LogText(str.str());
 #endif
-
+	// Synchronization point to wait for vsync before we start to send work to the GPU
+	// This avoids blocking the CPU while the compositor waits for the pixel shader effects to run in the GPU
+	// (that's what happens if we sync after Submit+Present)
+	if (g_ExecuteCount == 0) { //only wait once per frame
+		vr::EVRCompositorError error = g_pVRCompositor->WaitGetPoses(&g_rTrackedDevicePose, 0, NULL, 0);
+	}
 	g_ExecuteCount++;
 
 	//log_debug("[DBG] Execute (1)");

--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -225,6 +225,7 @@ float s_XwaHudScale = 1.0f;
 #include "Direct3DTexture.h"
 #include "BackbufferSurface.h"
 #include "ExecuteBufferDumper.h"
+#include "PrimarySurface.h"
 // TODO: Remove later
 #include "TextureSurface.h"
 
@@ -4563,6 +4564,7 @@ bool InitSteamVR()
 	}
 	log_debug("[DBG] SteamVR Compositor Initialized");
 
+	g_pVRCompositor->SetTrackingSpace(vr::TrackingUniverseSeated);
 	g_pVRCompositor->ForceInterleavedReprojectionOn(g_bInterleavedReprojection);
 	log_debug("[DBG] InterleavedReprojection: %d", g_bInterleavedReprojection);
 
@@ -6645,14 +6647,16 @@ HRESULT Direct3DDevice::Execute(
 	str << this << " " << __FUNCTION__;
 	LogText(str.str());
 #endif
-
+/*
 	if (g_bUseSteamVR && g_ExecuteCount==0) {//only wait once per frame
 		// Synchronization point to wait for vsync before we start to send work to the GPU
 		// This avoids blocking the CPU while the compositor waits for the pixel shader effects to run in the GPU
 		// (that's what happens if we sync after Submit+Present)
-		vr::EVRCompositorError error = g_pVRCompositor->WaitGetPoses(&g_rTrackedDevicePose, 0, NULL, 0);
+		//vr::EVRCompositorError error = g_pVRCompositor->WaitGetPoses(&g_rTrackedDevicePose, 0, NULL, 0);
+		CalculateViewMatrix();
 		g_bRunningStartAppliedOnThisFrame = true;
 	}
+*/
 	g_ExecuteCount++;
 
 	//log_debug("[DBG] Execute (1)");
@@ -6949,6 +6953,15 @@ HRESULT Direct3DDevice::Execute(
 		{
 			this->_deviceResources->InitIndexBuffer(this->_indexBuffer, g_config.D3dHookExists);
 		}
+	}
+
+	if (g_bUseSteamVR && g_ExecuteCount == 1) {//only wait once per frame
+	// Synchronization point to wait for vsync before we start to send work to the GPU
+	// This avoids blocking the CPU while the compositor waits for the pixel shader effects to run in the GPU
+	// (that's what happens if we sync after Submit+Present)
+	//vr::EVRCompositorError error = g_pVRCompositor->WaitGetPoses(&g_rTrackedDevicePose, 0, NULL, 0);
+		UpdateViewMatrix();
+		g_bRunningStartAppliedOnThisFrame = true;
 	}
 
 	// Render images

--- a/impl11/ddraw/PrimarySurface.h
+++ b/impl11/ddraw/PrimarySurface.h
@@ -11,7 +11,7 @@ class Direct3DTexture;
 void InitHeadingMatrix();
 Matrix4 GetCurrentHeadingMatrix(Vector4 &Rs, Vector4 &Us, Vector4 &Fs, bool invert, bool debug);
 Matrix4 GetCurrentHeadingViewMatrix();
-void CalculateViewMatrix();
+void UpdateViewMatrix();
 void ProcessFreePIEGamePad(uint32_t axis0, uint32_t axis1, uint32_t buttonsPressed);
 void ACRunAction(WORD* action);
 


### PR DESCRIPTION
Use `WaitGetPoses()` for updating the tracking pose instead of accessing the raw values with an arbitrary prediction time (`GetDeviceToAbsoluteTrackingPose()`).

I placed it  Direct3DDevice::Execute(), before the render stage.
I tried putting it at the very beginning, but I didn't see any benefit.
Ideally it must be done as late as possible before starting rendering. I tried it just before rendering one of the eyes, but it destroys the framerate.

There is still some jitter in the tracking, but I believe it's not due to the tracking itself, but with the reconstruction calculations, as it's more apparent in some elements of the 3D scene than other, especially in the 2D rendered stuff. Still need to investigate more.