### PR TITLE
Use pose from cockpitlook shared memory

### DIFF
--- a/impl11/ddraw/SteamVR.cpp
+++ b/impl11/ddraw/SteamVR.cpp
@@ -307,6 +307,7 @@ void GetSteamVRPositionalData(float* yaw, float* pitch, float* roll, float* x, f
 			// Here we're using g_pSharedData->pDataPtr to access the shared data, but
 			// we can also save pDataPtr to a global variable and use that instead.
 			trackedDevicePose = *(vr::TrackedDevicePose_t*) g_pSharedData->pDataPtr;
+			g_pSharedData->bDataReady = false;
 			vr::VRCompositor()->WaitGetPoses(NULL, vr::k_unMaxTrackedDeviceCount, NULL, 0);
 			//log_debug("[DBG] Using trackedDevidePose from CockpitLook");
 		}


### PR DESCRIPTION
Using the shared memory functions included by @Prof-Butts, share the `trackedDevicePose` obtained by CockpitLook and use it in ddraw.

Status: pitch, yaw, x,y,z work, but roll is broken (seems to be fixed to 0).