### PR TITLE
Gimbal Lock Fix.

### DIFF
--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -10,6 +10,21 @@
 // g_WindowWidth, g_WindowHeight --> Actual Windows screen as returned by GetWindowRect
 
 /*
+From Jeremy, regarding how to replace the transform matrix in MobileObject
+
+The function to recalculate the forward vector is:
+// L0043FFB0
+void XwaRecalculateForwardVector( word A4, word A8, Ptr<XwaObject> AC )
+
+The function to recalculate the transform matrix is:
+// L00440140
+void XwaRecalculateTransformMatrix( word A4, word A8, Ptr<XwaObject> AC )
+
+I think you can modify/replace the implementation of this function to define the matrix to whatever you want 
+
+*/
+
+/*
 * Is there a field that tells us when a ship is under the effect of a beam weapon?
 *
 * RandomStarfighter:

--- a/impl11/ddraw/Effects.cpp
+++ b/impl11/ddraw/Effects.cpp
@@ -227,7 +227,6 @@ DeleteAllTempZIPDirectoriesFun	DeleteAllTempZIPDirectories = nullptr;
 GetZIPImageMetadataFun			GetZIPImageMetadata = nullptr;
 // **************************
 
-
 void SmallestK::insert(Vector3 P, Vector3 col, Vector3 dir, float falloff, float angle) {
 	int i = _size - 1;
 	while (i >= 0 && P.z < _elems[i].P.z) {
@@ -876,7 +875,7 @@ CraftInstance *GetPlayerCraftInstanceSafe()
 {
 	// I've seen the game crash when trying to access the CraftInstance table in the
 	// first few frames of a new mission. Let's add this test to prevent this crash.
-	if (g_iPresentCounter <= 5) return NULL;
+	if (g_iPresentCounter <= PLAYERDATATABLE_MIN_SAFE_FRAME) return NULL;
 
 	// Fetch the pointer to the current CraftInstance
 	int16_t objectIndex = (int16_t)PlayerDataTable[*g_playerIndex].objectIndex;
@@ -886,6 +885,42 @@ CraftInstance *GetPlayerCraftInstanceSafe()
 	MobileObjectEntry *mobileObject = object->MobileObjectPtr;
 	if (mobileObject == NULL) return NULL;
 	CraftInstance *craftInstance = mobileObject->craftInstancePtr;
+	if (craftInstance == NULL) return NULL;
+	return craftInstance;
+}
+
+CraftInstance* GetPlayerCraftInstanceSafe(ObjectEntry **object)
+{
+	// I've seen the game crash when trying to access the CraftInstance table in the
+	// first few frames of a new mission. Let's add this test to prevent this crash.
+	if (g_iPresentCounter <= PLAYERDATATABLE_MIN_SAFE_FRAME) return NULL;
+
+	// Fetch the pointer to the current CraftInstance
+	int16_t objectIndex = (int16_t)PlayerDataTable[*g_playerIndex].objectIndex;
+	if (objectIndex < 0) return NULL;
+	*object = &((*objects)[objectIndex]);
+	if (object == NULL) return NULL;
+	MobileObjectEntry* mobileObject = (*object)->MobileObjectPtr;
+	if (mobileObject == NULL) return NULL;
+	CraftInstance* craftInstance = mobileObject->craftInstancePtr;
+	if (craftInstance == NULL) return NULL;
+	return craftInstance;
+}
+
+CraftInstance* GetPlayerCraftInstanceSafe(ObjectEntry** object, MobileObjectEntry **mobileObject)
+{
+	// I've seen the game crash when trying to access the CraftInstance table in the
+	// first few frames of a new mission. Let's add this test to prevent this crash.
+	if (g_iPresentCounter <= PLAYERDATATABLE_MIN_SAFE_FRAME) return NULL;
+
+	// Fetch the pointer to the current CraftInstance
+	int16_t objectIndex = (int16_t)PlayerDataTable[*g_playerIndex].objectIndex;
+	if (objectIndex < 0) return NULL;
+	*object = &((*objects)[objectIndex]);
+	if (object == NULL) return NULL;
+	*mobileObject = (*object)->MobileObjectPtr;
+	if (*mobileObject == NULL) return NULL;
+	CraftInstance* craftInstance = (*mobileObject)->craftInstancePtr;
 	if (craftInstance == NULL) return NULL;
 	return craftInstance;
 }

--- a/impl11/ddraw/Effects.h
+++ b/impl11/ddraw/Effects.h
@@ -188,5 +188,7 @@ std::vector<short> ReadZIPImageListFromGroup(const char *sZIPFileName, int Group
 // ********************************
 
 CraftInstance *GetPlayerCraftInstanceSafe();
+CraftInstance *GetPlayerCraftInstanceSafe(ObjectEntry** object);
+CraftInstance* GetPlayerCraftInstanceSafe(ObjectEntry** object, MobileObjectEntry** mobileObject);
 // Also updates g_bInTechGlobe when called.
 bool InTechGlobe();

--- a/impl11/ddraw/LBVH.cpp
+++ b/impl11/ddraw/LBVH.cpp
@@ -12,7 +12,7 @@
 // atomically, so that's why it's a global variable for now.
 static int QBVHEncodeNodeIdx = 0;
 
-bool g_bEnableQBVHwSAH = true;
+bool g_bEnableQBVHwSAH = false; // The FastLQBVH builder still has some problems when SAH is enabled
 
 void PrintTreeBuffer(std::string level, BVHNode* buffer, int curNode);
 int BinTreeToBuffer(BVHNode* buffer, int EncodeOfs,

--- a/impl11/ddraw/VRConfig.cpp
+++ b/impl11/ddraw/VRConfig.cpp
@@ -558,6 +558,8 @@ next:
 	LoadDefaultGlobalMaterial();
 	// Load hook_tourmultiplayer.cfg
 	LoadMultiplayerConfig();
+	// Load gimbal lock fix parameters
+	LoadGimbaLockFixConfig();
 	// Reload the materials
 	ReloadMaterials();
 }
@@ -2793,6 +2795,94 @@ bool LoadMultiplayerConfig() {
 
 			if (_stricmp(param, "GreenAndRedForIFFColorsOnly") == 0) {
 				g_bGreenAndRedForIFFColorsOnly = (bool)fValue;
+			}
+		}
+	}
+	fclose(file);
+
+	return true;
+}
+
+bool LoadGimbaLockFixConfig() {
+	log_debug("[DBG] Loading GimbalLockFix.cfg...");
+	FILE* file;
+	int error = 0, line = 0;
+
+	try {
+		error = fopen_s(&file, "./GimbalLockFix.cfg", "rt");
+	}
+	catch (...) {
+		log_debug("[DBG] Could not load GimbalLockFix.cfg");
+	}
+
+	if (error != 0) {
+		log_debug("[DBG] Error %d when loading GimbalLockFix.cfg", error);
+		return false;
+	}
+
+	char buf[256], param[128], svalue[128];
+	int param_read_count = 0;
+	float fValue = 0.0f;
+
+	while (fgets(buf, 256, file) != NULL) {
+		line++;
+		// Skip comments and blank lines
+		if (buf[0] == ';' || buf[0] == '#')
+			continue;
+		if (strlen(buf) == 0)
+			continue;
+
+		if (sscanf_s(buf, "%s = %s", param, 128, svalue, 128) > 0) {
+			fValue = (float)atof(svalue);
+
+			if (_stricmp(param, "enable_gimbal_lock_fix") == 0) {
+				g_bEnableGimbalLockFix = (bool)fValue;
+			}
+			else if (_stricmp(param, "debug_mode") == 0) {
+				g_bGimbalLockDebugMode = (bool)fValue;
+			}
+
+			else if (_stricmp(param, "yaw_accel_rate_s") == 0) {
+				g_fYawAccelRate_s = fValue;
+			}
+			else if (_stricmp(param, "pitch_accel_rate_s") == 0) {
+				g_fPitchAccelRate_s = fValue;
+			}
+			else if (_stricmp(param, "roll_accel_rate_s") == 0) {
+				g_fRollAccelRate_s = fValue;
+			}
+
+			else if (_stricmp(param, "max_yaw_rate_s") == 0) {
+				g_fMaxYawRate_s = fValue;
+			}
+			else if (_stricmp(param, "max_pitch_rate_s") == 0) {
+				g_fMaxYawRate_s = fValue;
+			}
+			else if (_stricmp(param, "max_roll_rate_s") == 0) {
+				g_fMaxRollRate_s = fValue;
+			}
+
+			else if (_stricmp(param, "turn_rate_scale_throttle_0") == 0) {
+				g_fTurnRateScaleThr_0 = fValue;
+			}
+			else if (_stricmp(param, "turn_rate_scale_throttle_100") == 0) {
+				g_fTurnRateScaleThr_100 = fValue;
+			}
+			else if (_stricmp(param, "max_turn_accel_rate_s") == 0) {
+				g_fMaxTurnAccelRate_s = fValue;
+			}
+
+			else if (_stricmp(param, "mouse_center_x") == 0) {
+				g_iMouseCenterX = (int)fValue;
+			}
+			else if (_stricmp(param, "mouse_center_y") == 0) {
+				g_iMouseCenterY = (int)fValue;
+			}
+			else if (_stricmp(param, "mouse_range_x") == 0) {
+				g_fMouseRangeX = fValue;
+			}
+			else if (_stricmp(param, "mouse_range_y") == 0) {
+				g_fMouseRangeY = fValue;
 			}
 		}
 	}

--- a/impl11/ddraw/VRConfig.h
+++ b/impl11/ddraw/VRConfig.h
@@ -83,6 +83,7 @@ bool LoadHyperParams();
 bool Load3DVisionParams();
 bool LoadDefaultGlobalMaterial();
 bool LoadMultiplayerConfig();
+bool LoadGimbaLockFixConfig();
 void ReloadMaterials();
 
 #ifdef DBG_VR

--- a/impl11/ddraw/dllmain.cpp
+++ b/impl11/ddraw/dllmain.cpp
@@ -533,11 +533,15 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 			//	return 0;
 			case 'G':
 				//g_bDumpLaserPointerDebugInfo = true;
+				g_bEnableGimbalLockFix = !g_bEnableGimbalLockFix;
+				DisplayTimedMessage(3, 0, g_bEnableGimbalLockFix ? "Gimbal Lock Fix ON" : "Regular Joystick Controls");
+				/*
 				g_bAutoGreeblesEnabled = !g_bAutoGreeblesEnabled;
 				if (g_bAutoGreeblesEnabled)
 					DisplayTimedMessage(3, 0, "Greebles Enabled");
 				else
 					DisplayTimedMessage(3, 0, "Greebles Disabled");
+				*/
 				return 0;
 				// DEBUG
 			case 'P':
