### PR TITLE
Use class template and semaphore for shared memory

### DIFF
--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -11,15 +11,6 @@
 
 /*
 
-How to fix the videos in VR, from Jeremy:
-
-	JeremyaFr — 05/13/2022
-	You can retrieve the current image with the GetCurrentImage method on the IMFVideoDisplayControl interface.
-
-	You can take a look at the method Repaint in mfplayer.player.cpp. The video is painted with the
-	method RepaintVideo on the m_pVideoDisplay object. You can retrieve the video frame with the method
-	GetCurrentImage on the m_pVideoDisplay object.
-
 Mission Index:
 	Skirmish: 0
 	PPG: 6 (looks like this is complicated in TFTC).
@@ -404,7 +395,6 @@ float s_XwaHudScale = 1.0f;
 #define DBG_MAX_PRESENT_LOGS 0
 
 #include "SharedMem.h"
-SharedDataProxy *g_pSharedData = NULL;
 
 #include "XWAFramework.h"
 

--- a/impl11/ddraw/Effects.cpp
+++ b/impl11/ddraw/Effects.cpp
@@ -592,7 +592,7 @@ bool SavePOVOffsetToIniFile()
 		OUT_OF_TAG_ST
 	} fsm = INIT_ST;
 
-	if (g_pSharedData == NULL || !g_pSharedData->bDataReady) {
+	if (g_pSharedDataCockpitLook == NULL || !g_SharedMemCockpitLook.IsDataReady()) {
 		log_debug("[DBG] [POV] Shared Memory has not been initialized, cannot write POV Offset");
 		return false;
 	}
@@ -653,9 +653,9 @@ bool SavePOVOffsetToIniFile()
 				if (fsm == IN_TAG_ST) {
 					fsm = OUT_OF_TAG_ST;
 					fprintf(out_file, "[CockpitPOVOffset]\n");
-					fprintf(out_file, "OffsetX = %0.3f\n", g_pSharedData->pSharedData->POVOffsetX);
-					fprintf(out_file, "OffsetY = %0.3f\n", g_pSharedData->pSharedData->POVOffsetY);
-					fprintf(out_file, "OffsetZ = %0.3f\n", g_pSharedData->pSharedData->POVOffsetZ);
+					fprintf(out_file, "OffsetX = %0.3f\n", g_pSharedDataCockpitLook->POVOffsetX);
+					fprintf(out_file, "OffsetY = %0.3f\n", g_pSharedDataCockpitLook->POVOffsetY);
+					fprintf(out_file, "OffsetZ = %0.3f\n", g_pSharedDataCockpitLook->POVOffsetZ);
 					fprintf(out_file, "\n");
 					bPOVWritten = true;
 				}
@@ -670,9 +670,9 @@ bool SavePOVOffsetToIniFile()
 	// This DC file may not have the "xwahacker_fov" line, so let's add it:
 	if (!bPOVWritten) {
 		fprintf(out_file, "[CockpitPOVOffset]\n");
-		fprintf(out_file, "OffsetX = %0.3f\n", g_pSharedData->pSharedData->POVOffsetX);
-		fprintf(out_file, "OffsetY = %0.3f\n", g_pSharedData->pSharedData->POVOffsetY);
-		fprintf(out_file, "OffsetZ = %0.3f\n", g_pSharedData->pSharedData->POVOffsetZ);
+		fprintf(out_file, "OffsetX = %0.3f\n", g_pSharedDataCockpitLook->POVOffsetX);
+		fprintf(out_file, "OffsetY = %0.3f\n", g_pSharedDataCockpitLook->POVOffsetY);
+		fprintf(out_file, "OffsetZ = %0.3f\n", g_pSharedDataCockpitLook->POVOffsetZ);
 		fprintf(out_file, "\n");
 		bPOVWritten = true;
 	}
@@ -687,8 +687,8 @@ bool SavePOVOffsetToIniFile()
 }
 
 /*
- * Saves the current POV Offset to the current .ini file.
- * Only call this function if the shared memory pointer proxy (g_pSharedData)
+ * Loads the current POV Offset from the current .ini file.
+ * Only call this function if the shared memory pointer (g_pSharedDataCockpitLook)
  * has been initialized.
  */
 bool LoadPOVOffsetFromIniFile()
