### PR TITLE
Fix incompatibility with modern OpenVR API

### DIFF
--- a/impl11/ddraw/SteamVR.cpp
+++ b/impl11/ddraw/SteamVR.cpp
@@ -10,6 +10,7 @@
 #include "XWAFramework.h"
 
 vr::IVRSystem* g_pHMD = NULL;
+vr::IVRChaperone* g_pChaperone = NULL;
 vr::IVRCompositor* g_pVRCompositor = NULL;
 vr::IVRScreenshots* g_pVRScreenshots = NULL;
 vr::TrackedDevicePose_t g_rTrackedDevicePose;
@@ -62,6 +63,7 @@ bool InitSteamVR()
 	vr::EVRInitError eError = vr::VRInitError_None;
 	g_pHMD = vr::VR_Init(&eError, vr::VRApplication_Scene);
 	g_headCenter.set(0, 0, 0);
+	g_pChaperone = vr::VRChaperone();
 
 	if (eError != vr::VRInitError_None)
 	{
@@ -102,7 +104,8 @@ bool InitSteamVR()
 	}
 
 	// Reset the seated pose
-	g_pHMD->ResetSeatedZeroPose();
+	//g_pHMD->ResetSeatedZeroPose();
+	g_pChaperone->ResetZeroPose(vr::TrackingUniverseSeated);
 
 	// Pre-multiply and store the eye and projection matrices:
 	ProcessSteamVREyeMatrices(vr::EVREye::Eye_Left);

--- a/impl11/ddraw/SteamVR.h
+++ b/impl11/ddraw/SteamVR.h
@@ -9,6 +9,7 @@
 
 
 extern vr::IVRSystem* g_pHMD;
+extern vr::IVRChaperone* g_pChaperone;
 extern vr::IVRCompositor* g_pVRCompositor;
 extern vr::IVRScreenshots* g_pVRScreenshots;
 extern vr::TrackedDevicePose_t g_rTrackedDevicePose;

--- a/impl11/ddraw/dllmain.cpp
+++ b/impl11/ddraw/dllmain.cpp
@@ -923,7 +923,7 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 
 			case VK_OEM_PERIOD:
 				if (g_bUseSteamVR)
-					g_pHMD->ResetSeatedZeroPose();
+					g_pChaperone->ResetZeroPose(vr::TrackingUniverseSeated);
 				g_bResetHeadCenter = true;
 
 				//g_contOriginWorldSpace.set(0.0f, 0.0f, 0.05f, 1);


### PR DESCRIPTION
Replace IVRSystem::ResetSeatedZeroPose() with IVRChaperone::ResetZeroPose(vr::TrackingUniverseSeated)

This needs an update of openvr_api.dll, should be included in the release when this is merged.