### PR TITLE
Pose prediction jitter fix

### DIFF
--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -7398,12 +7398,13 @@ void UpdateViewMatrix()
 
 	// Enable roll (formerly this was 6dof)
 	if (g_bUseSteamVR) {
-		//Matrix3 rotMatrix;
+		Matrix4 fullViewMatrix;
 
-		GetSteamVRPositionalData(&yaw, &pitch, &roll, &x, &y, &z /*, &rotMatrix*/);
+		GetSteamVRPositionalData(&yaw, &pitch, &roll, &x, &y, &z, &fullViewMatrix);
 		yaw   *= RAD_TO_DEG * g_fYawMultiplier;
 		pitch *= RAD_TO_DEG * g_fPitchMultiplier;
 		roll  *= RAD_TO_DEG * g_fRollMultiplier;
+
 
 		// DEBUG
 		if (g_bSteamVRYawPitchRollFromMouseLook)
@@ -7413,28 +7414,25 @@ void UpdateViewMatrix()
 		yaw   += g_fYawOffset;
 		pitch += g_fPitchOffset;
 
-		// Compute the full rotation
-		Matrix4 rotMatrixFull, rotMatrixYaw, rotMatrixPitch, rotMatrixRoll;
-		rotMatrixFull.identity();
-		rotMatrixYaw.identity();   rotMatrixYaw.rotateY(-yaw);
-		rotMatrixPitch.identity(); rotMatrixPitch.rotateX(-pitch);
-		rotMatrixRoll.identity();  rotMatrixRoll.rotateZ(roll);
-		rotMatrixFull = rotMatrixRoll * rotMatrixPitch * rotMatrixYaw;
+		// Compute the correction matrix with the correct axis signs
+		Matrix4 correctionMatrixFull, rotMatrixYaw, rotMatrixPitch, rotMatrixRoll, posMatrix;
+		rotMatrixYaw.identity();	rotMatrixYaw.rotateY(-yaw);
+		rotMatrixPitch.identity();	rotMatrixPitch.rotateX(-pitch);
+		rotMatrixRoll.identity();	rotMatrixRoll.rotateZ(roll);
+		posMatrix.identity();		posMatrix.translate(x, y, -z);
+		correctionMatrixFull = rotMatrixRoll * rotMatrixPitch * rotMatrixYaw * posMatrix;
+		
 
-		// Transform the absolute head position into a relative position. This is
-		// needed because the game will apply the yaw/pitch on its own. So, we need
-		// to undo the yaw/pitch transformation by computing the inverse of the
-		// rotation matrix. Fortunately, rotation matrices can be inverted with a
-		// simple transpose.
-		// rotMatrix.invert(); // I don't think we need to invert this matrix anymore: it's not used after this point
+		//g_viewMatrix.identity();
+		//g_viewMatrix.rotateZ(roll);
 
-		g_viewMatrix.identity();
-		g_viewMatrix.rotateZ(roll);
 		
 		// viewMat is not a full transform matrix: it's only RotZ
 		// because the cockpit hook already applies the yaw/pitch rotation
-		g_VSMatrixCB.viewMat = g_viewMatrix;
-		g_VSMatrixCB.fullViewMat = rotMatrixFull;
+		//g_VSMatrixCB.viewMat = g_viewMatrix;
+		//g_VSMatrixCB.fullViewMat = rotMatrixFull;
+		g_VSMatrixCB.viewMat = correctionMatrixFull;
+		g_VSMatrixCB.fullViewMat = correctionMatrixFull;
 	}
 	else 
 	{
@@ -9090,8 +9088,6 @@ HRESULT PrimarySurface::Flip(
 				context->ClearDepthStencilView(resources->_shadowMapDSV, D3D11_CLEAR_DEPTH, 1.0f, 0);
 			}
 			*/
-
-			//CalculateViewMatrix();
 
 #ifdef DBG_VR
 			if (g_bStart3DCapture && !g_bDo3DCapture) {

--- a/impl11/ddraw/SteamVR.cpp
+++ b/impl11/ddraw/SteamVR.cpp
@@ -285,7 +285,7 @@ char* GetTrackedDeviceString(vr::TrackedDeviceIndex_t unDevice, vr::TrackedDevic
 	return pchBuffer;
 }
 
-void GetSteamVRPositionalData(float* yaw, float* pitch, float* roll, float* x, float* y, float* z, Matrix3* rotMatrix)
+void GetSteamVRPositionalData(float* yaw, float* pitch, float* roll, float* x, float* y, float* z, Matrix4* fullMatrix)
 {
 	vr::TrackedDeviceIndex_t unDevice = vr::k_unTrackedDeviceIndex_Hmd;
 	if (!g_pHMD->IsTrackedDeviceConnected(unDevice)) {
@@ -301,7 +301,7 @@ void GetSteamVRPositionalData(float* yaw, float* pitch, float* roll, float* x, f
 		// Pose array predicted for next frame N+1, to use by XWA for CPU calculations next time CockpitLook is called.
 		vr::TrackedDevicePose_t trackedDevicePoseArrayNext[vr::k_unMaxTrackedDeviceCount];
 		vr::TrackedDevicePose_t trackedDevicePose; // HMD pose to use for the current frame render
-		vr::HmdMatrix34_t poseMatrix;
+		vr::HmdMatrix34_t m34_correctionMatrix;
 		vr::HmdQuaternionf_t q;
 		vr::ETrackedDeviceClass trackedDeviceClass = vr::VRSystem()->GetTrackedDeviceClass(unDevice);
 
@@ -334,17 +334,50 @@ void GetSteamVRPositionalData(float* yaw, float* pitch, float* roll, float* x, f
 
 		if (trackedDevicePose.bPoseIsValid)
 		{
-			poseMatrix = trackedDevicePose.mDeviceToAbsoluteTracking;  // This matrix contains all positional and rotational data.
-			q = rotationToQuaternion(poseMatrix);
+			// We need to apply the perspective correction between the pose predicted in the previous frame
+			// (used by CockpitLook in this frame and implicitly in the 2D->3D retroprojection)
+			// and the actual pose returned by WaitGetPoses that will be used to do the final 3D->2D projection
+
+			// Obtain the yaw, pitch that was applied by CockpitLook. Roll was ignored.
+			float yaw_cockpitlook, pitch_cockpitlook, x_cockpitlook, y_cockpitlook, z_cockpitlook;
+			Matrix4 m4_UndoCockpitLook;
+			yaw_cockpitlook = (float) (PlayerDataTable[*g_playerIndex].cockpitCameraYaw * 360.0f / 65535.0f);
+			pitch_cockpitlook = (float) (PlayerDataTable[*g_playerIndex].cockpitCameraPitch * 360.0f / 65535.0f);
+
+			// Get the translation
+			float g_fXWAUnitsToMetersScale = 400.0f; // Empirical value used hardcoded in CockpitLook, or set in cockpitlook.cfg (xwa_units_to_meters_scale)
+			x_cockpitlook = (float)PlayerDataTable[*g_playerIndex].cockpitXReference / g_fXWAUnitsToMetersScale;
+			y_cockpitlook = (float)PlayerDataTable[*g_playerIndex].cockpitYReference / g_fXWAUnitsToMetersScale;
+			z_cockpitlook = (float)PlayerDataTable[*g_playerIndex].cockpitZReference / g_fXWAUnitsToMetersScale;
+
+
+			// Build a transform matrix to "undo" the CockpitLook transformation based on HMD pose estimated in the previous frame
+			Matrix4 rotMatrixYaw, rotMatrixPitch, posMatrix;
+			rotMatrixYaw.identity();	rotMatrixYaw.rotateY(yaw_cockpitlook);
+			rotMatrixPitch.identity();	rotMatrixPitch.rotateX(-pitch_cockpitlook);
+			posMatrix.identity();		posMatrix.translate(-x_cockpitlook, -y_cockpitlook, z_cockpitlook);
+			// Create inverse matrix by applying the opposite angles, in inverse order
+			m4_UndoCockpitLook = posMatrix * rotMatrixYaw * rotMatrixPitch;
+
+			// Invert it to get the transform from that pose into the head center coordinate reference,
+			// hopefully cancelling the pose estimation and the loss of precision (float to int32)
+			//mCockpitLook.invert();
+
+			//Compose it with the transformation matrix for the actual HMD pose in the current frame (this is the correct view space for rendering, including roll)
+			Matrix4 m4_correctionMatrix = HmdMatrix34toMatrix4(trackedDevicePose.mDeviceToAbsoluteTracking) * m4_UndoCockpitLook;
+			Matrix4toHmdMatrix34(m4_correctionMatrix, m34_correctionMatrix);  // This matrix contains all positional and rotational data.
+			
+			// Finally we extract the components of the composed matrix to apply them later
+			q = rotationToQuaternion(m34_correctionMatrix);
 			quatToEuler(q, yaw, pitch, roll);
 
-			*x = poseMatrix.m[0][3];
-			*y = poseMatrix.m[1][3];
-			*z = poseMatrix.m[2][3];
-			*rotMatrix = HmdMatrix34toMatrix3(poseMatrix);
+			*x = m34_correctionMatrix.m[0][3];
+			*y = m34_correctionMatrix.m[1][3];
+			*z = m34_correctionMatrix.m[2][3];
+			*fullMatrix = m4_correctionMatrix;
 		}
 		else {
-			//log_debug("[DBG] HMD pose not valid");
+			log_debug("[DBG] HMD pose not valid");
 		}
 	}
 }
@@ -495,6 +528,40 @@ Matrix3 HmdMatrix33toMatrix3(const vr::HmdMatrix33_t& mat) {
 	return matrixObj;
 }
 
+Matrix4 HmdMatrix44toMatrix4(const vr::HmdMatrix44_t& mat) {
+	Matrix4 matrixObj(
+		mat.m[0][0], mat.m[1][0], mat.m[2][0], mat.m[3][0],
+		mat.m[0][1], mat.m[1][1], mat.m[2][1], mat.m[3][1],
+		mat.m[0][2], mat.m[1][2], mat.m[2][2], mat.m[3][2],
+		mat.m[0][3], mat.m[1][3], mat.m[2][3], mat.m[3][3]
+	);
+	return matrixObj;
+}
+
+Matrix4 HmdMatrix34toMatrix4(const vr::HmdMatrix34_t& mat) {
+	Matrix4 matrixObj(
+		mat.m[0][0], mat.m[1][0], mat.m[2][0], 0.0f,
+		mat.m[0][1], mat.m[1][1], mat.m[2][1], 0.0f,
+		mat.m[0][2], mat.m[1][2], mat.m[2][2], 0.0f,
+		mat.m[0][3], mat.m[1][3], mat.m[2][3], 1.0f
+	);
+	return matrixObj;
+}
+
+void Matrix4toHmdMatrix44(const Matrix4& m4, vr::HmdMatrix44_t& mat) {
+	mat.m[0][0] = m4[0];  mat.m[1][0] = m4[1];  mat.m[2][0] = m4[2];  mat.m[3][0] = m4[3];
+	mat.m[0][1] = m4[4];  mat.m[1][1] = m4[5];  mat.m[2][1] = m4[6];  mat.m[3][1] = m4[7];
+	mat.m[0][2] = m4[8];  mat.m[1][2] = m4[9];  mat.m[2][2] = m4[10]; mat.m[3][2] = m4[11];
+	mat.m[0][3] = m4[12]; mat.m[1][3] = m4[13]; mat.m[2][3] = m4[14]; mat.m[3][3] = m4[15];
+}
+
+void Matrix4toHmdMatrix34(const Matrix4& m4, vr::HmdMatrix34_t& mat) {
+	mat.m[0][0] = m4[0];  mat.m[1][0] = m4[1];  mat.m[2][0] = m4[2];
+	mat.m[0][1] = m4[4];  mat.m[1][1] = m4[5];  mat.m[2][1] = m4[6];
+	mat.m[0][2] = m4[8];  mat.m[1][2] = m4[9];  mat.m[2][2] = m4[10];
+	mat.m[0][3] = m4[12]; mat.m[1][3] = m4[13]; mat.m[2][3] = m4[14];
+}
+
 void DumpMatrix34(FILE* file, const vr::HmdMatrix34_t& m) {
 	if (file == NULL)
 		return;
@@ -560,33 +627,6 @@ void ShowHmdMatrix44(const vr::HmdMatrix44_t& mat, char* name) {
 	log_debug("[DBG] %0.6f, %0.6f, %0.6f, %0.6f", mat.m[2][0], mat.m[2][1], mat.m[2][2], mat.m[2][3]);
 	log_debug("[DBG] %0.6f, %0.6f, %0.6f, %0.6f", mat.m[3][0], mat.m[3][1], mat.m[3][2], mat.m[3][3]);
 	log_debug("[DBG] =========================================");
-}
-
-void Matrix4toHmdMatrix44(const Matrix4& m4, vr::HmdMatrix44_t& mat) {
-	mat.m[0][0] = m4[0];  mat.m[1][0] = m4[1];  mat.m[2][0] = m4[2];  mat.m[3][0] = m4[3];
-	mat.m[0][1] = m4[4];  mat.m[1][1] = m4[5];  mat.m[2][1] = m4[6];  mat.m[3][1] = m4[7];
-	mat.m[0][2] = m4[8];  mat.m[1][2] = m4[9];  mat.m[2][2] = m4[10]; mat.m[3][2] = m4[11];
-	mat.m[0][3] = m4[12]; mat.m[1][3] = m4[13]; mat.m[2][3] = m4[14]; mat.m[3][3] = m4[14];
-}
-
-Matrix4 HmdMatrix44toMatrix4(const vr::HmdMatrix44_t& mat) {
-	Matrix4 matrixObj(
-		mat.m[0][0], mat.m[1][0], mat.m[2][0], mat.m[3][0],
-		mat.m[0][1], mat.m[1][1], mat.m[2][1], mat.m[3][1],
-		mat.m[0][2], mat.m[1][2], mat.m[2][2], mat.m[3][2],
-		mat.m[0][3], mat.m[1][3], mat.m[2][3], mat.m[3][3]
-	);
-	return matrixObj;
-}
-
-Matrix4 HmdMatrix34toMatrix4(const vr::HmdMatrix34_t& mat) {
-	Matrix4 matrixObj(
-		mat.m[0][0], mat.m[1][0], mat.m[2][0], 0.0f,
-		mat.m[0][1], mat.m[1][1], mat.m[2][1], 0.0f,
-		mat.m[0][2], mat.m[1][2], mat.m[2][2], 0.0f,
-		mat.m[0][3], mat.m[1][3], mat.m[2][3], 1.0f
-	);
-	return matrixObj;
 }
 
 void ProcessSteamVREyeMatrices(vr::EVREye eye) {

--- a/impl11/ddraw/SteamVR.cpp
+++ b/impl11/ddraw/SteamVR.cpp
@@ -272,16 +272,6 @@ void projectSteamVR(float X, float Y, float Z, vr::EVREye eye, float& x, float& 
 	z = PX[2];
 }
 
-/*
-// To prevent jittering, avoid calling WaitGetPoses from ddraw -- call it from the CockpitLook hook
-// instead. m0rgg found that we were calling WaitGetPoses from those two places, thus causing jittering.
-bool WaitGetPoses() {
-	vr::EVRCompositorError error = g_pVRCompositor->WaitGetPoses(&g_rTrackedDevicePose,
-		0, NULL, 0);
-	return true;
-}
-*/
-
 char* GetTrackedDeviceString(vr::TrackedDeviceIndex_t unDevice, vr::TrackedDeviceProperty prop, vr::TrackedPropertyError* peError)
 {
 	char* pchBuffer = NULL;
@@ -306,13 +296,16 @@ void GetSteamVRPositionalData(float* yaw, float* pitch, float* roll, float* x, f
 	vr::VRControllerState_t state;
 	if (g_pHMD->GetControllerState(unDevice, &state, sizeof(state)))
 	{
-		vr::TrackedDevicePose_t trackedDevicePose;
+		// Pose array predicted for current frame N, to use by ddraw to render current frame in GPU (minimize latency)
 		vr::TrackedDevicePose_t trackedDevicePoseArray[vr::k_unMaxTrackedDeviceCount];
+		// Pose array predicted for next frame N+1, to use by XWA for CPU calculations next time CockpitLook is called.
+		vr::TrackedDevicePose_t trackedDevicePoseArrayNext[vr::k_unMaxTrackedDeviceCount];
+		vr::TrackedDevicePose_t trackedDevicePose; // HMD pose to use for the current frame render
 		vr::HmdMatrix34_t poseMatrix;
 		vr::HmdQuaternionf_t q;
 		vr::ETrackedDeviceClass trackedDeviceClass = vr::VRSystem()->GetTrackedDeviceClass(unDevice);
 
-		//vr::VRCompositor()->WaitGetPoses(trackedDevicePoseArray, vr::k_unMaxTrackedDeviceCount, NULL, 0);
+		vr::VRCompositor()->WaitGetPoses(trackedDevicePoseArray, vr::k_unMaxTrackedDeviceCount, trackedDevicePoseArrayNext, vr::k_unMaxTrackedDeviceCount);
 
 		// When the mouse hook is active, we the pose through g_pSharedData; but in 2D mode, or when we
 		// are in the hangar, we still need to query SteamVR directly. So we have to check g_bRendering3D
@@ -325,12 +318,12 @@ void GetSteamVRPositionalData(float* yaw, float* pitch, float* roll, float* x, f
 			// bDataReady is true, but I don't think there's a huge advantage to doing that.
 			//trackedDevicePose = *(vr::TrackedDevicePose_t*) g_pSharedData->pDataPtr;
 			//log_debug("[DBG] Using trackedDevicePose from CockpitLook\n");
-			vr::VRCompositor()->GetLastPoses(trackedDevicePoseArray, vr::k_unMaxTrackedDeviceCount, NULL, 0);
+			//vr::VRCompositor()->GetLastPoses(trackedDevicePoseArray, vr::k_unMaxTrackedDeviceCount, NULL, 0);
 			trackedDevicePose = trackedDevicePoseArray[vr::k_unTrackedDeviceIndex_Hmd];
 		}
 		else {
 			// We are probably in 2D mode, CockpitLook is not working. Get the poses here.
-			vr::VRCompositor()->WaitGetPoses(trackedDevicePoseArray, vr::k_unMaxTrackedDeviceCount, NULL, 0);
+			//vr::VRCompositor()->WaitGetPoses(trackedDevicePoseArray, vr::k_unMaxTrackedDeviceCount, NULL, 0);
 			trackedDevicePose = trackedDevicePoseArray[vr::k_unTrackedDeviceIndex_Hmd];
 			//log_debug("[DBG] Using trackedDevidePose from WaitGetPoses\n");
 			//log_debug("[DBG] g_bRendering3D=%d\n",g_bRendering3D);

--- a/impl11/ddraw/SteamVR.h
+++ b/impl11/ddraw/SteamVR.h
@@ -42,7 +42,7 @@ void ShutDownSteamVR();
 void projectSteamVR(float X, float Y, float Z, vr::EVREye eye, float& x, float& y, float& z);
 void ProcessSteamVREyeMatrices(vr::EVREye eye);
 char* GetTrackedDeviceString(vr::TrackedDeviceIndex_t unDevice, vr::TrackedDeviceProperty prop, vr::TrackedPropertyError* peError = NULL);
-void GetSteamVRPositionalData(float* yaw, float* pitch, float* roll, float* x, float* y, float* z, Matrix3* rotMatrix);
+void GetSteamVRPositionalData(float* yaw, float* pitch, float* roll, float* x, float* y, float* z, Matrix4* rotMatrix);
 // WaitGetPoses is now called from the CockpitLook hook.
 //bool WaitGetPoses();
 
@@ -60,6 +60,7 @@ void ShowMatrix4(const Matrix4& mat, char* name);
 void ShowHmdMatrix34(const vr::HmdMatrix34_t& mat, char* name);
 void ShowHmdMatrix44(const vr::HmdMatrix44_t& mat, char* name);
 void Matrix4toHmdMatrix44(const Matrix4 & m4, vr::HmdMatrix44_t & mat);
+void Matrix4toHmdMatrix34(const Matrix4& m4, vr::HmdMatrix34_t& mat);
 Matrix4 HmdMatrix44toMatrix4(const vr::HmdMatrix44_t& mat);
 Matrix4 HmdMatrix34toMatrix4(const vr::HmdMatrix34_t& mat);
 void ShowVector4(const Vector4& X, char* name);

--- a/impl11/ddraw/SteamVR.h
+++ b/impl11/ddraw/SteamVR.h
@@ -42,7 +42,7 @@ void ShutDownSteamVR();
 void projectSteamVR(float X, float Y, float Z, vr::EVREye eye, float& x, float& y, float& z);
 void ProcessSteamVREyeMatrices(vr::EVREye eye);
 char* GetTrackedDeviceString(vr::TrackedDeviceIndex_t unDevice, vr::TrackedDeviceProperty prop, vr::TrackedPropertyError* peError = NULL);
-void GetSteamVRPositionalData(float* yaw, float* pitch, float* roll, float* x, float* y, float* z, Matrix4* rotMatrix);
+void GetSteamVRPositionalData(float* yaw, float* pitch, float* roll, float* x, float* y, float* z);
 // WaitGetPoses is now called from the CockpitLook hook.
 //bool WaitGetPoses();
 

--- a/impl11/ddraw/SteamVR.h
+++ b/impl11/ddraw/SteamVR.h
@@ -42,7 +42,7 @@ void ShutDownSteamVR();
 void projectSteamVR(float X, float Y, float Z, vr::EVREye eye, float& x, float& y, float& z);
 void ProcessSteamVREyeMatrices(vr::EVREye eye);
 char* GetTrackedDeviceString(vr::TrackedDeviceIndex_t unDevice, vr::TrackedDeviceProperty prop, vr::TrackedPropertyError* peError = NULL);
-void GetSteamVRPositionalData(float* yaw, float* pitch, float* roll, float* x, float* y, float* z /*, Matrix3* rotMatrix */);
+void GetSteamVRPositionalData(float* yaw, float* pitch, float* roll, float* x, float* y, float* z, Matrix4* rotMatrix);
 // WaitGetPoses is now called from the CockpitLook hook.
 //bool WaitGetPoses();
 
@@ -60,6 +60,7 @@ void ShowMatrix4(const Matrix4& mat, char* name);
 void ShowHmdMatrix34(const vr::HmdMatrix34_t& mat, char* name);
 void ShowHmdMatrix44(const vr::HmdMatrix44_t& mat, char* name);
 void Matrix4toHmdMatrix44(const Matrix4 & m4, vr::HmdMatrix44_t & mat);
+void Matrix4toHmdMatrix34(const Matrix4& m4, vr::HmdMatrix34_t& mat);
 Matrix4 HmdMatrix44toMatrix4(const vr::HmdMatrix44_t& mat);
 Matrix4 HmdMatrix34toMatrix4(const vr::HmdMatrix34_t& mat);
 void ShowVector4(const Vector4& X, char* name);

--- a/impl11/ddraw/VRConfig.cpp
+++ b/impl11/ddraw/VRConfig.cpp
@@ -120,6 +120,7 @@ const char* ROLL_MULTIPLIER_VRPARAM = "roll_multiplier";
 const char* FREEPIE_SLOT_VRPARAM = "freepie_slot";
 const char* STEAMVR_POS_FROM_FREEPIE_VRPARAM = "steamvr_pos_from_freepie";
 // Cockpitlook params
+const char* POSE_CORRECTED_HEADTRACKING = "pose_corrected_headtracking";
 const char* YAW_MULTIPLIER_CLPARAM = "yaw_multiplier";
 const char* PITCH_MULTIPLIER_CLPARAM = "pitch_multiplier";
 const char* YAW_OFFSET_CLPARAM = "yaw_offset";
@@ -149,6 +150,7 @@ true if either DirectSBS or SteamVR are enabled. false for original display mode
 */
 bool g_bEnableVR = true;
 TrackerType g_TrackerType = TRACKER_NONE;
+bool g_bCorrectedHeadTracking = false;
 
 float g_fDebugFOVscale = 1.0f;
 float g_fDebugYCenter = 0.0f;
@@ -648,7 +650,7 @@ void SaveVRParams() {
 			fprintf(file, "%s = %s\n", VR_MODE_VRPARAM, VR_MODE_STEAMVR_SVAL);
 	}
 	fprintf(file, "\n");
-
+	
 	//fprintf(file, "focal_dist = %0.6f # Try not to modify this value, change IPD instead.\n", focal_dist);
 
 	fprintf(file, "; %s is measured in cms. Set it to 0 to remove the stereoscopy effect.\n", IPD_VRPARAM);
@@ -825,6 +827,10 @@ void LoadCockpitLookParams() {
 					g_TrackerType = TRACKER_NONE;
 				}
 
+			}
+			else if (_stricmp(param, POSE_CORRECTED_HEADTRACKING) == 0) {
+				log_debug("Using pose corrected head tracking");
+				g_bCorrectedHeadTracking = (bool)fValue;
 			}
 			/*else if (_stricmp(param, "cockpit_inertia_enabled") == 0) {
 				g_bCockpitInertiaEnabled = (bool)fValue;

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -173,6 +173,7 @@ extern bool g_bExternalHUDEnabled, g_bEdgeDetectorEnabled, g_bStarDebugEnabled;
 
 extern float g_f2DYawMul, g_f2DPitchMul, g_f2DRollMul;
 extern TrackerType g_TrackerType;
+extern bool g_bCorrectedHeadTracking;
 
 extern bool g_bAOEnabled;
 


### PR DESCRIPTION
This is an attempt to recover the performance improvements of moving WaitGetPoses() to Execute() in ddraw.dll, while fixing the jitter introduced by the pose prediction.

The idea is to compose a "correction" transformation matrix by "undoing" the yaw,pitch,x,y,z transformation applied by CockpitLook using the predicted pose, and then apply the complete actual pose returned by WaitGetPoses() (full rotation+translation).