### PR TITLE
Implementation of 2D rendering as OpenVR overlay

### DIFF
--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -4768,6 +4768,8 @@ HRESULT DeviceResources::RenderMain(char* src, DWORD width, DWORD height, DWORD 
 	if (g_bEnableVR && !bRenderToDC) { // SteamVR and DirectSBS modes
 		InitVSConstantBuffer2D(this->_mainShadersConstantBuffer.GetAddressOf(), 0.0f, g_fConcourseAspectRatio, g_fConcourseScale, g_fBrightness, 1.0f); // Use 3D projection matrices
 		InitPSConstantBuffer2D(this->_mainShadersConstantBuffer.GetAddressOf(), 0.0f, g_fConcourseAspectRatio, g_fConcourseScale, g_fBrightness);
+		//InitVSConstantBuffer2D(this->_mainShadersConstantBuffer.GetAddressOf(), 0.0f, g_fConcourseAspectRatio, 1, g_fBrightness, 0.0f); // Use 3D projection matrices
+		//InitPSConstantBuffer2D(this->_mainShadersConstantBuffer.GetAddressOf(), 0.0f, g_fConcourseAspectRatio, 1, g_fBrightness);
 	} 
 	else {
 		InitVSConstantBuffer2D(this->_mainShadersConstantBuffer.GetAddressOf(), 0, 1, 1, g_fBrightness, 0.0f); // Don't use 3D projection matrices when VR is disabled
@@ -4818,8 +4820,7 @@ HRESULT DeviceResources::RenderMain(char* src, DWORD width, DWORD height, DWORD 
 		float screen_res_y = (float)this->_backbufferHeight;
 
 		if (!g_bEnableVR || bRenderToDC) {
-			// The Concourse and 2D menu are drawn here... maybe the default starfield too?
-			// We also render the CMD sub-component bracket here.
+			// The CMD sub-component bracket are drawn here... maybe the default starfield too?
 			this->_d3dDeviceContext->DrawIndexed(6, 0, 0);
 			if (bRenderToDC)
 			{
@@ -4875,9 +4876,13 @@ HRESULT DeviceResources::RenderMain(char* src, DWORD width, DWORD height, DWORD 
 		viewport.MaxDepth = D3D11_MAX_DEPTH;
 		viewport.MinDepth = D3D11_MIN_DEPTH;
 		this->InitViewport(&viewport);
-		this->InitVSConstantBuffer2D(_mainShadersConstantBuffer.GetAddressOf(),
-			g_fTechLibraryParallax * g_iDraw2DCounter, g_fConcourseAspectRatio, g_fConcourseScale, g_fBrightness, 
+		/*this->InitVSConstantBuffer2D(_mainShadersConstantBuffer.GetAddressOf(),
+			g_fTechLibraryParallax * g_iDraw2DCounter, g_fConcourseAspectRatio, g_fConcourseScale, g_fBrightness,
 			1.0f); // Use 3D projection matrices
+		*/
+		this->InitVSConstantBuffer2D(_mainShadersConstantBuffer.GetAddressOf(),
+			g_fTechLibraryParallax * g_iDraw2DCounter, 1, 1, g_fBrightness,
+			0.0f); // Do not use 3D projection matrices
 
 		// The Concourse and 2D menu are drawn here... maybe the default starfield too?
 		// When SteamVR is not used, the RenderTargets are set in the OnSizeChanged() event above
@@ -4902,11 +4907,17 @@ HRESULT DeviceResources::RenderMain(char* src, DWORD width, DWORD height, DWORD 
 		viewport.MaxDepth = D3D11_MAX_DEPTH;
 		viewport.MinDepth = D3D11_MIN_DEPTH;
 		this->InitViewport(&viewport);
-		this->InitVSConstantBuffer2D(this->_mainShadersConstantBuffer.GetAddressOf(),
+		/*this->InitVSConstantBuffer2D(this->_mainShadersConstantBuffer.GetAddressOf(),
 			g_fTechLibraryParallax * g_iDraw2DCounter, g_fConcourseAspectRatio, g_fConcourseScale, g_fBrightness,
 			1.0f); // Use 3D projection matrices
+		*/
+		this->InitVSConstantBuffer2D(this->_mainShadersConstantBuffer.GetAddressOf(),
+			g_fTechLibraryParallax * g_iDraw2DCounter, 1, 1, g_fBrightness,
+			0.0f); // Do not use 3D projection matrices
+
 		// The Concourse and 2D menu are drawn here... maybe the default starfield too?
 		g_VSMatrixCB.projEye = g_FullProjMatrixRight;
+		g_VSMatrixCB.fullViewMat.identity();
 		InitVSConstantBufferMatrix(_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
 		if (g_bUseSteamVR)
 			_d3dDeviceContext->OMSetRenderTargets(1, _renderTargetViewR.GetAddressOf(), _depthStencilViewR.Get());

--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -1896,18 +1896,12 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 
 				step = "_steamVRPOverlayBuffer";
 				// This buffer will contain the Concourse, loading screen menu and ESC menu with the right aspect ratio (4:3) to show in VR overlay.
-				oldDescWidth = desc.Width;
-				oldDescHeight = desc.Height;
-				desc.Width = dwWidth;
-				desc.Height = dwHeight;
 				hr = this->_d3dDevice->CreateTexture2D(&desc, nullptr, &this->_steamVROverlayBuffer);
 				if (FAILED(hr)) {
 					log_err("dwWidth, Height: %u, %u\n", dwWidth, dwHeight);
 					log_err_desc(step, hWnd, hr, desc);
 					goto out;
 				}
-				desc.Width = oldDescWidth;
-				desc.Height = oldDescHeight;
 			}
 
 			// Shading System, Bloom Mask, Normals Buffer, etc

--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -1373,6 +1373,7 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 	HRESULT hr;
 	char* step = "";
 	DXGI_FORMAT oldFormat;
+	UINT oldDescWidth, oldDescHeight;
 
 	//log_debug("[DBG] OnSizeChanged, dwWidth,Height: %d, %d", dwWidth, dwHeight);
 
@@ -1444,7 +1445,9 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 		this->_renderTargetViewR.Release();
 		this->_renderTargetViewPostR.Release();
 		this->_steamVRPresentBuffer.Release();
+		this->_steamVROverlayBuffer.Release();
 		this->_renderTargetViewSteamVRResize.Release();
+		this->_renderTargetViewSteamVROverlayResize.Release();
 		if (this->_useMultisampling)
 			this->_shadertoyBufMSAA_R.Release();
 		this->_shadertoyBufR.Release();
@@ -1890,6 +1893,21 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 					log_err_desc(step, hWnd, hr, desc);
 					goto out;
 				}
+
+				step = "_steamVRPOverlayBuffer";
+				// This buffer will contain the Concourse, loading screen menu and ESC menu with the right aspect ratio (4:3) to show in VR overlay.
+				oldDescWidth = desc.Width;
+				oldDescHeight = desc.Height;
+				desc.Width = dwWidth;
+				desc.Height = dwHeight;
+				hr = this->_d3dDevice->CreateTexture2D(&desc, nullptr, &this->_steamVROverlayBuffer);
+				if (FAILED(hr)) {
+					log_err("dwWidth, Height: %u, %u\n", dwWidth, dwHeight);
+					log_err_desc(step, hWnd, hr, desc);
+					goto out;
+				}
+				desc.Width = oldDescWidth;
+				desc.Height = oldDescHeight;
 			}
 
 			// Shading System, Bloom Mask, Normals Buffer, etc
@@ -2912,6 +2930,10 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 
 			step = "renderTargetViewSteamVRResize";
 			hr = this->_d3dDevice->CreateRenderTargetView(this->_steamVRPresentBuffer, &renderTargetViewDesc, &this->_renderTargetViewSteamVRResize);
+			if (FAILED(hr)) goto out;
+
+			step = "renderTargetViewSteamVRResizeOverlay";
+			hr = this->_d3dDevice->CreateRenderTargetView(this->_steamVROverlayBuffer, &renderTargetViewDesc, &this->_renderTargetViewSteamVROverlayResize);
 			if (FAILED(hr)) goto out;
 
 			step = "_shadertoyRTV_R";

--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -4902,8 +4902,24 @@ HRESULT DeviceResources::RenderMain(char* src, DWORD width, DWORD height, DWORD 
 			g_fTechLibraryParallax * g_iDraw2DCounter, g_fConcourseAspectRatio, g_fConcourseScale, g_fBrightness,
 			1.0f); // Use 3D projection matrices
 		*/
+
+		float parallax = 1;
+		if (g_iDraw2DCounter > 0)		
+		{
+			D3D11_DEPTH_STENCIL_DESC desc;
+			ComPtr<ID3D11DepthStencilState> depthState;
+			desc.DepthEnable = FALSE;
+			desc.DepthWriteMask = D3D11_DEPTH_WRITE_MASK_ZERO;
+			desc.DepthFunc = D3D11_COMPARISON_ALWAYS;
+			desc.StencilEnable = FALSE;
+			this->InitDepthStencilState(depthState, &desc);
+			parallax = 0;
+
+		}
+
 		this->InitVSConstantBuffer2D(_mainShadersConstantBuffer.GetAddressOf(),
-			g_fTechLibraryParallax * g_iDraw2DCounter, 1, 1, g_fBrightness,
+			//g_fTechLibraryParallax * g_iDraw2DCounter, 1, 1, g_fBrightness,
+			1, 1, 1, g_fBrightness,
 			0.0f); // Do not use 3D projection matrices
 
 		// The Concourse and 2D menu are drawn here... maybe the default starfield too?
@@ -4934,7 +4950,8 @@ HRESULT DeviceResources::RenderMain(char* src, DWORD width, DWORD height, DWORD 
 			1.0f); // Use 3D projection matrices
 		*/
 		this->InitVSConstantBuffer2D(this->_mainShadersConstantBuffer.GetAddressOf(),
-			g_fTechLibraryParallax * g_iDraw2DCounter, 1, 1, g_fBrightness,
+			//g_fTechLibraryParallax * g_iDraw2DCounter, 1, 1, g_fBrightness,
+			1, 1, 1, g_fBrightness,
 			0.0f); // Do not use 3D projection matrices
 
 		// The Concourse and 2D menu are drawn here... maybe the default starfield too?

--- a/impl11/ddraw/DeviceResources.h
+++ b/impl11/ddraw/DeviceResources.h
@@ -203,7 +203,9 @@ public:
 	// Barrel effect
 	ComPtr<ID3D11Texture2D> _offscreenBufferPost;  // This is the output of the barrel effect
 	ComPtr<ID3D11Texture2D> _offscreenBufferPostR; // This is the output of the barrel effect for the right image when using SteamVR
-	ComPtr<ID3D11Texture2D> _steamVRPresentBuffer; // This is the buffer that will be presented for SteamVR
+	ComPtr<ID3D11Texture2D> _steamVRPresentBuffer; // This is the buffer that will be presented in the monitor mirror window for SteamVR
+	ComPtr<ID3D11Texture2D> _steamVROverlayBuffer; // This is the buffer that will be presented as a VR overlay.
+
 	// ShaderToy effects
 	ComPtr<ID3D11Texture2D> _shadertoyBufMSAA;
 	ComPtr<ID3D11Texture2D> _shadertoyBufMSAA_R;
@@ -279,7 +281,9 @@ public:
 	// Barrel Effect
 	ComPtr<ID3D11RenderTargetView> _renderTargetViewPost;  // Used for the barrel effect
 	ComPtr<ID3D11RenderTargetView> _renderTargetViewPostR; // Used for the barrel effect (right image) when SteamVR is used.
-	ComPtr<ID3D11RenderTargetView> _renderTargetViewSteamVRResize; // Used for the barrel effect
+	ComPtr<ID3D11RenderTargetView> _renderTargetViewSteamVRResize; // Used to resize the image before presenting it in the monitor window.
+	ComPtr<ID3D11RenderTargetView> _renderTargetViewSteamVROverlayResize; // Used to resize the image before copying it to the VR overlay to present 2D mode images.
+
 	// ShaderToy
 	ComPtr<ID3D11RenderTargetView> _shadertoyRTV;
 	ComPtr<ID3D11RenderTargetView> _shadertoyRTV_R;

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -7879,7 +7879,7 @@ HRESULT PrimarySurface::Flip(
 
 			// Read yaw,pitch,roll from SteamVR/FreePIE and apply the rotation to the 2D content
 			// on the next frame
-			UpdateViewMatrix(); // VR in TechRoom
+			UpdateViewMatrix();
 #ifdef DISABLED
 			//if (g_bEnableVR)
 			{
@@ -8202,7 +8202,19 @@ HRESULT PrimarySurface::Flip(
 					}
 					else {
 						// In SteamVR mode this will display the left image:
-						if (g_bUseSteamVR) {
+						if (g_bUseSteamVR) {							
+							if (g_VR2Doverlay != vr::k_ulOverlayHandleInvalid)
+							{
+								vr::Texture_t overlay_texture;
+								overlay_texture.eType = vr::TextureType_DirectX;
+								overlay_texture.eColorSpace = vr::ColorSpace_Auto;
+								overlay_texture.handle = resources->_offscreenBuffer;
+								// Fade compositor to black while the overlay is shown and we are not rendering the 3D scene.
+								g_pVRCompositor->FadeToColor(0.1f, 0.0f, 0.0f, 0.0f, 1.0f, false);
+								g_pVROverlay->SetOverlayTexture(g_VR2Doverlay, &overlay_texture);
+								g_pVROverlay->ShowOverlay(g_VR2Doverlay);
+							}
+
 							resizeForSteamVR(0, true);
 							context->ResolveSubresource(resources->_backBuffer, 0, resources->_steamVRPresentBuffer, 0, BACKBUFFER_FORMAT);
 						}
@@ -8229,11 +8241,11 @@ HRESULT PrimarySurface::Flip(
 					g_iDraw2DCounter = 0;				
 
 					if (g_bUseSteamVR) {
-						vr::EVRCompositorError error = vr::VRCompositorError_None;
+						/*vr::EVRCompositorError error = vr::VRCompositorError_None;
 						vr::Texture_t leftEyeTexture = { this->_deviceResources->_offscreenBuffer.Get(), vr::TextureType_DirectX, vr::ColorSpace_Auto };
 						vr::Texture_t rightEyeTexture = { this->_deviceResources->_offscreenBufferR.Get(), vr::TextureType_DirectX, vr::ColorSpace_Auto };
 						error = g_pVRCompositor->Submit(vr::Eye_Left, &leftEyeTexture);
-						error = g_pVRCompositor->Submit(vr::Eye_Right, &rightEyeTexture);
+						error = g_pVRCompositor->Submit(vr::Eye_Right, &rightEyeTexture);*/
 					}
 					
 					g_bRendering3D = false;
@@ -9409,6 +9421,9 @@ HRESULT PrimarySurface::Flip(
 				}
 
 				ApplyCustomHUDColor();
+
+				g_pVROverlay->HideOverlay(g_VR2Doverlay);
+				g_pVRCompositor->FadeToColor(0.2f, 0.0f, 0.0f, 0.0f, 0.0f, false);
 			}
 			// Make sure the hyperspace effect is off if we're back in the hangar. This is necessary to fix
 			// the Holdo bug (but more changes may be needed).

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -1169,7 +1169,7 @@ void PrimarySurface::resizeForSteamVR(int iteration, bool is_2D) {
 	{
 		if (!g_bRendering3D) // Only render for 2D content, no need to waste resources in 3D
 		{
-			aspect_ratio = g_fConcourseAspectRatio;			
+			aspect_ratio = g_fConcourseAspectRatio * (1.0f/ steamVR_aspect_ratio);
 			scale = 1.0f/aspect_ratio;
 			resources->InitPSConstantBuffer2D(resources->_mainShadersConstantBuffer.GetAddressOf(),
 				0.0f, aspect_ratio, scale, 1.0f, 1.0f);

--- a/impl11/ddraw/SteamVR.cpp
+++ b/impl11/ddraw/SteamVR.cpp
@@ -14,6 +14,8 @@ vr::IVRSystem* g_pHMD = NULL;
 vr::IVRChaperone* g_pChaperone = NULL;
 vr::IVRCompositor* g_pVRCompositor = NULL;
 vr::IVRScreenshots* g_pVRScreenshots = NULL;
+vr::IVROverlay* g_pVROverlay = NULL;
+vr::VROverlayHandle_t g_VR2Doverlay = vr::k_ulOverlayHandleInvalid;
 vr::TrackedDevicePose_t g_rTrackedDevicePose;
 uint32_t g_steamVRWidth = 0, g_steamVRHeight = 0; // The resolution recommended by SteamVR is stored here
 bool g_bSteamVREnabled = false; // The user sets this flag to true to request support for SteamVR.
@@ -206,6 +208,26 @@ bool InitSteamVR()
 			left, right, top, bottom);
 		fclose(file);
 	}
+
+	// Set a black background to draw the overlay over
+	g_pVRCompositor->FadeGrid(2.0f, false);
+	g_pVRCompositor->FadeToColor(2.0f, 0.0f, 0.0f, 0.0f, 1.0, 0);
+
+	// Create Overlay to draw 2D content fixed in space
+	g_pVROverlay = vr::VROverlay();
+	if (g_pVROverlay != NULL) {
+		log_debug("[DBG] SteamVR Overlay system initialized");
+	}
+	vr::HmdMatrix34_t overlay_transform;
+	// This transform matrix puts the overlay at 5m in front of the user POV
+	overlay_transform = {
+	1.0f, 0.0f, 0.0f, 0.0f,
+	0.0f, 1.0f, 0.0f, 0.0f,
+	0.0f, 0.0f, 1.0f, -5.0f
+	};
+	g_pVROverlay->CreateOverlay("xwa_2d_window", "X-Wing Alliance VR", &g_VR2Doverlay);
+	g_pVROverlay->SetOverlayWidthInMeters(g_VR2Doverlay, 5); // Make the overlay 5 meters wide.
+	g_pVROverlay->SetOverlayTransformAbsolute(g_VR2Doverlay, vr::TrackingUniverseSeated, &overlay_transform);
 
 out:
 	g_bSteamVRInitialized = result;

--- a/impl11/ddraw/SteamVR.h
+++ b/impl11/ddraw/SteamVR.h
@@ -11,6 +11,8 @@
 extern vr::IVRSystem* g_pHMD;
 extern vr::IVRChaperone* g_pChaperone;
 extern vr::IVRCompositor* g_pVRCompositor;
+extern vr::IVROverlay* g_pVROverlay;
+extern vr::VROverlayHandle_t g_VR2Doverlay; // Handle to the specific overlay displaying the 2D rendered scenes.
 extern vr::IVRScreenshots* g_pVRScreenshots;
 extern vr::TrackedDevicePose_t g_rTrackedDevicePose;
 extern uint32_t g_steamVRWidth, g_steamVRHeight; // The resolution recommended by SteamVR is stored here

--- a/impl11/shaders/MainVertexShader.hlsl
+++ b/impl11/shaders/MainVertexShader.hlsl
@@ -50,7 +50,7 @@ PixelShaderInput main(VertexShaderInput input)
 		// Project to 2D
 		output.pos = mul(projEyeMatrix, P);
 	} else { // Use this for the original 2D version of the game:
-		output.pos = float4((input.pos.x + parallax) * scale * aspect_ratio, input.pos.y * scale, 0.5f, 1.0f);
+		output.pos = float4((input.pos.x) * scale * aspect_ratio, input.pos.y * scale, parallax, 1.0f);
 	}
 	output.tex = input.tex;
 


### PR DESCRIPTION
The basics are working, and there are some improvements:

- Fixes the jerky headtracking in 2D when rendering at the original 25fps
- Fixes the flickering loading screen
- The mirror window in the monitor shows always the 2D content, regardless of the headtracking.

But there are a few things to fix:
- Dynamic Cockpit is broken, and also the hud rendering
- The mirror window in the monitor has the wrong scale (it is probably assuming the wrong buffer size).
- Positional headtracking feels stuttery, not sure it's related.