### PR TITLE
Missing break in switch statement

### DIFF
--- a/impl11/ddraw/dllmain.cpp
+++ b/impl11/ddraw/dllmain.cpp
@@ -412,6 +412,7 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 					g_LaserPointDebug.y -= 0.1f;
 					log_debug("[DBG] g_LaserPointDebug: %0.3f, %0.3f, %0.3f",
 						g_LaserPointDebug.x, g_LaserPointDebug.y, g_LaserPointDebug.z);
+					break;
 				case 4:
 					//g_fDebugYCenter -= 0.01f;
 					//log_debug("[DBG] g_fDebugYCenter: %0.3f", g_fDebugYCenter);


### PR DESCRIPTION
I just saw a warning about this while working on something else, just a quick fix before I forget.