@@ -707,7 +707,7 @@ bool LoadPOVOffsetFromIniFile()
 	} fsm = OUT_OF_TAG_ST;
 
 	log_debug("[DBG] [POV] LoadPOVOffset");
-	if (g_pSharedData == NULL || !g_pSharedData->bDataReady) {
+	if (g_pSharedDataCockpitLook == NULL || !g_SharedMemCockpitLook.IsDataReady()) {
 		log_debug("[DBG] [POV] Shared Memory has not been initialized. Cannot read current POV Offset");
 		return false;
 	}
@@ -757,15 +757,15 @@ bool LoadPOVOffsetFromIniFile()
 				// Read the relevant parameters
 				if (_stricmp(param, "OffsetX") == 0) {
 					log_debug("[DBG] [POV] Read OffsetX: %0.3f", fValue);
-					g_pSharedData->pSharedData->POVOffsetX = fValue;
+					g_pSharedDataCockpitLook->POVOffsetX = fValue;
 				}
 				if (_stricmp(param, "OffsetY") == 0) {
 					log_debug("[DBG] [POV] Read OffsetY: %0.3f", fValue);
-					g_pSharedData->pSharedData->POVOffsetY = fValue;
+					g_pSharedDataCockpitLook->POVOffsetY = fValue;
 				}
 				if (_stricmp(param, "OffsetZ") == 0) {
 					log_debug("[DBG] [POV] Read OffsetZ: %0.3f", fValue);
-					g_pSharedData->pSharedData->POVOffsetZ = fValue;
+					g_pSharedDataCockpitLook->POVOffsetZ = fValue;
 				}
 			}
 		}

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -981,7 +981,7 @@ void EffectsRenderer::ApplyDiegeticCockpit()
 		// throttle are present.
 		//if (!_bThrottleTransformReady)
 		{
-			float throttle = (DiegeticMesh == DM_THR_ROT_X || DiegeticMesh == DM_THR_ROT_Y || DM_THR_ROT_Z) ?
+			float throttle = (DiegeticMesh == DM_THR_ROT_X || DiegeticMesh == DM_THR_ROT_Y || DiegeticMesh == DM_THR_ROT_Z) ?
 				GetThrottle() : GetHyperThrottle();
 
 			// Build the transform matrix

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -941,7 +941,7 @@ void EffectsRenderer::ApplyDiegeticCockpit()
 		// _bJoystickTransformReady is set to false at the beginning of each frame. We set it to
 		// true as soon as one mesh computes it, so that we don't compute it several times per
 		// frame.
-		if (!_bJoystickTransformReady && g_pSharedData != NULL && g_pSharedData->bDataReady) {
+		if (!_bJoystickTransformReady && g_pSharedDataJoystick != NULL && g_SharedMemJoystick.IsDataReady()) {
 			Vector3 JoystickRoot = _lastTextureSelected->material.JoystickRoot;
 			float MaxYaw = _lastTextureSelected->material.JoystickMaxYaw;
 			float MaxPitch = _lastTextureSelected->material.JoystickMaxPitch;
@@ -951,10 +951,10 @@ void EffectsRenderer::ApplyDiegeticCockpit()
 			T.identity(); T.translate(-JoystickRoot);
 			_joystickMeshTransform = T;
 
-			R.identity(); R.rotateY(MaxYaw * g_pSharedData->pSharedData->JoystickYaw);
+			R.identity(); R.rotateY(MaxYaw * g_pSharedDataJoystick->JoystickYaw);
 			_joystickMeshTransform = R * _joystickMeshTransform;
 
-			R.identity(); R.rotateX(MaxPitch * g_pSharedData->pSharedData->JoystickPitch);
+			R.identity(); R.rotateX(MaxPitch * g_pSharedDataJoystick->JoystickPitch);
 			_joystickMeshTransform = R * _joystickMeshTransform;
 
 			// Return the system to its original position
@@ -981,7 +981,7 @@ void EffectsRenderer::ApplyDiegeticCockpit()
 		// throttle are present.
 		//if (!_bThrottleTransformReady)
 		{
-			float throttle = (DiegeticMesh == DM_THR_ROT_X || DM_THR_ROT_Y || DM_THR_ROT_Z) ?
+			float throttle = (DiegeticMesh == DM_THR_ROT_X || DiegeticMesh == DM_THR_ROT_Y || DM_THR_ROT_Z) ?
 				GetThrottle() : GetHyperThrottle();
 
 			// Build the transform matrix

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -27,9 +27,6 @@
 // Text Rendering
 TimedMessage g_TimedMessages[MAX_TIMED_MESSAGES];
 
-extern SharedDataProxy *g_pSharedData;
-extern SharedMem g_SharedMem;
-
 void ZToDepthRHW(float Z, float *sz, float *rhw);
 void GetCraftViewMatrix(Matrix4 *result);
 void GetGunnerTurretViewMatrixSpeedEffect(Matrix4 * result);
@@ -47,8 +44,8 @@ bool rayTriangleIntersect(
 
 void SetPresentCounter(int val, int bResetReticle) {
 	g_iPresentCounter = val;
-	if (g_pSharedData != nullptr && g_pSharedData->bDataReady && g_pSharedData->pSharedData != NULL && bResetReticle) {
-		g_pSharedData->pSharedData->bIsReticleSetup = 0;
+	if (g_pSharedDataCockpitLook != nullptr && g_SharedMemCockpitLook.IsDataReady() && bResetReticle) {
+		g_pSharedDataCockpitLook->bIsReticleSetup = 0;
 	}
 }
 

--- a/impl11/ddraw/SharedMem.cpp
+++ b/impl11/ddraw/SharedMem.cpp
@@ -2,65 +2,26 @@
 
 void log_debug(const char *format, ...);
 
-SharedMem::SharedMem(bool OpenCreate) 
-{
-	InitMemory(OpenCreate);
+void InitSharedMem() {
+
+	g_pSharedDataCockpitLook = g_SharedMemCockpitLook.GetMemoryPointer();
+	if (g_pSharedDataCockpitLook == NULL)
+		log_debug("[DBG][SharedMem] Could not load CockpitLook shared data ptr");
+
+	g_pSharedDataTgSmush = g_SharedMemTgSmush.GetMemoryPointer();
+	if (g_pSharedDataTgSmush == NULL)
+		log_debug("[DBG][SharedMem] Could not load TgSmush shared data ptr");
+
+	g_pSharedDataJoystick = g_SharedMemJoystick.GetMemoryPointer();
+	if (g_pSharedDataTgSmush == NULL)
+		log_debug("[DBG][SharedMem] Could not load Joystick shared data ptr");
 }
 
-bool SharedMem::InitMemory(bool OpenCreate) 
-{
-	pSharedMemPtr = NULL;
 
-	if (OpenCreate) {
-		hMapFile = CreateFileMapping(
-			INVALID_HANDLE_VALUE,    // use paging file
-			NULL,                    // default security
-			PAGE_READWRITE,          // read/write access
-			0,                       // maximum object size (high-order DWORD)
-			SHARED_MEM_SIZE,         // maximum object size (low-order DWORD)
-			SHARED_MEM_NAME);        // name of mapping object
+SharedMemDataCockpitLook* g_pSharedDataCockpitLook = nullptr;
+SharedMemDataTgSmush* g_pSharedDataTgSmush = nullptr;
+SharedMemDataJoystick* g_pSharedDataJoystick = nullptr;
 
-		if (hMapFile == NULL)
-		{
-			log_debug("Could not create file mapping object (%d)", GetLastError());
-			return false;
-		}
-	}
-	else {
-		hMapFile = OpenFileMapping(
-			FILE_MAP_ALL_ACCESS,   // read/write access
-			FALSE,                 // do not inherit the name
-			SHARED_MEM_NAME);      // name of mapping object
-
-		if (hMapFile == NULL)
-		{
-			log_debug("Could not open file mapping object (%d).\n", GetLastError());
-			return false;
-		}
-	}
-
-	pSharedMemPtr = (LPTSTR)MapViewOfFile(hMapFile,   // handle to map object
-		FILE_MAP_ALL_ACCESS, // read/write permission
-		0,
-		0,
-		SHARED_MEM_SIZE);
-
-	if (pSharedMemPtr == NULL) {
-		log_debug("Could not map view of file (%d)", GetLastError());
-		return false;
-	}
-
-	return true;
-}
-
-SharedMem::~SharedMem()
-{
-	UnmapViewOfFile(pSharedMemPtr);
-
-	CloseHandle(hMapFile);
-}
-
-void *SharedMem::GetMemoryPtr()
-{
-	return pSharedMemPtr;
-}
+SharedMem<SharedMemDataCockpitLook> g_SharedMemCockpitLook(SHARED_MEM_NAME_COCKPITLOOK, true, false);
+SharedMem<SharedMemDataTgSmush> g_SharedMemTgSmush(SHARED_MEM_NAME_TGSMUSH, true, true);
+SharedMem<SharedMemDataJoystick> g_SharedMemJoystick(SHARED_MEM_NAME_JOYSTICK, true, false);

--- a/impl11/ddraw/SharedMem.h
+++ b/impl11/ddraw/SharedMem.h
@@ -1,24 +1,16 @@
 #pragma once
 
 #include <windows.h>
+#include "SharedMemTemplate.h"
 
-constexpr float POVOffsetIncr = 0.025f;
-
-// This is the actual data that will be shared across DLLs. It contains
-// a mixture of custom fields and a generic pointer to share whatever else
-// we need later.
-struct SharedData {
+struct SharedMemDataCockpitLook {
 	// Offset added to the current POV when VR is active. This is controlled by ddraw
 	float POVOffsetX, POVOffsetY, POVOffsetZ;
-	void *pDataPtr;
 	// Euler angles, in degrees, for the current camera matrix coming from SteamVR. This is
 	// written by CockpitLookHook:
 	float Yaw, Pitch, Roll;
 	// Positional tracking data. Written by CockpitLookHook:
 	float X, Y, Z;
-	// Joystick's position, written by the joystick hook, or by the joystick emulation code.
-	// These values are normalized in the range -1..1
-	float JoystickYaw, JoystickPitch;
 	// Flag to indicate that the reticle needs setup, to inhibit tracking and avoid roll messing with
 	// the pips positions.
 	// Set to 0 by ddraw when the game starts a mission (in OnSizeChanged())
@@ -26,32 +18,37 @@ struct SharedData {
 	int bIsReticleSetup;
 };
 
-// This is a proxy to share data between the hook and ddraw.
-// This proxy should only contain two fields:
-// - bDataReady is set to true once the writer has initialized
-//   the proxy structure.
-// - pDataPtr points to the actual data to be shared in the regular
-//   heap space
-struct SharedDataProxy {
-	bool bDataReady;
-	SharedData *pSharedData;
+struct SharedMemDataJoystick
+{
+	// Joystick's position, written by the joystick hook, or by the joystick emulation code.
+	// These values are normalized in the range -1..1
+	float JoystickYaw, JoystickPitch;
+
+	SharedMemDataJoystick() {
+		JoystickYaw = 0.0f;
+		JoystickPitch = 0.0f;
+	}
 };
 
-constexpr auto SHARED_MEM_NAME = "Local\\CockpitLookHook";
-constexpr auto SHARED_MEM_SIZE = sizeof(SharedDataProxy);
-
-// This is the shared memory handler. Call GetMemoryPtr to get a pointer
-// to a SharedData structure
-class SharedMem {
-private:
-	HANDLE hMapFile;
-	void *pSharedMemPtr;
-	bool InitMemory(bool OpenCreate);
-
-public:
-	// Specify true in OpenCreate to create the shared memory handle. Set it to false to
-	// open an existing shared memory handle.
-	SharedMem(bool OpenCreate);
-	~SharedMem();
-	void *GetMemoryPtr();
+struct SharedMemDataTgSmush
+{
+	int videoFrameIndex;
+	int videoFrameWidth;
+	int videoFrameHeight;
+	int videoDataLength;
+	char* videoDataPtr;
 };
+
+void InitSharedMem();
+
+const auto SHARED_MEM_NAME_COCKPITLOOK = L"Local\\CockpitLookHook";
+const auto SHARED_MEM_NAME_TGSMUSH = L"Local\\TgSmushVideo";
+const auto SHARED_MEM_NAME_JOYSTICK = L"Local\\JoystickFfHook";
+
+extern SharedMem<SharedMemDataCockpitLook> g_SharedMemCockpitLook;
+extern SharedMem<SharedMemDataTgSmush> g_SharedMemTgSmush;
+extern SharedMem<SharedMemDataJoystick> g_SharedMemJoystick;
+
+extern SharedMemDataCockpitLook* g_pSharedDataCockpitLook;
+extern SharedMemDataTgSmush* g_pSharedDataTgSmush;
+extern SharedMemDataJoystick* g_pSharedDataJoystick;

--- a/impl11/ddraw/SharedMemTemplate.h
+++ b/impl11/ddraw/SharedMemTemplate.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <string>
+
+template<class T>
+class SharedMem
+{
+public:
+	SharedMem(LPCWSTR name, bool createIfNotExists, bool availableOnCreate);
+	~SharedMem();
+
+	T* GetMemoryPointer();
+	bool IsDataReady();
+	void SetDataReady();
+
+private:
+	HANDLE hMapFile;
+	HANDLE hSemaphore;
+	T* pSharedData;
+};
+
+template<class T>
+SharedMem<T>::SharedMem(LPCWSTR name, bool createIfNotExists, bool availableOnCreate)
+{
+	pSharedData = nullptr;
+	hSemaphore = NULL;
+
+	if (createIfNotExists)
+	{
+		hMapFile = CreateFileMappingW(
+			INVALID_HANDLE_VALUE,    // use paging file
+			NULL,                    // default security
+			PAGE_READWRITE,          // read/write access
+			0,                       // maximum object size (high-order DWORD)
+			sizeof(T),         // maximum object size (low-order DWORD)
+			name);        // name of mapping object
+	}
+	else
+	{
+		hMapFile = OpenFileMappingW(
+			FILE_MAP_ALL_ACCESS,   // read/write access
+			FALSE,                 // do not inherit the name
+			name);      // name of mapping object
+	}
+
+	if (!hMapFile)
+	{
+		return;
+	}
+
+	pSharedData = (T*)MapViewOfFile(
+		hMapFile,   // handle to map object
+		FILE_MAP_ALL_ACCESS, // read/write permission
+		0,
+		0,
+		sizeof(T));
+
+	LONG initialCount = availableOnCreate ? 1 : 0;
+	initialCount = 1;
+	std::wstring semaphoreName = name;
+	semaphoreName.append(L"Semaphore");
+	hSemaphore = CreateSemaphoreW(
+		NULL,					// default security attributes
+		initialCount,			// initial count
+		1,						// maximum count
+		semaphoreName.c_str()	// semaphore name);
+	);
+}
+
+template<class T>
+SharedMem<T>::~SharedMem()
+{
+	UnmapViewOfFile(pSharedData);
+	CloseHandle(hMapFile);
+	CloseHandle(hSemaphore);
+}
+
+template<class T>
+T* SharedMem<T>::GetMemoryPointer()
+{
+	return pSharedData;
+}
+
+template<class T>
+bool SharedMem<T>::IsDataReady()
+{
+	if (hSemaphore == NULL) return false;
+	DWORD dwWaitResult;
+	dwWaitResult = WaitForSingleObject(hSemaphore, 0);
+	//log_debug("[DBG][SharedMem] IsDataReady::dwWaitResult = %d",  dwWaitResult);
+	switch (dwWaitResult) {
+		// The semaphore was signaled, the data is ready
+		case WAIT_OBJECT_0:
+			// We release it again immediately since we don't need exclusive or atomic access
+			// (there are no concurrent threads)
+			ReleaseSemaphore(hSemaphore, 1, NULL);
+			return true;
+			break;
+
+		// The semaphore was nonsignaled, so a time-out occurred.
+		// This should only happen when the data is not ready to be accessed
+		// (missing/disabled hook, not initialized or not generating data.
+		case WAIT_TIMEOUT:
+			return false;
+			break;
+	}
+	return false;
+}
+
+template<class T>
+void SharedMem<T>::SetDataReady()
+{
+	ReleaseSemaphore(hSemaphore, 1, NULL);
+}

--- a/impl11/ddraw/SteamVR.cpp
+++ b/impl11/ddraw/SteamVR.cpp
@@ -41,8 +41,6 @@ int g_iSteamVR_Remaining_ms = 3, g_iSteamVR_VSync_ms = 11;
 bool g_bSteamVRPosFromFreePIE = DEFAULT_STEAMVR_POS_FROM_FREEPIE;
 float g_fSteamVRMirrorWindow3DScale = 0.7f, g_fSteamVRMirrorWindowAspectRatio = 0.0f;
 
-extern SharedDataProxy* g_pSharedData;
-
 bool InitSteamVR()
 {
 	/*

--- a/impl11/ddraw/VRConfig.cpp
+++ b/impl11/ddraw/VRConfig.cpp
@@ -158,6 +158,8 @@ float g_fDebugYCenter = 0.0f;
 float g_fCockpitPZThreshold = DEFAULT_COCKPIT_PZ_THRESHOLD; // The TIE-Interceptor needs this thresold!
 float g_fBackupCockpitPZThreshold = g_fCockpitPZThreshold; // Backup of the cockpit threshold, used when toggling this effect on or off.
 
+const float POVOffsetIncr = 0.025f;
+
 // METRIC 3D RECONSTRUCTION
 // The following values were determined by comparing the back-projected 3D reconstructed
 // with ddraw against the OBJ exported from the OPT. The values were tweaked until a

--- a/impl11/ddraw/VRConfig.h
+++ b/impl11/ddraw/VRConfig.h
@@ -10,6 +10,8 @@ extern const char* COVER_TEX_NAME_DCPARAM;
 extern const char* COVER_TEX_SIZE_DCPARAM;
 extern const char* ERASE_REGION_DCPARAM;
 
+extern const float POVOffsetIncr;
+
 // This is the current resolution of the screen:
 extern float g_fLensK1;
 extern float g_fLensK2;
@@ -59,8 +61,6 @@ extern bool g_bEdgeDetectorEnabled;
 extern bool g_bEnableVR;
 extern bool g_bCockpitPZHackEnabled;
 extern bool g_bOverrideAspectRatio;
-
-
 
 // User-facing functions
 void ResetVRParams(); // Restores default values for the view params

--- a/impl11/ddraw/ddraw.vcxproj
+++ b/impl11/ddraw/ddraw.vcxproj
@@ -21,14 +21,12 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
-    <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -60,6 +58,7 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <AdditionalOptions>/std:c++17 %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -196,6 +195,7 @@
     <ClInclude Include="Reticle.h" />
     <ClInclude Include="ShadowMapping.h" />
     <ClInclude Include="SharedMem.h" />
+    <ClInclude Include="SharedMemTemplate.h" />
     <ClInclude Include="SteamVR.h" />
     <ClInclude Include="targetver.h" />
     <ClInclude Include="TextureSurface.h" />

--- a/impl11/ddraw/ddraw.vcxproj.filters
+++ b/impl11/ddraw/ddraw.vcxproj.filters
@@ -320,6 +320,9 @@
     <ClInclude Include="LBVH.h">
       <Filter>Fichiers d%27en-tête</Filter>
     </ClInclude>
+    <ClInclude Include="SharedMemTemplate.h">
+      <Filter>Fichiers d%27en-tête</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="ddraw.rc">

--- a/impl11/ddraw/dllmain.cpp
+++ b/impl11/ddraw/dllmain.cpp
@@ -28,10 +28,6 @@
 #include "XWAFramework.h"
 #include "SharedMem.h"
 
-extern SharedDataProxy *g_pSharedData;
-// ddraw is loaded after the hooks, so here we open an existing shared memory handle:
-SharedMem g_SharedMem(false);
-
 extern HiResTimer g_HiResTimer;
 extern PlayerDataEntry* PlayerDataTable;
 extern uint32_t* g_playerIndex;
@@ -989,39 +985,39 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 			case VK_LEFT:
 				//IncreaseHUDParallax(-0.1f);
 				// Adjust the POV in VR (through cockpit shake), see CockpitLook
-				if (g_pSharedData != NULL && g_pSharedData->bDataReady) {
-					g_pSharedData->pSharedData->POVOffsetZ -= POVOffsetIncr;
+				if (g_pSharedDataCockpitLook != NULL && g_SharedMemCockpitLook.IsDataReady()) {
+					g_pSharedDataCockpitLook->POVOffsetZ -= POVOffsetIncr;
 					SavePOVOffsetToIniFile();
 				}
 				return 0;
 			case VK_RIGHT:
 				//IncreaseHUDParallax(0.1f);
 				// Adjust the POV in VR (through cockpit shake), see CockpitLook
-				if (g_pSharedData != NULL && g_pSharedData->bDataReady) {
-					g_pSharedData->pSharedData->POVOffsetZ += POVOffsetIncr;
+				if (g_pSharedDataCockpitLook != NULL && g_SharedMemCockpitLook.IsDataReady()) {
+					g_pSharedDataCockpitLook->POVOffsetZ += POVOffsetIncr;
 					SavePOVOffsetToIniFile();
 				}
 				return 0;
 			case VK_UP:
 				// Adjust the POV in VR (through cockpit shake), see CockpitLook
-				if (g_pSharedData != NULL && g_pSharedData->bDataReady) {
-					g_pSharedData->pSharedData->POVOffsetY += POVOffsetIncr;
+				if (g_pSharedDataCockpitLook != NULL && g_SharedMemCockpitLook.IsDataReady()) {
+					g_pSharedDataCockpitLook->POVOffsetY += POVOffsetIncr;
 					SavePOVOffsetToIniFile();
 				}
 				return 0;
 			case VK_DOWN:
 				// Adjust the POV in VR (through cockpit shake), see CockpitLook
-				if (g_pSharedData != NULL && g_pSharedData->bDataReady) {
-					g_pSharedData->pSharedData->POVOffsetY -= POVOffsetIncr;
+				if (g_pSharedDataCockpitLook != NULL && g_SharedMemCockpitLook.IsDataReady()) {
+					g_pSharedDataCockpitLook->POVOffsetY -= POVOffsetIncr;
 					SavePOVOffsetToIniFile();
 				}
 				return 0;
 			case VK_OEM_PERIOD:
 				log_debug("[DBG] Resetting POVOffset for %s", g_sCurrentCockpit);
-				if (g_pSharedData != NULL && g_pSharedData->bDataReady) {
-					g_pSharedData->pSharedData->POVOffsetX = 0.0f;
-					g_pSharedData->pSharedData->POVOffsetY = 0.0f;
-					g_pSharedData->pSharedData->POVOffsetZ = 0.0f;
+				if (g_pSharedDataCockpitLook != NULL && g_SharedMemCockpitLook.IsDataReady()) {
+					g_pSharedDataCockpitLook->POVOffsetX = 0.0f;
+					g_pSharedDataCockpitLook->POVOffsetY = 0.0f;
+					g_pSharedDataCockpitLook->POVOffsetZ = 0.0f;
 					SavePOVOffsetToIniFile();
 				}
 				return 0;
@@ -1254,12 +1250,6 @@ void LoadPOVOffsets() {
 out:
 	fclose(file);
 	log_debug("[DBG] [POV] %d POV entries modified", entries_applied);
-}
-
-void InitSharedMem() {
-	g_pSharedData = (SharedDataProxy *)g_SharedMem.GetMemoryPtr();
-	if (g_pSharedData == NULL)
-		log_debug("[DBG] Could not load shared data ptr");
 }
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -201,7 +201,10 @@ extern float g_fDebugFOVscale, g_fDebugYCenter;
 extern bool g_bCustomFOVApplied, g_bLastFrameWasExterior;
 extern float g_fRealHorzFOV, g_fRealVertFOV;
 
-extern SharedDataProxy *g_pSharedData;
+extern SharedMem<SharedMemDataCockpitLook> g_SharedMemCockpitLook;
+extern SharedMem<SharedMemDataTgSmush> g_SharedMemTgSmush;
+extern SharedMemDataCockpitLook* g_pSharedDataCockpitLook;
+extern SharedMemDataTgSmush* g_pSharedDataTgSmush;
 
 // Custom HUD colors
 extern uint32_t g_iHUDInnerColor, g_iHUDBorderColor;

--- a/impl11/ddraw/joystick.cpp
+++ b/impl11/ddraw/joystick.cpp
@@ -12,7 +12,6 @@
 #include "joystick.h"
 extern PlayerDataEntry *PlayerDataTable;
 extern uint32_t *g_playerIndex;
-extern SharedDataProxy *g_pSharedData;
 
 #pragma comment(lib, "winmm")
 #pragma comment(lib, "XInput9_1_0")
@@ -312,9 +311,9 @@ UINT WINAPI emulJoyGetPosEx(UINT joy, struct joyinfoex_tag *pji)
 	// Normalize each axis to the range -1..1:
 	float normYaw = 2.0f * (pji->dwXpos / 512.0f - 0.5f);
 	float normPitch = 2.0f * (pji->dwYpos / 512.0f - 0.5f);
-	if (g_pSharedData != NULL && g_pSharedData->bDataReady) {
-		g_pSharedData->pSharedData->JoystickYaw = normYaw;
-		g_pSharedData->pSharedData->JoystickPitch = normPitch;
+	if (g_pSharedDataJoystick != NULL) {
+		g_pSharedDataJoystick->JoystickYaw = normYaw;
+		g_pSharedDataJoystick->JoystickPitch = normPitch;
 	}
 
 	return JOYERR_NOERROR;


### PR DESCRIPTION
Use a class template to define the SharedMem manager class. This allows to re-use exactly the same SharedMemTemplate.h code for sharing data between different hooks. You just need to create specific struct definitions that you pass to the SharedMem Template to create a dedicated manager object.

Instead of storing just a pointer to the heap in shared memory, put the whole shared structure in the memory mapped file for simplicity.

To signal the availability of data from the hook, use a binary semaphore. This is optional, it's up to the producer and consumer to use the IsDataReady() function.

This PR depends on https://github.com/JeremyAnsel/xwa_hooks/pull/9 and https://github.com/Prof-Butts/Hook_XWACockpitLook/pull/20