### PR TITLE
Switch to dynamic runtime library

### DIFF
--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -47,7 +47,7 @@ bool rayTriangleIntersect(
 
 void SetPresentCounter(int val, int bResetReticle) {
 	g_iPresentCounter = val;
-	if (g_pSharedData->bDataReady && g_pSharedData->pSharedData != NULL && bResetReticle) {
+	if (g_pSharedData != nullptr && g_pSharedData->bDataReady && g_pSharedData->pSharedData != NULL && bResetReticle) {
 		g_pSharedData->pSharedData->bIsReticleSetup = 0;
 	}
 }

--- a/impl11/ddraw/ddraw.vcxproj
+++ b/impl11/ddraw/ddraw.vcxproj
@@ -56,8 +56,9 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;DDRAW_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalOptions>/std:c++17 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -81,9 +82,10 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;DDRAW_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWarningAsError>false</TreatWarningAsError>
       <UndefinePreprocessorDefinitions>
       </UndefinePreprocessorDefinitions>

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,9 @@ This dll requires:
 How to install the latest version of DirectX
 http://support.microsoft.com/kb/179113/en
 
+To download the latest vc redist runtime:
+https://docs.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist
+
 
 *** Usage ***
 


### PR DESCRIPTION
From Jeremy:

> The first version of ddraw DLL was compiled with dynamic runtime and required VC 2013 runtime. Then the project was updated to use VC 2015 runtime. At this time there are also TgSmush DLL and hooks DLLs. To avoid requiring users to install multiple different versions of the c++ runtime I switched the DLLs to use static runtime library. Early this year I've switched all my DLLs to VS 2022 and I removed support for Windows XP. So now all the DLLs use the same c++ toolset. Since VS 2015 all VS versions use the same redist runtime. So now with dynamic runtime library the users have to install only one redist c++ package. For now the TgSmush DLL uses dynamic runtime library and all other DLLs use static runtime library. So I think that it is fine now to use dynamic runtime library.