### PR TITLE
Fixed pitch,yaw order in pose_corrected_headtracking = 1 mode

### DIFF
--- a/impl11/ddraw/SteamVR.cpp
+++ b/impl11/ddraw/SteamVR.cpp
@@ -346,7 +346,7 @@ void GetSteamVRPositionalData(float* yaw, float* pitch, float* roll, float* x, f
 				rotMatrixPitch.identity();	rotMatrixPitch.rotateX(-pitch_cockpitlook);
 				posMatrix.identity();		posMatrix.translate(-x_cockpitlook, -y_cockpitlook, -z_cockpitlook);
 				// Create inverse matrix by applying the opposite angles, in inverse order
-				m4_UndoCockpitLook = posMatrix * rotMatrixYaw * rotMatrixPitch;
+				m4_UndoCockpitLook = posMatrix * rotMatrixPitch * rotMatrixYaw;
 
 				// DEBUG: you can cancel positional tracking completely by uncommenting these lines
 				// g_fPosXMultiplier = 0;


### PR DESCRIPTION
I realized the largest tracking error I was suffering was due to applying pitch before raw when constructing the inverse matrix for the CockpitLook transform.

With the proper order, the tracking is almost fine, although there is some distortion that now is (I believe, again) similar to the one observed in the hangar.