@@ -959,8 +963,10 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 		}
 
 		// Ctrl + Shift
-		if (CtrlKey && !AltKey && ShiftKey) {
-			switch (wParam) {
+		if (CtrlKey && !AltKey && ShiftKey)
+		{
+			switch (wParam)
+			{
 			case 0xbb:
 				//IncreaseNoExecIndices(0, 1);
 				IncreaseD3DExecuteCounterSkipHi(1);
@@ -969,16 +975,16 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 				//IncreaseNoExecIndices(0, -1);
 				IncreaseD3DExecuteCounterSkipHi(-1);
 				return 0;
-			// Ctrl+Shift+C: Reset the cockpit damage
+				// Ctrl+Shift+C: Reset the cockpit damage
 			case 'C':
 				g_bResetCockpitDamage = true;
 				return 0;
-			/*
-			case 'T': {
-				g_bDCHologramsVisible = !g_bDCHologramsVisible;
-				return 0;
-			}
-			*/
+				/*
+				case 'T': {
+					g_bDCHologramsVisible = !g_bDCHologramsVisible;
+					return 0;
+				}
+				*/
 
 			case VK_UP:
 				IncreaseFloatingGUIParallax(0.05f);
@@ -998,6 +1004,7 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 		// Shift
 		if (ShiftKey && !AltKey && !CtrlKey) {
 			switch (wParam) {
+			// Shift + Arrow Keys
 			case VK_LEFT:
 				//IncreaseHUDParallax(-0.1f);
 				// Adjust the POV in VR (through cockpit shake), see CockpitLook
@@ -1028,6 +1035,7 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 					SavePOVOffsetToIniFile();
 				}
 				return 0;
+
 			case VK_OEM_PERIOD:
 				log_debug("[DBG] Resetting POVOffset for %s", g_sCurrentCockpit);
 				if (g_pSharedDataCockpitLook != NULL && g_SharedMemCockpitLook.IsDataReady()) {

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -63,6 +63,7 @@ extern bool g_bPrevIsTargetHighlighted; // The value of g_bIsTargetHighlighted f
 //bool g_bLaserBoxLimitsUpdated = false; // Set to true whenever the laser/ion charge limit boxes are updated
 extern unsigned int g_iFloatingGUIDrawnCounter;
 extern int g_iPresentCounter, g_iNonZBufferCounter, g_iSkipNonZBufferDrawIdx;
+constexpr int PLAYERDATATABLE_MIN_SAFE_FRAME = 5;
 extern float g_fZBracketOverride; // 65535 is probably the maximum Z value in XWA
 extern bool g_bResetDC;
 
@@ -136,6 +137,7 @@ extern bool g_bApplyCockpitDamage, g_bResetCockpitDamage;
 extern bool g_bAutoGreeblesEnabled;
 extern bool g_bShowBlastMarks;
 extern float g_fBlastMarkOfsX, g_fBlastMarkOfsY;
+extern bool g_bEnableGimbalLockFix;
 
 /*
  * Dumps the vertices in the current instruction to the given file after back-projecting them
@@ -243,6 +245,30 @@ extern bool g_bRTCaptureCameraAABB;
 extern bool g_bEnableLevelsShader;
 extern float g_fLevelsWhitePoint;
 extern float g_fLevelsBlackPoint;
+
+// Gimbal Lock Fix
+// Configurable settings
+extern bool g_bEnableGimbalLockFix, g_bGimbalLockActive, g_bGimbalLockDebugMode;
+extern float g_fRollFromYawScale;
+
+extern float g_fYawAccelRate_s;
+extern float g_fPitchAccelRate_s;
+extern float g_fRollAccelRate_s;
+
+extern float g_fMaxYawRate_s;
+extern float g_fMaxPitchRate_s;
+extern float g_fMaxRollRate_s;
+
+extern float g_fTurnRateScaleThr_0;
+extern float g_fTurnRateScaleThr_100;
+extern float g_fMaxTurnAccelRate_s;
+
+// Non-configurable
+extern float g_fJoystickRudder;
+
+// Gimbal lock debug settings
+extern int g_iMouseCenterX, g_iMouseCenterY;
+extern float g_fMouseRangeX, g_fMouseRangeY;
 
 // *****************************************************
 // Global functions


### PR DESCRIPTION
The basic idea is to use a Right, Up, Forward orthonormal vector basis system and then translate that back into XWA's yaw, pitch, roll. Then we can overwrite the ship's yaw, pitch, roll in the player's ObjectEntry slot.

The RUF system is reortho on every frame and renormalized, that way precision errors are not accumulated.

If the PlayerRUF and XWA's mobileObject orientation matrix get out of sync, the code will re-initialize PlayerRUF. This effectively makes PlayerRUF get the proper initial values.

To enable mouse support, do the following in DDraw.cfg:

	JoystickEmul = 1
	MouseSensitivity = 2.0