### PR TITLE
New (hopefully) complete fix for reticle pips misalignment and remove pose corrected tracking

### DIFF
--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -152,7 +152,7 @@
 
 
 inline Vector3 project(Vector3 pos3D, Matrix4 viewMatrix, Matrix4 projEyeMatrix);
-void SetPresentCounter(int, int);
+void SetPresentCounter(int val, int b_resetReticle);
 
 bool g_bWndProcReplaced = false;
 bool ReplaceWindowProc(HWND ThisWindow);
@@ -1403,8 +1403,8 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 		log_debug("[DBG] Using SteamVR settings: %u, %u", dwWidth, dwHeight);
 	}
 
-	// Reset the present counter
-	SetPresentCounter(0, 0);
+	// Reset the present counter and the reticle status
+	SetPresentCounter(0, 1);
 	g_bPrevPlayerInHangar = false;
 	// Reset the FOV application flag
 	g_bCustomFOVApplied = false;

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -7176,48 +7176,8 @@ void UpdateViewMatrix()
 		yaw   += g_fYawOffset;
 		pitch += g_fPitchOffset;
 
-		if (g_bCorrectedHeadTracking) {
-			// If we want corrected tracking, we need to apply the full rotation+translation matrix in all cases
-
-			rotMatrixYaw.identity();
-			rotMatrixPitch.identity();
-			posMatrix.identity();
-			rotMatrixRoll.identity();
-
-			// Compute the component matrices with the correct axis signs
-			rotMatrixYaw.rotateY(-yaw);
-			rotMatrixPitch.rotateX(-pitch);
-			rotMatrixRoll.rotateZ(roll);
-			posMatrix.translate(x, y, -z);
-
-			// Compose the full transformation matrix to use in the Vertex Shader.
-			viewMatrixFull = rotMatrixRoll * rotMatrixPitch * rotMatrixYaw * posMatrix;
-
-			g_viewMatrix = viewMatrixFull;
-			// The following section applies the correct transform rule to the HUD.
-			// Apparently, the current yaw, pitch, roll values coming from GetSteamVRPositionalData don't work well for the
-			// HUD because we're using pose-corrected data. It looks like only the correction is applied to the HUD. So,
-			// instead we're using the current pose coming from the CockpitLook hook just for the HUD here.
-			/*if (g_pSharedData->bDataReady && g_pSharedData->pSharedData != NULL) {
-				yaw		= g_pSharedData->pSharedData->Yaw;
-				pitch	= g_pSharedData->pSharedData->Pitch;
-				roll		= g_pSharedData->pSharedData->Roll;
-				x		= g_pSharedData->pSharedData->X;
-				y		= g_pSharedData->pSharedData->Y;
-				z		= g_pSharedData->pSharedData->Z;
-
-				rotMatrixYaw.rotateY(-yaw);
-				rotMatrixPitch.rotateX(-pitch);
-				rotMatrixRoll.rotateZ(-roll);
-				posMatrix.translate(-x, -y, z);
-				viewMatrixFull = rotMatrixRoll * rotMatrixPitch * rotMatrixYaw * posMatrix;
-			}*/
-		}
-		else {
-			// If we don't need corrected headtracking, there is no rotation to apply
-			// since the full rotation+translation is applied in CockpitLook now.
+		// There is no rotation to applynce the full rotation+translation is applied in CockpitLook now.
 			g_viewMatrix.identity();
-		}
 
 		g_VSMatrixCB.viewMat = g_viewMatrix;
 		g_VSMatrixCB.fullViewMat = viewMatrixFull;
