### PR TITLE
Sync with CockpitLook new positional tracking hook and improvements to pose prediction corrected tracking

### DIFF
--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -3039,7 +3039,7 @@ HRESULT Direct3DDevice::Execute(
 					We're using a non-exhaustive list of GUI CRCs to tell when the 3D content has finished drawing.
 				*/
 
-				const bool bExternalCamera = (bool)PlayerDataTable[*g_playerIndex].externalCamera;
+				const bool bExternalCamera = (bool)PlayerDataTable[*g_playerIndex].Camera.ExternalCamera;
 				/* 
 				 * ZWriteEnabled is false when rendering the background starfield or when
 				 * rendering the GUI elements -- except that the targetting computer GUI
@@ -3254,12 +3254,12 @@ HRESULT Direct3DDevice::Execute(
 							g_PSCBuffer.bInHyperspace = 1;
 							g_PSCBuffer.fBloomStrength = g_BloomConfig.fHyperStreakStrength;
 							g_bClearedAuxBuffer = false; // We use this flag to clear the aux buffer if the cockpit camera moves
-							if (PlayerDataTable[*g_playerIndex].cockpitCameraYaw != g_fLastCockpitCameraYaw ||
-								PlayerDataTable[*g_playerIndex].cockpitCameraPitch != g_fLastCockpitCameraPitch)
+							if (PlayerDataTable[*g_playerIndex].MousePositionX != g_fLastCockpitCameraYaw ||
+								PlayerDataTable[*g_playerIndex].MousePositionY != g_fLastCockpitCameraPitch)
 								g_bHyperHeadSnapped = true;
 							if (*numberOfPlayersInGame == 1) {
-								PlayerDataTable[*g_playerIndex].cockpitCameraYaw = g_fLastCockpitCameraYaw;
-								PlayerDataTable[*g_playerIndex].cockpitCameraPitch = g_fLastCockpitCameraPitch;
+								PlayerDataTable[*g_playerIndex].MousePositionX = g_fLastCockpitCameraYaw;
+								PlayerDataTable[*g_playerIndex].MousePositionY = g_fLastCockpitCameraPitch;
 								// Restoring the cockpitX/Y/Z/Reference didn't seem to have any effect when cockpit inertia was on:
 								//PlayerDataTable[*g_playerIndex].cockpitXReference = g_lastCockpitXReference;
 								//PlayerDataTable[*g_playerIndex].cockpitYReference = g_lastCockpitYReference;
@@ -3434,11 +3434,11 @@ HRESULT Direct3DDevice::Execute(
 					{
 						if (g_bHyperDebugMode || g_HyperspacePhaseFSM == HS_INIT_ST || g_HyperspacePhaseFSM == HS_POST_HYPER_EXIT_ST)
 						{
-							g_fLastCockpitCameraYaw   = PlayerDataTable[*g_playerIndex].cockpitCameraYaw;
-							g_fLastCockpitCameraPitch = PlayerDataTable[*g_playerIndex].cockpitCameraPitch;
-							g_lastCockpitXReference   = PlayerDataTable[*g_playerIndex].cockpitXReference;
-							g_lastCockpitYReference   = PlayerDataTable[*g_playerIndex].cockpitYReference;
-							g_lastCockpitZReference   = PlayerDataTable[*g_playerIndex].cockpitZReference;
+							g_fLastCockpitCameraYaw   = PlayerDataTable[*g_playerIndex].MousePositionX;
+							g_fLastCockpitCameraPitch = PlayerDataTable[*g_playerIndex].MousePositionY;
+							g_lastCockpitXReference   = PlayerDataTable[*g_playerIndex].Camera.ShakeX;
+							g_lastCockpitYReference   = PlayerDataTable[*g_playerIndex].Camera.ShakeY;
+							g_lastCockpitZReference   = PlayerDataTable[*g_playerIndex].Camera.ShakeZ;
 
 							context->ResolveSubresource(resources->_shadertoyAuxBuf, 0, resources->_offscreenBuffer, 0, BACKBUFFER_FORMAT);
 							if (g_bUseSteamVR) {
@@ -6156,7 +6156,7 @@ void Direct3DDevice::RenderEdgeDetector()
 	auto& context = resources->_d3dDeviceContext;
 	D3D11_VIEWPORT viewport;
 	float bgColor[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
-	const bool bExternalView = PlayerDataTable[*g_playerIndex].externalCamera;
+	const bool bExternalView = PlayerDataTable[*g_playerIndex].Camera.ExternalCamera;
 	D3D11_DEPTH_STENCIL_DESC desc;
 	D3D11_BLEND_DESC blendDesc{};
 	ComPtr<ID3D11DepthStencilState> depthState;

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -189,9 +189,9 @@ void ComputeRotationMatrixFromXWAView(Vector4 *light, int num_lights) {
 
 	// TODO: Switch between cockpit and external cameras -- apply the external camera rotation
 	float viewYaw, viewPitch;
-	if (PlayerDataTable[*g_playerIndex].externalCamera) {
-		viewYaw   = PlayerDataTable[*g_playerIndex].cameraYaw   / 65536.0f * 360.0f;
-		viewPitch = PlayerDataTable[*g_playerIndex].cameraPitch / 65536.0f * 360.0f;
+	if (PlayerDataTable[*g_playerIndex].Camera.ExternalCamera) {
+		viewYaw   = PlayerDataTable[*g_playerIndex].Camera.Yaw   / 65536.0f * 360.0f;
+		viewPitch = PlayerDataTable[*g_playerIndex].Camera.Pitch / 65536.0f * 360.0f;
 	}
 	else {
 		viewYaw   = PlayerDataTable[*g_playerIndex].cockpitCameraYaw   / 65536.0f * 360.0f;
@@ -252,8 +252,8 @@ void GetFakeYawPitchRollFromKeyboard(float *yaw, float *pitch, float *roll) {
  * Returns the current yaw, pitch in PlayerDataTable in degrees
  */
 void GetFakeYawPitchRollFromMouseLook(float *yaw, float *pitch, float *roll) {
-	*yaw   = -(float)PlayerDataTable[*g_playerIndex].cockpitCameraYaw   / 65536.0f * 360.0f;
-	*pitch =  (float)PlayerDataTable[*g_playerIndex].cockpitCameraPitch / 65536.0f * 360.0f;
+	*yaw   = -(float)PlayerDataTable[*g_playerIndex].MousePositionX   / 65536.0f * 360.0f;
+	*pitch =  (float)PlayerDataTable[*g_playerIndex].MousePositionY / 65536.0f * 360.0f;
 	*roll  =  0.0f;
 }
 
@@ -3465,9 +3465,9 @@ Matrix4 GetCurrentHeadingMatrix(Vector4 &Rs, Vector4 &Us, Vector4 &Fs, bool inve
 	Matrix4 rotMatrixFull, rotMatrixYaw, rotMatrixPitch, rotMatrixRoll;
 	Vector4 T, B, N;
 	// Compute the full rotation
-	yaw   = PlayerDataTable[*g_playerIndex].yaw   / 65536.0f * 360.0f;
-	pitch = PlayerDataTable[*g_playerIndex].pitch / 65536.0f * 360.0f;
-	roll  = PlayerDataTable[*g_playerIndex].roll  / 65536.0f * 360.0f;
+	yaw   = PlayerDataTable[*g_playerIndex].Camera.CraftYaw   / 65536.0f * 360.0f;
+	pitch = PlayerDataTable[*g_playerIndex].Camera.CraftPitch/ 65536.0f * 360.0f;
+	roll  = PlayerDataTable[*g_playerIndex].Camera.CraftRoll / 65536.0f * 360.0f;
 
 	// To test how (x,y,z) is aligned with either the Y+ or Z+ axis, just multiply rotMatrixPitch * rotMatrixYaw * (x,y,z)
 	//Matrix4 rotMatrixFull, rotMatrixYaw, rotMatrixPitch, rotMatrixRoll;
@@ -3550,13 +3550,13 @@ Matrix4 GetCurrentHeadingViewMatrix() {
 	Matrix4 H = GetCurrentHeadingMatrix(Rs, Us, Fs, false, false);
 
 	float viewYaw, viewPitch;
-	if (PlayerDataTable[*g_playerIndex].externalCamera) {
-		viewYaw   = PlayerDataTable[*g_playerIndex].cameraYaw   / 65536.0f * 360.0f;
-		viewPitch = PlayerDataTable[*g_playerIndex].cameraPitch / 65536.0f * 360.0f;
+	if (PlayerDataTable[*g_playerIndex].Camera.ExternalCamera) {
+		viewYaw   = PlayerDataTable[*g_playerIndex].Camera.Yaw   / 65536.0f * 360.0f;
+		viewPitch = PlayerDataTable[*g_playerIndex].Camera.Pitch / 65536.0f * 360.0f;
 	}
 	else {
-		viewYaw   = PlayerDataTable[*g_playerIndex].cockpitCameraYaw   / 65536.0f * 360.0f;
-		viewPitch = PlayerDataTable[*g_playerIndex].cockpitCameraPitch / 65536.0f * 360.0f;
+		viewYaw   = PlayerDataTable[*g_playerIndex].MousePositionX   / 65536.0f * 360.0f;
+		viewPitch = PlayerDataTable[*g_playerIndex].MousePositionY / 65536.0f * 360.0f;
 	}
 	Matrix4 viewMatrixYaw, viewMatrixPitch;
 	viewMatrixYaw.identity();
@@ -3569,13 +3569,13 @@ Matrix4 GetCurrentHeadingViewMatrix() {
 void GetCockpitViewMatrix(Matrix4 *result, bool invert=true) {
 	float yaw, pitch;
 	
-	if (PlayerDataTable[*g_playerIndex].externalCamera) {
-		yaw   = (float)PlayerDataTable[*g_playerIndex].cameraYaw   / 65536.0f * 360.0f + 180.0f;
-		pitch = (float)PlayerDataTable[*g_playerIndex].cameraPitch / 65536.0f * 360.0f;
+	if (PlayerDataTable[*g_playerIndex].Camera.ExternalCamera) {
+		yaw   = (float)PlayerDataTable[*g_playerIndex].Camera.Yaw   / 65536.0f * 360.0f + 180.0f;
+		pitch = (float)PlayerDataTable[*g_playerIndex].Camera.Pitch / 65536.0f * 360.0f;
 	}
 	else {
-		yaw   = (float)PlayerDataTable[*g_playerIndex].cockpitCameraYaw   / 65536.0f * 360.0f + 180.0f;
-		pitch = (float)PlayerDataTable[*g_playerIndex].cockpitCameraPitch / 65536.0f * 360.0f;
+		yaw   = (float)PlayerDataTable[*g_playerIndex].MousePositionX   / 65536.0f * 360.0f + 180.0f;
+		pitch = (float)PlayerDataTable[*g_playerIndex].MousePositionY / 65536.0f * 360.0f;
 	}
 
 	Matrix4 rotMatrixFull, rotMatrixYaw, rotMatrixPitch, rotMatrixRoll;
@@ -3606,13 +3606,13 @@ void PrimarySurface::GetCockpitViewMatrixSpeedEffect(Matrix4 *result, bool inver
 	{
 		float yaw, pitch;
 
-		if (PlayerDataTable[*g_playerIndex].externalCamera) {
-			yaw = -(float)PlayerDataTable[*g_playerIndex].cameraYaw / 65536.0f * 360.0f;
-			pitch = (float)PlayerDataTable[*g_playerIndex].cameraPitch / 65536.0f * 360.0f;
+		if (PlayerDataTable[*g_playerIndex].Camera.ExternalCamera) {
+			yaw = -(float)PlayerDataTable[*g_playerIndex].Camera.Yaw / 65536.0f * 360.0f;
+			pitch = (float)PlayerDataTable[*g_playerIndex].Camera.Pitch / 65536.0f * 360.0f;
 		}
 		else {
-			yaw = -(float)PlayerDataTable[*g_playerIndex].cockpitCameraYaw / 65536.0f * 360.0f;
-			pitch = (float)PlayerDataTable[*g_playerIndex].cockpitCameraPitch / 65536.0f * 360.0f;
+			yaw = -(float)PlayerDataTable[*g_playerIndex].MousePositionX / 65536.0f * 360.0f;
+			pitch = (float)PlayerDataTable[*g_playerIndex].MousePositionY / 65536.0f * 360.0f;
 		}
 
 		Matrix4 rotMatrixYaw, rotMatrixPitch, rotMatrixRoll;
@@ -4018,9 +4018,9 @@ void PrimarySurface::RenderHyperspaceEffect(D3D11_VIEWPORT *lastViewport,
 
 	if (*xwa::numberOfPlayersInGame == 1 && !g_bCockpitInertiaEnabled) 
 	{
-		PlayerDataTable[*g_playerIndex].cockpitXReference = iShakeX;
-		PlayerDataTable[*g_playerIndex].cockpitYReference = iShakeY;
-		PlayerDataTable[*g_playerIndex].cockpitZReference = iShakeZ;
+		PlayerDataTable[*g_playerIndex].Camera.ShakeX = iShakeX;
+		PlayerDataTable[*g_playerIndex].Camera.ShakeY = iShakeY;
+		PlayerDataTable[*g_playerIndex].Camera.ShakeZ = iShakeZ;
 	}
 	*/
 
@@ -4529,7 +4529,7 @@ void PrimarySurface::RenderStarDebug()
 	float x0, y0, x1, y1;
 	D3D11_VIEWPORT viewport;
 	float bgColor[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
-	const bool bExternalView = PlayerDataTable[*g_playerIndex].externalCamera;
+	const bool bExternalView = PlayerDataTable[*g_playerIndex].Camera.ExternalCamera;
 
 	GetScreenLimitsInUVCoords(&x0, &y0, &x1, &y1);
 	GetCraftViewMatrix(&g_ShadertoyBuffer.viewMat);
@@ -4792,7 +4792,7 @@ void PrimarySurface::RenderExternalHUD()
 	float x0, y0, x1, y1;
 	D3D11_VIEWPORT viewport;
 	float bgColor[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
-	const bool bExternalView = PlayerDataTable[*g_playerIndex].externalCamera;
+	const bool bExternalView = PlayerDataTable[*g_playerIndex].Camera.ExternalCamera;
 	const bool bReticleInvisible = g_ReticleCentroid.x < 0.0f || g_ReticleCentroid.y < 0.0f;
 	const bool bTriangleInvisible = g_TriangleCentroid.x < 0.0f || g_TriangleCentroid.y < 0.0f;
 
@@ -5295,7 +5295,7 @@ void PrimarySurface::RenderSpeedEffect()
 	D3D11_VIEWPORT viewport;
 	float bgColor[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 	int NumParticleVertices = 0, NumParticles = 0;
-	const bool bExternalView = PlayerDataTable[*g_playerIndex].externalCamera;
+	const bool bExternalView = PlayerDataTable[*g_playerIndex].Camera.ExternalCamera;
 	static float ZTimeDisp[MAX_SPEED_PARTICLES] = { 0 };
 	float craft_speed = PlayerDataTable[*g_playerIndex].currentSpeed / g_fSpeedShaderScaleFactor;
 
@@ -5755,9 +5755,9 @@ Matrix4 PrimarySurface::ComputeAddGeomViewMatrix(Matrix4 *HeadingMatrix, Matrix4
 	}
 
 	// Add the CockpitRef translation
-	T.x = PlayerDataTable[*g_playerIndex].cockpitXReference * g_fCockpitTranslationScale;
-	T.y = PlayerDataTable[*g_playerIndex].cockpitYReference * g_fCockpitTranslationScale;
-	T.z = PlayerDataTable[*g_playerIndex].cockpitZReference * g_fCockpitTranslationScale;
+	T.x = PlayerDataTable[*g_playerIndex].Camera.ShakeX * g_fCockpitTranslationScale;
+	T.y = PlayerDataTable[*g_playerIndex].Camera.ShakeY * g_fCockpitTranslationScale;
+	T.z = PlayerDataTable[*g_playerIndex].Camera.ShakeZ * g_fCockpitTranslationScale;
 
 	T.w = 0.0f;
 	T = *HeadingMatrix * T; // The heading matrix is needed to convert the translation into the correct frame
@@ -5775,7 +5775,7 @@ void PrimarySurface::RenderAdditionalGeometry()
 	D3D11_VIEWPORT viewport;
 	float bgColor[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 	int NumParticleVertices = 0, NumParticles = 0;
-	const bool bExternalView = PlayerDataTable[*g_playerIndex].externalCamera;
+	const bool bExternalView = PlayerDataTable[*g_playerIndex].Camera.ExternalCamera;
 	Matrix4 HeadingMatrix, CockpitMatrix;
 
 	Matrix4 ViewMatrix = ComputeAddGeomViewMatrix(&HeadingMatrix, &CockpitMatrix);
@@ -6284,7 +6284,7 @@ void PrimarySurface::TagXWALights()
 	int NumTagged = 0;
 	// Get the screen limits, we'll need them to tell when a light is visible on the screen
 	float x0, y0, x1, y1;
-	bool bExternal = PlayerDataTable[*g_playerIndex].externalCamera;
+	bool bExternal = PlayerDataTable[*g_playerIndex].Camera.ExternalCamera;
 	// Don't tag anything in external view (I don't know if y_center needs to be used)
 	if (bExternal)
 		return;
@@ -6691,7 +6691,7 @@ void PrimarySurface::RenderSunFlare()
 	static float iTime = 0.0f;
 	Vector3 Centroid, QL[MAX_SUN_FLARES], QR[MAX_SUN_FLARES];
 	Vector2 Q[MAX_SUN_FLARES];
-	const bool bExternalView = PlayerDataTable[*g_playerIndex].externalCamera;
+	const bool bExternalView = PlayerDataTable[*g_playerIndex].Camera.ExternalCamera;
 
 	iTime += 0.01f;
 	GetScreenLimitsInUVCoords(&x0, &y0, &x1, &y1);
@@ -7425,7 +7425,6 @@ void UpdateViewMatrix()
 		posMatrix.translate(x, y, -z);
 		// In all cases we want the roll from the HMD pose as it is never applied in CockpitLook
 		rotMatrixRoll.rotateZ(roll);
-		g_viewMatrix = rotMatrixRoll;
 
 		// Compose the full transformation matrix to use in the Vertex Shader.
 		viewMatrixFull = rotMatrixRoll * rotMatrixPitch * rotMatrixYaw * posMatrix;
@@ -7433,6 +7432,9 @@ void UpdateViewMatrix()
 		if (g_bCorrectedHeadTracking) {
 			// If we want corrected tracking, we need to apply the full rotation+translation matrix in all cases
 			g_viewMatrix = viewMatrixFull;
+		}
+		else {
+			g_viewMatrix = rotMatrixRoll;
 		}
 
 		g_VSMatrixCB.viewMat = g_viewMatrix;
@@ -7459,8 +7461,8 @@ void UpdateViewMatrix()
 
 		if (g_bYawPitchFromMouseOverride) {
 			// If FreePIE could not be read, then get the yaw/pitch from the mouse:
-			yaw   =  (float)PlayerDataTable[*g_playerIndex].cockpitCameraYaw / 32768.0f * 180.0f;
-			pitch = -(float)PlayerDataTable[*g_playerIndex].cockpitCameraPitch / 32768.0f * 180.0f;
+			yaw   =  (float)PlayerDataTable[*g_playerIndex].MousePositionX / 32768.0f * 180.0f;
+			pitch = -(float)PlayerDataTable[*g_playerIndex].MousePositionY / 32768.0f * 180.0f;
 		}
 
 		if (g_bEnableVR) {
@@ -7468,13 +7470,13 @@ void UpdateViewMatrix()
 			// so we need to use the yaw,pitch,roll coming from FreePIE. But if we're doing 3D rendering, then
 			// the hook should've updated the cockpit/external camera and we can read it here:
 			if (g_bRendering3D && !(*g_playerInHangar)) {
-				if (PlayerDataTable[*g_playerIndex].externalCamera) {
-					yaw   = (float)PlayerDataTable[*g_playerIndex].cameraYaw / 65536.0f * 360.0f;
-					pitch = (float)PlayerDataTable[*g_playerIndex].cameraPitch / 65536.0f * 360.0f;
+				if (PlayerDataTable[*g_playerIndex].Camera.ExternalCamera) {
+					yaw   = (float)PlayerDataTable[*g_playerIndex].Camera.Yaw / 65536.0f * 360.0f;
+					pitch = (float)PlayerDataTable[*g_playerIndex].Camera.Pitch / 65536.0f * 360.0f;
 				}
 				else {
-					yaw   = (float)PlayerDataTable[*g_playerIndex].cockpitCameraYaw / 65536.0f * 360.0f;
-					pitch = (float)PlayerDataTable[*g_playerIndex].cockpitCameraPitch / 65536.0f * 360.0f;
+					yaw   = (float)PlayerDataTable[*g_playerIndex].MousePositionX / 65536.0f * 360.0f;
+					pitch = (float)PlayerDataTable[*g_playerIndex].MousePositionY / 65536.0f * 360.0f;
 				}
 			}
 
@@ -7511,19 +7513,19 @@ void UpdateViewMatrix()
 	// The reason we have to do this here is because the hangar does not activate the regular
 	// mouse look hook.
 	if ((g_TrackerType == TRACKER_FREEPIE || g_TrackerType == TRACKER_STEAMVR) && *g_playerInHangar) {
-		const bool bExternalCamera = PlayerDataTable[*g_playerIndex].externalCamera;
+		const bool bExternalCamera = PlayerDataTable[*g_playerIndex].Camera.ExternalCamera;
 		
 		// For the DirectSBS mode we need to invert the yaw:
 		if (g_TrackerType == TRACKER_FREEPIE)
 			yaw = -yaw;
 
 		if (bExternalCamera) {
-			PlayerDataTable[*g_playerIndex].cameraYaw = -(short )((yaw / 360.0f) * 65535.0f);
-			PlayerDataTable[*g_playerIndex].cameraPitch = (short)((pitch / 360.0f) * 65535.0f);
+			PlayerDataTable[*g_playerIndex].Camera.Yaw = -(short )((yaw / 360.0f) * 65535.0f);
+			PlayerDataTable[*g_playerIndex].Camera.Pitch = (short)((pitch / 360.0f) * 65535.0f);
 		}
 		else {
-			PlayerDataTable[*g_playerIndex].cockpitCameraYaw = -(short)((yaw / 360.0f) * 65535.0f);
-			PlayerDataTable[*g_playerIndex].cockpitCameraPitch = (short)((pitch / 360.0f) * 65535.0f);
+			PlayerDataTable[*g_playerIndex].MousePositionX = -(short)((yaw / 360.0f) * 65535.0f);
+			PlayerDataTable[*g_playerIndex].MousePositionY = (short)((pitch / 360.0f) * 65535.0f);
 		}
 	}
 
@@ -8138,16 +8140,16 @@ HRESULT PrimarySurface::Flip(
 		auto &resources = this->_deviceResources;
 		auto &context = resources->_d3dDeviceContext;
 		auto &device = resources->_d3dDevice;
-		const bool bExternalCamera = PlayerDataTable[*g_playerIndex].externalCamera;
+		const bool bExternalCamera = PlayerDataTable[*g_playerIndex].Camera.ExternalCamera;
 		const bool bCockpitDisplayed = PlayerDataTable[*g_playerIndex].cockpitDisplayed;
 		const bool bMapOFF = PlayerDataTable[*g_playerIndex].mapState == 0;
-		const int cameraObjIdx = PlayerDataTable[*g_playerIndex].cameraFG;
-		int FlyByCameraTime = PlayerDataTable[*g_playerIndex].FlyByCameraTime;
+		const int cameraObjIdx = PlayerDataTable[*g_playerIndex].Camera.CraftIndex;
+		int FlyByCameraTime = PlayerDataTable[*g_playerIndex].Camera.FlyByCameraTime;
 
 		// This moves the external camera when in the hangar:
 		//static __int16 yaw = 0;
-		//PlayerDataTable[*g_playerIndex].cameraYaw   += 40 * *mouseLook_X;
-		//PlayerDataTable[*g_playerIndex].cameraPitch += 15 * *mouseLook_Y;
+		//PlayerDataTable[*g_playerIndex].Camera.Yaw   += 40 * *mouseLook_X;
+		//PlayerDataTable[*g_playerIndex].Camera.Pitch += 15 * *mouseLook_Y;
 		//yaw += 600;
 		//log_debug("[DBG] roll: %0.3f", PlayerDataTable[*g_playerIndex].roll / 32768.0f * 180.0f);
 		/*
@@ -8157,7 +8159,7 @@ HRESULT PrimarySurface::Flip(
 			yaw += 256;
 			log_debug("[DBG] yaw: %0.3f", (float)yaw / 65536.0f);
 			if (bExternalCamera) {
-				PlayerDataTable[*g_playerIndex].cameraYaw = yaw;
+				PlayerDataTable[*g_playerIndex].Camera.Yaw = yaw;
 			}
 			else {
 				PlayerDataTable[*g_playerIndex].cockpitCameraYaw = yaw;
@@ -8221,11 +8223,11 @@ HRESULT PrimarySurface::Flip(
 				// not travelling through hyperspace:
 				if (g_bHyperDebugMode || g_HyperspacePhaseFSM == HS_INIT_ST || g_HyperspacePhaseFSM == HS_POST_HYPER_EXIT_ST)
 				{
-					g_fLastCockpitCameraYaw   = PlayerDataTable[*g_playerIndex].cockpitCameraYaw;
-					g_fLastCockpitCameraPitch = PlayerDataTable[*g_playerIndex].cockpitCameraPitch;
-					g_lastCockpitXReference	  = PlayerDataTable[*g_playerIndex].cockpitXReference;
-					g_lastCockpitYReference   = PlayerDataTable[*g_playerIndex].cockpitYReference;
-					g_lastCockpitZReference   = PlayerDataTable[*g_playerIndex].cockpitZReference;
+					g_fLastCockpitCameraYaw   = PlayerDataTable[*g_playerIndex].MousePositionX;
+					g_fLastCockpitCameraPitch = PlayerDataTable[*g_playerIndex].MousePositionY;
+					g_lastCockpitXReference	  = PlayerDataTable[*g_playerIndex].Camera.ShakeX;
+					g_lastCockpitYReference   = PlayerDataTable[*g_playerIndex].Camera.ShakeY;
+					g_lastCockpitZReference   = PlayerDataTable[*g_playerIndex].Camera.ShakeZ;
 
 					context->ResolveSubresource(resources->_shadertoyAuxBuf, 0, resources->_offscreenBuffer, 0, BACKBUFFER_FORMAT);
 					if (g_bUseSteamVR)
@@ -8809,7 +8811,7 @@ HRESULT PrimarySurface::Flip(
 			// I should probably render the laser pointer before the HUD; but if I do that, then the
 			// HUD gets messed up. I guess I'm destroying the state somehow
 			// Render the Laser Pointer for VR
-			if (g_bActiveCockpitEnabled && g_bRendering3D && !PlayerDataTable[*g_playerIndex].externalCamera)
+			if (g_bActiveCockpitEnabled && g_bRendering3D && !PlayerDataTable[*g_playerIndex].Camera.ExternalCamera)
 			{
 				UINT vertexBufferStride = sizeof(D3DTLVERTEX), vertexBufferOffset = 0;
 				RenderLaserPointer(&g_nonVRViewport, resources->_pixelShaderTexture, NULL, NULL, &vertexBufferStride, &vertexBufferOffset);
@@ -8954,7 +8956,7 @@ HRESULT PrimarySurface::Flip(
 				g_bSkyBoxJustFinished = false;
 				g_bPrevIsPlayerObject = false;
 				g_bIsPlayerObject = false;
-				g_bLastFrameWasExterior = PlayerDataTable[*g_playerIndex].externalCamera;
+				g_bLastFrameWasExterior = PlayerDataTable[*g_playerIndex].Camera.ExternalCamera;
 				// Disable the Dynamic Cockpit whenever we're in external camera mode:
 				g_bDCManualActivate = !g_bLastFrameWasExterior;
 				g_bDepthBufferResolved = false;
@@ -10088,7 +10090,7 @@ void PrimarySurface::RenderText()
 	g_xwa_text.clear();
 	g_xwa_text.reserve(4096);
 
-	bool bExternalCamera = PlayerDataTable[*g_playerIndex].externalCamera;
+	bool bExternalCamera = PlayerDataTable[*g_playerIndex].Camera.ExternalCamera;
 	// It looks like sometimes the craftInstance table/pointer is not valid during the first few
 	// frames of a new mission. I've seen some intermittent cores when playing with the GUN or
 	// the MIS and then switching to other craft. So adding g_iPresentCounter > 5 seems to prevent
@@ -10525,7 +10527,7 @@ void PrimarySurface::RenderSynthDCElems()
 	static ComPtr<ID2D1SolidColorBrush> s_gray_brush, s_content_brush;
 	D2D1_RECT_F rect;
 	DCElemSrcBox *dcElemSrcBox;
-	bool bExternalCamera = PlayerDataTable[*g_playerIndex].externalCamera;
+	bool bExternalCamera = PlayerDataTable[*g_playerIndex].Camera.ExternalCamera;
 	//static UINT s_left;
 	//static UINT s_top;
 	//static float s_scaleX;

--- a/impl11/ddraw/SteamVR.cpp
+++ b/impl11/ddraw/SteamVR.cpp
@@ -40,6 +40,7 @@ bool g_bSteamVRPosFromFreePIE = DEFAULT_STEAMVR_POS_FROM_FREEPIE;
 float g_fSteamVRMirrorWindow3DScale = 0.7f, g_fSteamVRMirrorWindowAspectRatio = 0.0f;
 
 extern SharedDataProxy* g_pSharedData;
+vr::TrackedDevicePose_t g_lastPredictedHmdPose; // HMD pose predicted in last frame used by CockpitLook.
 
 bool InitSteamVR()
 {
@@ -299,8 +300,14 @@ void GetSteamVRPositionalData(float* yaw, float* pitch, float* roll, float* x, f
 	{
 		// Pose array predicted for current frame N, to use by ddraw to render current frame in GPU (minimize latency)
 		vr::TrackedDevicePose_t trackedDevicePoseArray[vr::k_unMaxTrackedDeviceCount];
+		vr::TrackedDevicePose_t trackedDevicePredictedPoseArray[vr::k_unMaxTrackedDeviceCount];
 		vr::TrackedDevicePose_t trackedDevicePose; // HMD pose to use for the current frame render
+		//vr::TrackedDevicePose_t g_lastPredictedhmdPose; // HMD pose predicted in last frame used by CockpitLook.
 		vr::HmdMatrix34_t m34_fullMatrix;
+		vr::HmdMatrix34_t m34_cockpitLookPose;
+		Matrix4 m4_hmdPose;
+		Matrix4 m4_UndoCockpitLook;
+		Matrix4 m4_correctionMatrix;
 		vr::HmdQuaternionf_t q;
 		vr::ETrackedDeviceClass trackedDeviceClass = vr::VRSystem()->GetTrackedDeviceClass(unDevice);
 
@@ -313,60 +320,68 @@ void GetSteamVRPositionalData(float* yaw, float* pitch, float* roll, float* x, f
 		else {
 			// CockpitLookHook is not running (we are in 2D mode) or not calling WaitGetPoses (pose_corrected_headtracking = 1).
 			// We do the vsync blocking here and use the latest poses obtained just before starting rendering
-			vr::VRCompositor()->WaitGetPoses(trackedDevicePoseArray, vr::k_unMaxTrackedDeviceCount, NULL, 0);
+			vr::VRCompositor()->WaitGetPoses(trackedDevicePoseArray, vr::k_unMaxTrackedDeviceCount, trackedDevicePredictedPoseArray, vr::k_unMaxTrackedDeviceCount);
 			//log_debug("[DBG] ddraw.dll calling WaitGetPoses()\n");
 		}
 		trackedDevicePose = trackedDevicePoseArray[vr::k_unTrackedDeviceIndex_Hmd];		
 
 		if (trackedDevicePose.bPoseIsValid)
 		{
-			Matrix4 m4_hmdPose = HmdMatrix34toMatrix4(trackedDevicePose.mDeviceToAbsoluteTracking);
+			m4_hmdPose = HmdMatrix34toMatrix4(trackedDevicePose.mDeviceToAbsoluteTracking);
+			m34_cockpitLookPose = g_lastPredictedHmdPose.mDeviceToAbsoluteTracking;
 
 			if (g_bCorrectedHeadTracking) {
 				// We need to apply the perspective correction between the pose predicted in the previous frame
 				// (used by CockpitLook in this frame and implicitly in the 2D->3D retroprojection)
 				// and the actual pose just returned by WaitGetPoses() that will be used to do the D3D render
+				float yaw_cockpitlook, pitch_cockpitlook, roll_cockpitlook, x_cockpitlook, y_cockpitlook, z_cockpitlook;
+				if (false)
+				{ //Full transform applied by CockpitLook, including roll. Currently not implemented
+					m4_UndoCockpitLook = HmdMatrix34toMatrix4(g_lastPredictedHmdPose.mDeviceToAbsoluteTracking).invertAffine();
+				}
+				else {
+					//Get the pitch and yaw applied by CockpitLook from XWA variables. Roll was ignored.
+					//yaw_cockpitlook = (float)(PlayerDataTable[*g_playerIndex].cockpitCameraYaw * 360.0f / 65535.0f);
+					//pitch_cockpitlook = (float)(PlayerDataTable[*g_playerIndex].cockpitCameraPitch * 360.0f / 65535.0f);
 
-				// Obtain the yaw, pitch that was applied by CockpitLook. Roll was ignored.
-				float yaw_cockpitlook, pitch_cockpitlook, x_cockpitlook, y_cockpitlook, z_cockpitlook;
-				Matrix4 m4_UndoCockpitLook;
-				yaw_cockpitlook = (float)(PlayerDataTable[*g_playerIndex].cockpitCameraYaw * 360.0f / 65535.0f);
-				pitch_cockpitlook = (float)(PlayerDataTable[*g_playerIndex].cockpitCameraPitch * 360.0f / 65535.0f);
+					q = rotationToQuaternion(m34_cockpitLookPose);
+					quatToEuler(q, &yaw_cockpitlook, &pitch_cockpitlook, &roll_cockpitlook);
 
-				// Get the translation applied by CockpitLook
-				float g_fXWAUnitsToMetersScale = 400.0f; // Empirical value used hardcoded in CockpitLook, or set in cockpitlook.cfg (xwa_units_to_meters_scale)
-				x_cockpitlook = (float)PlayerDataTable[*g_playerIndex].cockpitXReference / g_fXWAUnitsToMetersScale;
-				y_cockpitlook = (float)PlayerDataTable[*g_playerIndex].cockpitYReference / g_fXWAUnitsToMetersScale;
-				z_cockpitlook = (float)PlayerDataTable[*g_playerIndex].cockpitZReference / g_fXWAUnitsToMetersScale;
+					// Get the translation applied by CockpitLook. It's not stored in XWA globals, we need to get it from the matrix					
+					x_cockpitlook = m34_cockpitLookPose.m[0][3];
+					y_cockpitlook = m34_cockpitLookPose.m[1][3];
+					z_cockpitlook = m34_cockpitLookPose.m[2][3];
 
-
-				// Build a transform matrix to "undo" the CockpitLook transformation based on HMD pose estimated in the previous frame
-				Matrix4 rotMatrixYaw, rotMatrixPitch, posMatrix;
-				rotMatrixYaw.identity();	rotMatrixYaw.rotateY(yaw_cockpitlook);
-				rotMatrixPitch.identity();	rotMatrixPitch.rotateX(-pitch_cockpitlook);
-				posMatrix.identity();		posMatrix.translate(-x_cockpitlook, -y_cockpitlook, -z_cockpitlook);
-				// Create inverse matrix by applying the opposite angles, in inverse order
-				m4_UndoCockpitLook = posMatrix * rotMatrixPitch * rotMatrixYaw;
-
-				// DEBUG: you can cancel positional tracking completely by uncommenting these lines
-				// g_fPosXMultiplier = 0;
-				// g_fPosYMultiplier = 0;
-				// g_fPosZMultiplier = 0;
-
-				// Invert axes so that it works properly. I don't understand yet why this is necessary.
-				int col = 3; //4th column (index 3) of the pose matrix is the translation vector x,y,z
-				m4_hmdPose[col * 4] = -m4_hmdPose[col * 4] * g_fPosXMultiplier;
-				m4_hmdPose[col * 4 + 1] = -m4_hmdPose[col * 4 + 1] * g_fPosYMultiplier;
-				m4_hmdPose[col * 4 + 2] = -m4_hmdPose[col * 4 + 2] * g_fPosZMultiplier;
-
+					// Build a transform matrix applied by CockpitLook based on HMD pose estimated in the previous frame
+					// We need to remove roll as it was not applied in the hook
+					Matrix4 rotMatrixYaw, rotMatrixPitch, posMatrix;
+					rotMatrixYaw.identity();	rotMatrixYaw.rotateY(RAD_TO_DEG * yaw_cockpitlook);
+					rotMatrixPitch.identity();	rotMatrixPitch.rotateX(RAD_TO_DEG * pitch_cockpitlook);
+					posMatrix.identity();		posMatrix.translate(x_cockpitlook, y_cockpitlook, z_cockpitlook);
+					// Create inverse matrix by applying the opposite angles, in inverse order
+					m4_UndoCockpitLook = (posMatrix * rotMatrixYaw * rotMatrixPitch ).invertAffine();
+					
+					// Invert axes so that it works properly. I don't understand yet why this is necessary.
+					//int col = 3; //4th column (index 3) of the pose matrix is the translation vector x,y,z
+					//m4_hmdPose[col * 4] = -m4_hmdPose[col * 4];
+					//m4_hmdPose[col * 4 + 1] = -m4_hmdPose[col * 4 + 1];
+					//m4_hmdPose[col * 4 + 2] = -m4_hmdPose[col * 4 + 2];
+				}
 				//Compose it with the transformation matrix for the actual HMD pose in the current frame (this is the correct view space for rendering, including roll)
-				Matrix4 m4_correctionMatrix = m4_hmdPose * m4_UndoCockpitLook;
+				m4_correctionMatrix = m4_hmdPose * m4_UndoCockpitLook;
+
 				Matrix4toHmdMatrix34(m4_correctionMatrix, m34_fullMatrix);  // This matrix contains all positional and rotational data.
+				//Store the prediction that will be used by CockpitLook for next frame.
+				g_lastPredictedHmdPose = trackedDevicePredictedPoseArray[vr::k_unTrackedDeviceIndex_Hmd];
 			}
-			else //Legacy headtracking. There is no pose prediction correction, we take the pose as it was returned by GetLastPoses() and used by CockpitLook.
-			{	
+			else
+			{	//Legacy headtracking. There is no pose prediction correction, we take the pose as it was returned by GetLastPoses() and used by CockpitLook.
 				Matrix4toHmdMatrix34(m4_hmdPose, m34_fullMatrix);
 			}
+
+			// DEBUG: 
+			//ShowHmdMatrix34(m34_fullMatrix, "m34_fullMatrix");
+
 			// Finally we extract the components of the composed matrix to apply them later
 			q = rotationToQuaternion(m34_fullMatrix);
 			quatToEuler(q, yaw, pitch, roll);

--- a/impl11/ddraw/SteamVR.h
+++ b/impl11/ddraw/SteamVR.h
@@ -32,6 +32,8 @@ extern void* g_pSurface;
 extern bool g_bTogglePostPresentHandoff;
 extern bool g_bSteamVRMirrorWindowLeftEye;
 
+extern vr::TrackedDevicePose_t g_lastPredictedHmdPose; // HMD pose predicted in last frame used by CockpitLook.
+
 /*
  *	SteamVR specific functions declarations
  */

--- a/impl11/ddraw/VRConfig.cpp
+++ b/impl11/ddraw/VRConfig.cpp
@@ -964,7 +964,7 @@ void ComputeHyperFOVParams() {
 	// To find the y-center of the screen, we're going to use math. The tangent of the current
 	// pitch can give us the information right away. This is closely related to the FOV and
 	// is easy to see if you draw the focal length and the in-game height to form a right triangle.
-	float pitch = (float)PlayerDataTable[*g_playerIndex].cockpitCameraPitch / 65536.0f * 2.0f * PI;
+	float pitch = (float)PlayerDataTable[*g_playerIndex].MousePositionY / 65536.0f * 2.0f * PI;
 	float H = *g_fRawFOVDist * tan(pitch); // This will give us the height, in pixels, measured from the center of the screen
 	H += g_fCurInGameHeight / 2.0f;
 	log_debug("[DBG] [FOV] Screen Y-Center: %0.3f, ReticleCentroid: %0.3f, pitch: %0.3f, ", H, g_ReticleCentroid.y, pitch / DEG2RAD);

--- a/impl11/ddraw/utils.cpp
+++ b/impl11/ddraw/utils.cpp
@@ -727,7 +727,7 @@ void log_debug(const char *format, ...)
 
 	vsprintf_s(buf, 512, format, args);
 	OutputDebugString(buf);
-
+	OutputDebugString("\n");
 	va_end(args);
 }
 


### PR DESCRIPTION
Hook_XWACockpitLook submodule updated with latest changes for jitter-free positional tracking, with new hook injecting the offset into CockpitPosition instead of Shake.

I also refactored GetSteamVRPositionalData() and implemented some changes needed for the new pose_prediction_corrected tracking mode. There are still some issues with the rotation, but it's almost ready.

It seems part of the backdrop (the vertical "walls", not the top and bottom) is missing in the first mission of the campaign, but it works fine in Skirmish. Not sure if it's due to my changes. Can you test that @Prof-Butts?
Other than that, the default tracking mode works fine in flight cockpit view, 2D, hangar and hyperspace.