### PR TITLE
Add D3D user annotations for profiling and debug

### DIFF
--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2014 J�r�my Ansel
+﻿// Copyright (c) 2014 Jérémy Ansel
 // Licensed under the MIT license. See LICENSE.txt
 // Extended for VR by Leo Reyes (c) 2019
 

--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2014 Jérémy Ansel
+﻿// Copyright (c) 2014 J�r�my Ansel
 // Licensed under the MIT license. See LICENSE.txt
 // Extended for VR by Leo Reyes (c) 2019
 
@@ -387,6 +387,8 @@ HRESULT DeviceResources::Initialize()
 		this->_d3dDriverType = D3D_DRIVER_TYPE_WARP;
 		hr = D3D11CreateDevice(nullptr, this->_d3dDriverType, nullptr, createDeviceFlags, featureLevels, numFeatureLevels, D3D11_SDK_VERSION, &this->_d3dDevice, &this->_d3dFeatureLevel, &this->_d3dDeviceContext);
 	}
+
+	this->_d3dDeviceContext->QueryInterface(__uuidof(ID3DUserDefinedAnnotation), (void**)&this->_d3dAnnotation);
 
 	/*
 	if (SUCCEEDED(hr)) {
@@ -4511,6 +4513,8 @@ HRESULT DeviceResources::RenderMain(char* src, DWORD width, DWORD height, DWORD 
 	ID3D11Texture2D* tex = nullptr;
 	ID3D11ShaderResourceView* texView = nullptr;
 
+	this->_d3dAnnotation->BeginEvent(L"RenderMain");
+
 	/*
 	if (g_bUseSteamVR) {
 		// Process SteamVR events
@@ -5044,6 +5048,8 @@ HRESULT DeviceResources::RenderMain(char* src, DWORD width, DWORD height, DWORD 
 
 		messageShown = true;
 	}
+
+	this->_d3dAnnotation->EndEvent();
 
 	return hr;
 }

--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -5049,7 +5049,7 @@ HRESULT DeviceResources::RenderMain(char* src, DWORD width, DWORD height, DWORD 
 		messageShown = true;
 	}
 
-	this->_d3dAnnotation->EndEvent();
+	this->EndAnnotatedEvent();
 
 	return hr;
 }

--- a/impl11/ddraw/DeviceResources.h
+++ b/impl11/ddraw/DeviceResources.h
@@ -193,6 +193,7 @@ public:
 	D3D_FEATURE_LEVEL _d3dFeatureLevel;
 	ComPtr<ID3D11Device> _d3dDevice;
 	ComPtr<ID3D11DeviceContext> _d3dDeviceContext;
+	ComPtr<ID3DUserDefinedAnnotation> _d3dAnnotation;
 	ComPtr<IDXGISwapChain> _swapChain = nullptr;
 	// Buffers/Textures
 	ComPtr<ID3D11Texture2D> _backBuffer;

--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -2636,6 +2636,8 @@ HRESULT Direct3DDevice::Execute(
 	DWORD dwFlags
 )
 {
+	_deviceResources->_d3dAnnotation->BeginEvent(L"Execute");
+
 #if LOGGER
 	std::ostringstream str;
 	str << this << " " << __FUNCTION__;
@@ -5666,6 +5668,8 @@ HRESULT Direct3DDevice::Execute(
 	g_iDumpOBJIdx = 1; g_iDumpLaserOBJIdx = 1;
 	// DEBUG
 
+	_deviceResources->_d3dAnnotation->EndEvent();
+
 	if (FAILED(hr))
 	{
 		static bool messageShown = false;
@@ -6223,6 +6227,9 @@ nochange:
 
 HRESULT Direct3DDevice::BeginScene()
 {
+
+	_deviceResources->_d3dAnnotation->BeginEvent(L"Direct3DDeviceScene");
+
 #if LOGGER
 	std::ostringstream str;
 	str << this << " " << __FUNCTION__;
@@ -6602,6 +6609,8 @@ HRESULT Direct3DDevice::EndScene()
 	UpdateEventsFired();
 	// Animate all materials
 	AnimateMaterials();
+
+	_deviceResources->_d3dAnnotation->EndEvent();
 
 	return D3D_OK;
 }

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2014 J�r�my Ansel
+﻿// Copyright (c) 2014 Jérémy Ansel
 // Licensed under the MIT license. See LICENSE.txt
 // Extended for VR by Leo Reyes (c) 2019
 

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2014 Jérémy Ansel
+﻿// Copyright (c) 2014 J�r�my Ansel
 // Licensed under the MIT license. See LICENSE.txt
 // Extended for VR by Leo Reyes (c) 2019
 
@@ -7414,6 +7414,8 @@ HRESULT PrimarySurface::Flip(
 	DWORD dwFlags
 	)
 {
+	_deviceResources->_d3dAnnotation->BeginEvent(L"PrimarySurfaceFlip");
+
 	static uint64_t frame, lastFrame = 0;
 	static float seconds;
 
@@ -7487,6 +7489,7 @@ HRESULT PrimarySurface::Flip(
 			if (FAILED(hr = this->_deviceResources->_backbufferSurface->BltFast(0, 0, this->_deviceResources->_frontbufferSurface, nullptr, 0)))
 				return hr;
 
+			_deviceResources->_d3dAnnotation->EndEvent();
 			return this->Flip(this->_deviceResources->_backbufferSurface, 0);
 		}
 
@@ -7983,6 +7986,7 @@ HRESULT PrimarySurface::Flip(
 				this->_deviceResources->_frontbufferSurface->wasBltFastCalled = false;
 			}
 
+			_deviceResources->_d3dAnnotation->EndEvent();
 			return hr;
 		}
 	}
@@ -9113,7 +9117,7 @@ HRESULT PrimarySurface::Flip(
 		{
 			hr = DD_OK;
 		}
-
+		_deviceResources->_d3dAnnotation->EndEvent();
 		return hr;
 	}
 
@@ -9122,6 +9126,7 @@ HRESULT PrimarySurface::Flip(
 	LogText(str.str());
 #endif
 
+	_deviceResources->_d3dAnnotation->EndEvent();
 	return DDERR_UNSUPPORTED;
 }
 
@@ -9759,6 +9764,8 @@ void PrimarySurface::RenderText()
 		return;
 	}
 
+	_deviceResources->_d3dAnnotation->BeginEvent(L"RenderText");
+
 	if (this->_deviceResources->_d2d1RenderTarget != s_d2d1RenderTarget || this->_deviceResources->_displayWidth != s_displayWidth || this->_deviceResources->_displayHeight != s_displayHeight)
 	{
 		s_d2d1RenderTarget = this->_deviceResources->_d2d1RenderTarget;
@@ -10092,6 +10099,8 @@ out:
 
 	g_xwa_text.clear();
 	g_xwa_text.reserve(4096);
+
+	_deviceResources->_d3dAnnotation->EndEvent();
 }
 
 void PrimarySurface::RenderRadar()
@@ -10114,6 +10123,8 @@ void PrimarySurface::RenderRadar()
 		s_brush.Release();
 		return;
 	}
+
+	_deviceResources->_d3dAnnotation->BeginEvent(L"RenderRadar");
 
 	if (this->_deviceResources->_d2d1RenderTarget != s_d2d1RenderTarget || this->_deviceResources->_displayWidth != s_displayWidth || this->_deviceResources->_displayHeight != s_displayHeight)
 	{
@@ -10214,6 +10225,8 @@ void PrimarySurface::RenderRadar()
 	g_xwa_radar.clear();
 	g_xwa_radar_selected_positionX = -1;
 	g_xwa_radar_selected_positionY = -1;
+
+	_deviceResources->_d3dAnnotation->EndEvent();
 }
 
 void PrimarySurface::RenderBracket()
@@ -10240,6 +10253,8 @@ void PrimarySurface::RenderBracket()
 		s_brushOffscreen.Release();
 		return;
 	}
+
+	_deviceResources->_d3dAnnotation->BeginEvent(L"RenderBracket");
 
 	if (this->_deviceResources->_d2d1RenderTarget != s_d2d1RenderTarget || this->_deviceResources->_displayWidth != s_displayWidth || this->_deviceResources->_displayHeight != s_displayHeight)
 	{
@@ -10528,4 +10543,6 @@ void PrimarySurface::RenderSynthDCElems()
 out:
 	this->_deviceResources->_d2d1RenderTarget->EndDraw();
 	this->_deviceResources->_d2d1RenderTarget->RestoreDrawingState(this->_deviceResources->_d2d1DrawingStateBlock);
+
+	_deviceResources->_d3dAnnotation->EndEvent();
 }

--- a/impl11/ddraw/XwaD3dRendererHook.cpp
+++ b/impl11/ddraw/XwaD3dRendererHook.cpp
@@ -231,6 +231,8 @@ void D3dRenderer::SceneBegin(DeviceResources* deviceResources)
 {
 	_deviceResources = deviceResources;
 
+	_deviceResources->_d3dAnnotation->BeginEvent(L"D3dRendererScene");
+
 	if (!_isInitialized)
 	{
 		Initialize();
@@ -263,6 +265,7 @@ void D3dRenderer::SceneBegin(DeviceResources* deviceResources)
 
 void D3dRenderer::SceneEnd()
 {
+	_deviceResources->_d3dAnnotation->EndEvent();
 }
 
 void D3dRenderer::FlightStart()
@@ -295,7 +298,6 @@ void D3dRenderer::MainSceneHook(const SceneCompData* scene)
 	ComPtr<ID3D11Buffer> oldVSConstantBuffer;
 	ComPtr<ID3D11Buffer> oldPSConstantBuffer;
 	ComPtr<ID3D11ShaderResourceView> oldVSSRV[3];
-
 	context->VSGetConstantBuffers(0, 1, oldVSConstantBuffer.GetAddressOf());
 	context->PSGetConstantBuffers(0, 1, oldPSConstantBuffer.GetAddressOf());
 	context->VSGetShaderResources(0, 3, oldVSSRV[0].GetAddressOf());
@@ -347,7 +349,6 @@ void D3dRenderer::HangarShadowSceneHook(const SceneCompData* scene)
 	ComPtr<ID3D11Buffer> oldVSConstantBuffer;
 	ComPtr<ID3D11Buffer> oldPSConstantBuffer;
 	ComPtr<ID3D11ShaderResourceView> oldVSSRV[3];
-
 	context->VSGetConstantBuffers(0, 1, oldVSConstantBuffer.GetAddressOf());
 	context->PSGetConstantBuffers(0, 1, oldPSConstantBuffer.GetAddressOf());
 	context->VSGetShaderResources(0, 3, oldVSSRV[0].GetAddressOf());
@@ -1137,7 +1138,6 @@ void D3dRenderer::RenderScene()
 	}
 
 	ID3D11DeviceContext* context = _deviceResources->_d3dDeviceContext;
-
 	unsigned short scissorLeft = *(unsigned short*)0x07D5244;
 	unsigned short scissorTop = *(unsigned short*)0x07CA354;
 	unsigned short scissorWidth = *(unsigned short*)0x08052B8;

--- a/impl11/ddraw/common.h
+++ b/impl11/ddraw/common.h
@@ -15,7 +15,7 @@
 
 #include <dxgi.h>
 #include <d3d11.h>
-//#include <d3d11_1.h>
+#include <d3d11_1.h>
 #include <d2d1.h>
 #include <d2d1helper.h>
 #include <dwrite.h>


### PR DESCRIPTION
Cherrypick from https://github.com/JeremyAnsel/xwa_ddraw_d3d11/pull/7

GPU performance events can be used to instrument your game by labeling regions and marking important occurrences. A performance event represents a logical, hierarchical grouping of work, consisting of a begin/end marker pair.
In Direct3D 11.1 and above, the ID3DUserDefinedAnnotation interface is the recommended way to define those events.

https://docs.microsoft.com/en-us/windows/win32/api/d3d11_1/nn-d3d11_1-id3duserdefinedannotation
https://developer.nvidia.com/blog/best-practices-gpu-performance-events/

These annotations can be used by different profiling tools, like Intel GPA, PIX, RenderDoc, NVIDIA Nsight... I could only do a capture with Intel GPA though.

![image](https://user-images.githubusercontent.com/2017580/180584073-a65ffa3c-7899-4fe1-bac9-c671f606a267.png)

The methods of ID3DUserDefinedAnnotation have no effect when the calling application is not running under a Direct3D-specific profiling tool.

To make them work I had to include d3d11_1.h.
I added a new property in DeviceResources that should be available everywhere that this functionality is needed.
I added some events for the high level functions that are performing draw calls.