@@ -7487,7 +7447,8 @@ HRESULT PrimarySurface::Flip(
 				g_MetricRecCBuffer.mr_aspect_ratio = g_fCurInGameAspectRatio;
 				if (g_bSteamVREnabled) {
 					// Compensate the distortion that happens when rendering the 3D craft over the 2D background in the tech room. 
-					g_MetricRecCBuffer.mr_aspect_ratio = ((float)g_WindowHeight / (float)g_WindowWidth) * g_fConcourseAspectRatio * ((float)g_steamVRHeight / (float)g_steamVRWidth);
+					//g_MetricRecCBuffer.mr_aspect_ratio = ((float)g_WindowHeight / (float)g_WindowWidth) * g_fConcourseAspectRatio * ((float)g_steamVRHeight / (float)g_steamVRWidth);
+					g_MetricRecCBuffer.mr_aspect_ratio = 0.5f;
 					//g_MetricRecCBuffer.mr_aspect_ratio = g_fCurInGameAspectRatio * (((float)g_WindowHeight / (float)g_WindowWidth) * (4.0f / 3.0f));
 				}
 				g_MetricRecCBuffer.mr_z_metric_mult = g_fOBJ_Z_MetricMult;

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -45,10 +45,10 @@ bool rayTriangleIntersect(
 	const Vector3 &v0, const Vector3 &v1, const Vector3 &v2,
 	float &t, Vector3 &P, float &u, float &v);
 
-void SetPresentCounter(int val, int InFlight) {
+void SetPresentCounter(int val, int bResetReticle) {
 	g_iPresentCounter = val;
-	if (g_pSharedData->bDataReady && g_pSharedData->pSharedData != NULL) {
-		g_pSharedData->pSharedData->InFlight = InFlight;
+	if (g_pSharedData->bDataReady && g_pSharedData->pSharedData != NULL && bResetReticle) {
+		g_pSharedData->pSharedData->bIsReticleSetup = 0;
 	}
 }
 
@@ -7868,7 +7868,7 @@ HRESULT PrimarySurface::Flip(
 
 					// Reset the 2D draw counter -- that'll help us increase the parallax for the Tech Library
 					g_iDraw2DCounter = 0;				
-					SetPresentCounter(0, g_bInTechRoom ? 1 : 0);
+					SetPresentCounter(0, 0);
 					if (g_bUseSteamVR) {
 						/*vr::EVRCompositorError error = vr::VRCompositorError_None;
 						vr::Texture_t leftEyeTexture = { this->_deviceResources->_offscreenBuffer.Get(), vr::TextureType_DirectX, vr::ColorSpace_Auto };
@@ -8799,7 +8799,7 @@ HRESULT PrimarySurface::Flip(
 
 				// Reset the frame counter if we just exited the hangar
 				if (!(*g_playerInHangar) && g_bPrevPlayerInHangar) {
-					SetPresentCounter(0, 1);
+					SetPresentCounter(0, 0);
 					log_debug("[DBG] EXITED HANGAR");
 				}
 				g_bPrevPlayerInHangar = *g_playerInHangar;
@@ -9050,7 +9050,7 @@ HRESULT PrimarySurface::Flip(
 				g_HyperspacePhaseFSM = HS_INIT_ST;
 			// We're about to show 3D content, so let's set the corresponding flag
 			g_bRendering3D = true;
-			SetPresentCounter(g_iPresentCounter + 1, 1);
+			SetPresentCounter(g_iPresentCounter + 1, 0);
 
 			if (g_iDelayedDumpDebugBuffers) {
 				g_iDelayedDumpDebugBuffers--;

--- a/impl11/ddraw/SharedMem.h
+++ b/impl11/ddraw/SharedMem.h
@@ -19,9 +19,11 @@ struct SharedData {
 	// Joystick's position, written by the joystick hook, or by the joystick emulation code.
 	// These values are normalized in the range -1..1
 	float JoystickYaw, JoystickPitch;
-	// InFlight flag. Set to 1 by ddraw when the game is in the Present 3D path.
-	// Set to 0 when the game is in the Present 2D path.
-	int InFlight;
+	// Flag to indicate that the reticle needs setup, to inhibit tracking and avoid roll messing with
+	// the pips positions.
+	// Set to 0 by ddraw when the game starts a mission (in OnSizeChanged())
+	// Set to 1 by a hook in the SetupReticle() XWA function.
+	int bIsReticleSetup;
 };
 
 // This is a proxy to share data between the hook and ddraw.

--- a/impl11/ddraw/SteamVR.h
+++ b/impl11/ddraw/SteamVR.h
@@ -34,8 +34,6 @@ extern void* g_pSurface;
 extern bool g_bTogglePostPresentHandoff;
 extern bool g_bSteamVRMirrorWindowLeftEye;
 
-extern vr::TrackedDevicePose_t g_lastPredictedHmdPose; // HMD pose predicted in last frame used by CockpitLook.
-
 /*
  *	SteamVR specific functions declarations
  */

--- a/impl11/ddraw/VRConfig.cpp
+++ b/impl11/ddraw/VRConfig.cpp
@@ -119,7 +119,6 @@ const char* ROLL_MULTIPLIER_VRPARAM = "roll_multiplier";
 const char* FREEPIE_SLOT_VRPARAM = "freepie_slot";
 const char* STEAMVR_POS_FROM_FREEPIE_VRPARAM = "steamvr_pos_from_freepie";
 // Cockpitlook params
-const char* POSE_CORRECTED_HEADTRACKING = "pose_corrected_headtracking";
 const char* YAW_MULTIPLIER_CLPARAM = "yaw_multiplier";
 const char* PITCH_MULTIPLIER_CLPARAM = "pitch_multiplier";
 const char* YAW_OFFSET_CLPARAM = "yaw_offset";
@@ -150,7 +149,6 @@ true if either DirectSBS or SteamVR are enabled. false for original display mode
 bool g_bEnableVR = true;
 bool g_b3DVisionEnabled = false, g_b3DVisionForceFullScreen = true;
 TrackerType g_TrackerType = TRACKER_NONE;
-bool g_bCorrectedHeadTracking = false;
 
 float g_fDebugFOVscale = 1.0f;
 float g_fDebugYCenter = 0.0f;
@@ -837,10 +835,6 @@ void LoadCockpitLookParams() {
 					g_TrackerType = TRACKER_NONE;
 				}
 
-			}
-			else if (_stricmp(param, POSE_CORRECTED_HEADTRACKING) == 0) {
-				log_debug("Using pose corrected head tracking");
-				g_bCorrectedHeadTracking = (bool)fValue;
 			}
 			/*else if (_stricmp(param, "cockpit_inertia_enabled") == 0) {
 				g_bCockpitInertiaEnabled = (bool)fValue;

--- a/impl11/ddraw/ddraw.vcxproj
+++ b/impl11/ddraw/ddraw.vcxproj
@@ -99,9 +99,7 @@
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);DirectXTK.lib;Windowscodecs.lib;openvr_api.lib;winmm.lib</AdditionalDependencies>
     </Link>
     <PostBuildEvent />
-    <PostBuildEvent>
-      <Command>copy /Y $(TargetPath) "C:\Program Files (x86)\GOG Galaxy\Games\Star Wars - X-Wing Alliance Update 5"</Command>
-    </PostBuildEvent>
+    <PostBuildEvent />
   </ItemDefinitionGroup>
   <ItemGroup>
     <None Include="ddraw.cfg">

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -174,7 +174,6 @@ extern bool g_bExternalHUDEnabled, g_bEdgeDetectorEnabled, g_bStarDebugEnabled;
 
 extern float g_f2DYawMul, g_f2DPitchMul, g_f2DRollMul;
 extern TrackerType g_TrackerType;
-extern bool g_bCorrectedHeadTracking;
 
 extern bool g_bAOEnabled;
 

--- a/impl11/shaders/ExternalHUDShader.hlsl
+++ b/impl11/shaders/ExternalHUDShader.hlsl
@@ -154,8 +154,6 @@ PixelShaderOutput main(PixelShaderInput input) {
 	p += vec2(0, y_center); // In XWA the aiming HUD is not at the screen's center in cockpit view
 	vec3 v = vec3(p, -FOVscale);
 	v = mul(viewMat, vec4(v, 0.0)).xyz;
-	// This line is needed to fix the reticle when pose_corrected_headtracking is set
-	//v = mul(reticleMat, vec4(v, 0.0)).xyz;
 
 	/*
 	float d, dm = 0.0;


### PR DESCRIPTION
Use a new flag in shared memory (bIsReticleSetup) that is reset at the start of a mission by OnSizeChanged(), and set to 1 by a hook in CockpitLook in the XWA SetupReticle().

I have also removed the option of pose_corrected_headtracking. Now WaitGetPoses() will always be called by CockpitLook.