### PR TITLE
LOD-Aware In-Flight Raytracing, 

### DIFF
--- a/impl11/ddraw/D3dRenderer.h
+++ b/impl11/ddraw/D3dRenderer.h
@@ -183,4 +183,7 @@ extern bool g_isInRenderLasers;
 extern bool g_isInRenderMiniature;
 extern bool g_isInRenderHyperspaceLines;
 
+extern std::map<int, int> g_OptHeaderMap;
+extern std::map<int, int> g_FGToSetMap;
+
 void ClearCachedSRVs();

--- a/impl11/ddraw/D3dRenderer.h
+++ b/impl11/ddraw/D3dRenderer.h
@@ -183,7 +183,7 @@ extern bool g_isInRenderLasers;
 extern bool g_isInRenderMiniature;
 extern bool g_isInRenderHyperspaceLines;
 
-extern std::map<int, int> g_OptHeaderMap;
+extern std::map<int, int> g_MeshTagMap;
 extern std::map<int, int> g_FGToLODMap;
 
 void ClearCachedSRVs();

--- a/impl11/ddraw/D3dRenderer.h
+++ b/impl11/ddraw/D3dRenderer.h
@@ -184,6 +184,6 @@ extern bool g_isInRenderMiniature;
 extern bool g_isInRenderHyperspaceLines;
 
 extern std::map<int, int> g_OptHeaderMap;
-extern std::map<int, int> g_FGToSetMap;
+extern std::map<int, int> g_FGToLODMap;
 
 void ClearCachedSRVs();

--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -212,6 +212,9 @@ void ResetRawMouseInput();
 // This maps meshKeys (the vertex pointer) to MeshData tuples.
 // This map is used to build a single BLAS in the Tech Room and
 // gets cleared when a new OPT is loaded.
+// It's also used to build Coalesced BVHs: all FGs in the same mesh
+// are coalesced into a single BVH. It gets cleared when OnSizeChanged()
+// is called.
 std::map<int32_t, MeshData> g_LBVHMap;
 
 // This maps FaceGroupIDs (FaceIndices pointer) to BLASData tuples.
@@ -219,10 +222,12 @@ std::map<int32_t, MeshData> g_LBVHMap;
 // (one per FaceGroup). It gets cleared when OnSizeChanged() is called
 std::map<int32_t, BLASData> g_BLASMap;
 
-// This maps (meshKey,centroid) to matrix slots. It gets cleared at the beginning of every frame
-// The centroid is important because the same mesh may appear multiple times if there are
-// multiple ships in the same FG, for instance.
-std::map<FaceGroupNCentroid_t, int32_t> g_TLASMap;
+// This maps (ID, centroid) to matrix slots.
+// The ID can be either a meshKey or a faceGroupID.
+// It gets cleared at the beginning of every frame.
+// The centroid is important because the same mesh may appear multiple
+// times if there are multiple ships in the same FG, for instance.
+std::map<IDCentroid_t, int32_t> g_TLASMap;
 std::vector<Matrix4> g_TLASMatrices;
 void ClearGlobalLBVHMap();
 

--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -217,16 +217,19 @@ void ResetRawMouseInput();
 // is called.
 std::map<int32_t, MeshData> g_LBVHMap;
 
-// This maps FaceGroupIDs (FaceIndices pointer) to BLASData tuples.
-// This map is used to build multiple BLASes during regular flight
-// (one per FaceGroup). It gets cleared when OnSizeChanged() is called
-std::map<int32_t, BLASData> g_BLASMap;
+// This maps (MeshKey, LOD) to BlasIds. Gets cleared when OnSizeChanged()
+std::map<BLASKey_t, int> g_BLASIdMap;
 
-// This maps (ID, centroid) to matrix slots.
-// The ID can be either a meshKey or a faceGroupID.
+// This maps BlasIds to BLASData tuples.
+// This map is used to build multiple BLASes during regular flight
+// (one per BlasId). It gets cleared when OnSizeChanged() is called
+std::map<int, BLASData> g_BLASMap;
+
+// This maps (BlasId, centroid) to matrix slots.
 // It gets cleared at the beginning of every frame.
-// The centroid is important because the same mesh may appear multiple
-// times if there are multiple ships in the same FG, for instance.
+// The centroid is important because the same BLAS may appear multiple
+// times if there are multiple ships in the same (Mesh, LOD), but in
+// different locations, for instance.
 std::map<IDCentroid_t, int32_t> g_TLASMap;
 std::vector<Matrix4> g_TLASMatrices;
 void ClearGlobalLBVHMap();

--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -231,6 +231,7 @@ std::map<IDCentroid_t, int32_t> g_TLASMap;
 std::vector<Matrix4> g_TLASMatrices;
 void ClearGlobalLBVHMap();
 
+#undef DEBUG_RT
 #ifdef DEBUG_RT
 // DEBUG: Map of meshKey --> (OPTname, vertcount, meshIndex). Only for debugging purposes.
 std::map<int32_t, std::tuple<std::string, int, int>> g_DebugMeshToNameMap;

--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -221,8 +221,8 @@ std::vector<Matrix4> g_TLASMatrices;
 void ClearGlobalLBVHMap();
 
 #ifdef DEBUG_RT
-// DEBUG: Map of meshKey --> OPT names. Only for debugging purposes.
-std::map<int32_t, std::tuple<std::string, int>> g_DebugMeshToNameMap;
+// DEBUG: Map of meshKey --> (OPTname, vertcount, meshIndex). Only for debugging purposes.
+std::map<int32_t, std::tuple<std::string, int, int>> g_DebugMeshToNameMap;
 #endif
 
 /* The different types of Constant Buffers used in the Pixel Shader: */

--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -208,15 +208,21 @@ void ResetObjectIndexMap();
 void ResetRawMouseInput();
 
 // Raytracing
-// This maps meshKeys (the vertex pointer) to MeshData tuples
-// This map is used to build BLASes and gets cleared in the following situations:
-// - Tech Room: Every time a new OPT is loaded
-// - Regular Flight: When OnSizeChanged() is called
+
+// This maps meshKeys (the vertex pointer) to MeshData tuples.
+// This map is used to build a single BLAS in the Tech Room and
+// gets cleared when a new OPT is loaded.
 std::map<int32_t, MeshData> g_LBVHMap;
+
+// This maps FaceGroupIDs (FaceIndices pointer) to BLASData tuples.
+// This map is used to build multiple BLASes during regular flight
+// (one per FaceGroup). It gets cleared when OnSizeChanged() is called
+std::map<int32_t, BLASData> g_BLASMap;
+
 // This maps (meshKey,centroid) to matrix slots. It gets cleared at the beginning of every frame
 // The centroid is important because the same mesh may appear multiple times if there are
 // multiple ships in the same FG, for instance.
-std::map<MeshNCentroid_t, int32_t> g_TLASMap;
+std::map<FaceGroupNCentroid_t, int32_t> g_TLASMap;
 std::vector<Matrix4> g_TLASMatrices;
 void ClearGlobalLBVHMap();
 

--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -486,6 +486,10 @@ float s_XwaHudScale = 1.0f;
 
 #include "XWAFramework.h"
 
+XwaPlanet* g_XwaPlanets = (XwaPlanet*)0x005B1140;
+TieFlightGroupEx* g_XwaTieFlightGroups = (TieFlightGroupEx*)0x0080DC80;
+ExeEnableEntry* g_ExeObjectsTable = (ExeEnableEntry*)0x005FB240; // (Not sure about the type in this one)
+
 FILE *g_HackFile = NULL;
 
 float RealVertFOVToRawFocalLength(float real_FOV);

--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -486,9 +486,12 @@ float s_XwaHudScale = 1.0f;
 
 #include "XWAFramework.h"
 
+//Array<XwaPlanet, 104> s_XwaPlanets
 XwaPlanet* g_XwaPlanets = (XwaPlanet*)0x005B1140;
-TieFlightGroupEx* g_XwaTieFlightGroups = (TieFlightGroupEx*)0x0080DC80;
-ExeEnableEntry* g_ExeObjectsTable = (ExeEnableEntry*)0x005FB240; // (Not sure about the type in this one)
+//Array<TieFlightGroupEx, 192> s_XwaTieFlightGroups;
+TieFlightGroup* g_XwaTieFlightGroups = (TieFlightGroup*)0x0080DC80;
+//Array<ExeObjectEntry, 557> s_ExeObjectsTable;
+const ExeEnableEntry* g_ExeObjectsTable = (ExeEnableEntry*)0x005FB240; // (Not sure about the type in this one)
 
 FILE *g_HackFile = NULL;
 

--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -16,6 +16,41 @@
 // https://github.com/Prof-Butts/xwa_ddraw_d3d11/commit/673da14a4b717ded5296dc6e17b1d95c43c20147
 
 /*
+From you-know-who:
+
+The function to create lights for backdrops look like that:
+// L00439040
+void XwaCreateGlobalLightsForBackdrops(  )
+{
+	dword ebx = s_XwaPlayers[s_XwaCurrentPlayerId].Region;
+
+	for( dword edi = 0; edi < s_XwaBackdropsCountPerRegion[ebx]; edi++ )
+	{
+		if( s_XwaBackdrops[ebx * 0x20 + edi].ColorIntensity <= 0.0f )
+			continue;
+
+		XwaAddGlobalLight(
+			s_XwaBackdrops[ebx * 0x20 + edi].WorldX / 256,
+			s_XwaBackdrops[ebx * 0x20 + edi].WorldY / 256,
+			s_XwaBackdrops[ebx * 0x20 + edi].WorldZ / 256,
+			s_XwaBackdrops[ebx * 0x20 + edi].ColorIntensity,
+			s_XwaBackdrops[ebx * 0x20 + edi].ColorR,
+			s_XwaBackdrops[ebx * 0x20 + edi].ColorG,
+			s_XwaBackdrops[ebx * 0x20 + edi].ColorB
+			);
+	}
+}
+
+Before the call to XwaCreateGlobalLightsForBackdrops the global lights count is set to 0.
+The lights are created in the same order as the backdrops appear in the mission tie file.
+In the XwaTieFlightGroups array you can get the PlanetId.
+For backdrops the CraftId is CraftId_183_9001_1100_ResData_Backdrop.
+With the PlanetId you can read the backdrop model index in the XwaPlanets.
+With the model index you can read in the ExeObjectsTable the backdrop dat GroupId and ImageId.
+
+*/
+
+/*
 From Jeremy, regarding LODs and how to parse the OPT structure:
 
 There is no direct way to tell which lod is rendered.

--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -9,6 +9,30 @@
 // resources->_displayWidth, resources->_displayHeight -- in-game resolution
 // g_WindowWidth, g_WindowHeight --> Actual Windows screen as returned by GetWindowRect
 
+// Important commits:
+// Improve Depth Value:
+// https://github.com/Prof-Butts/xwa_ddraw_d3d11/commit/f05c0ef6f65b2bf7f9e085baf9ebaf0e7207eb41
+
+/*
+From Jeremy, regarding LODs and how to parse the OPT structure:
+
+There is no direct way to tell which lod is rendered.
+There is int& s_XwaOptCurrentLodDistance = *(int*)0x007D4F8C;.
+There is float& s_XwaFlightLod = *(float*)0x00600288;.
+The distance is 1.0f / ( s_XwaOptCurrentLodDistance * s_XwaFlightLod );
+You can access to the whole opt structure via a model index.
+The SceneCompData struct contains a pObject member. The XwaObject has a model index.
+At offset 0x007CA6E0 there is an array s_XwaOptModelFileMemHandles of 557 short. The index in this array is a model index.
+There are these function to lock and unlock the handle.
+// L0050E2F0
+void* Lock_Handle( short A4 )
+// L0050E350
+void Unlock_Handle( short A4 )
+
+The data struct of the locked handle is a OptHeader pointer.
+With this header you can access to the whole opt.
+*/
+
 /*
 From Jeremy, regarding how to replace the transform matrix in MobileObject
 

--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -12,6 +12,8 @@
 // Important commits:
 // Improve Depth Value:
 // https://github.com/Prof-Butts/xwa_ddraw_d3d11/commit/f05c0ef6f65b2bf7f9e085baf9ebaf0e7207eb41
+// One BLAS per FaceGroup:
+// https://github.com/Prof-Butts/xwa_ddraw_d3d11/commit/673da14a4b717ded5296dc6e17b1d95c43c20147
 
 /*
 From Jeremy, regarding LODs and how to parse the OPT structure:

--- a/impl11/ddraw/Effects.h
+++ b/impl11/ddraw/Effects.h
@@ -154,19 +154,20 @@ inline int32_t& GetNumMeshVertices(MeshData& X) { return std::get<1>(X); }
 inline void*& GetLBVH(MeshData& X) { return std::get<2>(X); } // <-- This is probably not used anymore
 inline int& GetBaseNodeOffset(MeshData& X) { return std::get<3>(X); } // <-- This is probably not used anymore
 
-// (MeshVerticesPtr, NumMeshVertices, NumFaces, LBVH, BaseNodeOffset)
-// 0: MeshVerticesPtr  -- Pointer to the MeshVertices
+// (FaceGroup map, NumMeshVertices, LBVH, BaseNodeOffset, MeshVerticesPtr)
+// BLASData is now a superset of MeshData. At some point, I may be able to replace the latter.
+// 0: FaceGroupMap     -- An std::map with all the Face Groups in this mesh
 // 1: NumMeshVertices  -- The number of vertices in this mesh
 // 2: LBVH             -- The BVH for this mesh (only used during regular flight)
 // 3: BaseNodeOffset   -- The index into _RTBvh where this BLAS begins (only used during regular flight)
-// 4: FaceGroupMap     -- An std::map with all the Face Groups in this mesh (optional, only used if this is a coalesced BVH entry)
-using BLASData = std::tuple<int32_t, int32_t, void*, int, FaceGroups>;
+// 4: MeshVerticesPtr  -- Pointer to the MeshVertices
+using BLASData = std::tuple<FaceGroups, int32_t, void*, int32_t, int32_t>;
 
-inline int32_t&    BLASGetMeshVertices(BLASData& X) { return std::get<0>(X); }
+inline FaceGroups& BLASGetFaceGroups(BLASData& X) { return std::get<0>(X); }
 inline int32_t&    BLASGetNumVertices(BLASData& X) { return std::get<1>(X); }
 inline void *&     BLASGetBVH(BLASData& X) { return std::get<2>(X); }
 inline int32_t&    BLASGetBaseNodeOffset(BLASData& X) { return std::get<3>(X); }
-inline FaceGroups& BLASGetFaceGroups(BLASData& X) { return std::get<4>(X); }
+inline int32_t&    BLASGetMeshVertices(BLASData& X) { return std::get<4>(X); }
 
 // TLAS leaf keys are made of: (meshKey, FaceGroup)
 using MeshFG_t = std::tuple<int32_t, int32_t>;

--- a/impl11/ddraw/Effects.h
+++ b/impl11/ddraw/Effects.h
@@ -154,6 +154,9 @@ inline int32_t& GetNumMeshVertices(MeshData& X) { return std::get<1>(X); }
 inline void* &GetLBVH(MeshData& X) { return std::get<2>(X); }
 inline int &GetBaseNodeOffset(MeshData& X) { return std::get<3>(X); }
 
+// TLAS leaf keys are made of: (meshKey, FaceGroup)
+using MeshFG_t = std::tuple<int32_t, int32_t>;
+
 // TLAS leaf uniqueness is determined by the meshKey and its centroid (there can be
 // multiple instances of the same mesh belonging to different craft in a Flight Group, for instance)
 using MeshNCentroid_t = std::tuple<int32_t, float, float, float>;
@@ -167,7 +170,7 @@ extern std::vector<Matrix4> g_TLASMatrices;
 #define DEBUG_RT
 #ifdef DEBUG_RT
 // DEBUG only
-extern std::map<int32_t, std::tuple<std::string, int>> g_DebugMeshToNameMap;
+extern std::map<int32_t, std::tuple<std::string, int, int>> g_DebugMeshToNameMap;
 #endif
 
 // ********************************

--- a/impl11/ddraw/Effects.h
+++ b/impl11/ddraw/Effects.h
@@ -125,10 +125,12 @@ float RealVertFOVToRawFocalLength(float real_FOV);
 
 // ********************************
 // Raytracing
-// // Maps face group index --> numTris in face group
+// Maps face group index --> numTris in face group
 using FaceGroups = std::map<int32_t, int32_t>;
-// Each OPT is made of multiple meshes
-// Each mesh is made of multiple face groups
+
+// Each OPT is made of multiple meshes.
+// Each mesh is made of multiple LODs.
+// Each LOD is made of multiple Face Groups.
 // From our perspective, inside ddraw, we see a draw call per face group
 // but each face group references the whole set of vertices from the mesh.
 // The only way to reconstruct the original faces is by accumulating all
@@ -169,28 +171,27 @@ inline void *&     BLASGetBVH(BLASData& X) { return std::get<2>(X); }
 inline int32_t&    BLASGetBaseNodeOffset(BLASData& X) { return std::get<3>(X); }
 inline int32_t&    BLASGetMeshVertices(BLASData& X) { return std::get<4>(X); }
 
-// TLAS leaf keys are made of: (meshKey, FaceGroup)
-using MeshFG_t = std::tuple<int32_t, int32_t>;
+// BLAS Key: <MeshKey, LOD>. This tuple can be used to uniquely identify a BLAS entry.
+// There's one BLAS per mesh per LOD.
+// - MeshKey is scene->MeshVertices
+// - Set is the LOD index. We can get the LOD from its FaceGroup.
+using BLASKey_t = std::tuple<int, int>;
+// Map of unique IDs for BLASes. (MeshKey, LOD) --> BlasId
+extern std::map<BLASKey_t, int> g_BLASIdMap;
 
-// TLAS leaf uniqueness is determined by the {MeshKey|FaceGroupID} and its centroid.
-// The FaceGroupID must be used for OPTs with multiple LODs, so that we only display
-// the FGs for the current LOD.
-// For other meshes without LODs, like the cockpit, it's better to coalesce all FGs
-// belonging to the same mesh into a single BVH. For that case, we use the meshKey.
-// There can be multiple instances of the same Face Group|Mesh belonging to different
-// craft in a Flight Group; or there can be different LODs on the same mesh with
-// different FGs.
+// TLAS leaf uniqueness is determined by the BlasID and its centroid.
+// BlasId, x, y, z:
 using IDCentroid_t = std::tuple<int32_t, float, float, float>;
 
-// The {Single|Coalesced} BLAS map: meshKey --> MeshData
+// The {Single|Coalesced} BLAS map: meshKey --> MeshData (only used in the Tech Room)
 extern std::map<int32_t, MeshData> g_LBVHMap;
-// The Multiple BLAS map: faceGroup --> BLASData
-extern std::map<int32_t, BLASData> g_BLASMap;
-// The TLAS map: ({MeshKey|FaceGroupID}, centroid) --> matrixSlot
+// The Multiple BLAS map: BlasId --> BLASData
+extern std::map<int, BLASData> g_BLASMap;
+// The TLAS map: (BlasId, centroid) --> matrixSlot
 extern std::map<IDCentroid_t, int32_t> g_TLASMap;
 // The TLAS matrix buffer (1:1 correspondence with g_TLASMap)
 extern std::vector<Matrix4> g_TLASMatrices;
-#define DEBUG_RT
+#undef DEBUG_RT
 #ifdef DEBUG_RT
 // DEBUG only
 extern std::map<int32_t, std::tuple<std::string, int, int>> g_DebugMeshToNameMap;

--- a/impl11/ddraw/EffectsCommon.h
+++ b/impl11/ddraw/EffectsCommon.h
@@ -234,7 +234,7 @@ typedef struct PSShadingSystemCBStruct {
 
 typedef struct RTConstantsBufferStruct {
 	uint32_t bRTEnable;
-	uint32_t bRTEnabledInCockpit;
+	uint32_t bRTAllowShadowMapping;
 	uint32_t bEnablePBRShading;
 	uint32_t RTUnused;
 	// 16 bytes

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -2174,7 +2174,7 @@ void EffectsRenderer::DoStateManagement(const SceneCompData* scene)
 		//bIsHyperspaceTunnel = lastTextureSelected->is_HyperspaceAnim;
 		_bIsCockpit = _lastTextureSelected->is_CockpitTex;
 		_bIsGunner = _lastTextureSelected->is_GunnerTex;
-		//bIsExterior = lastTextureSelected->is_Exterior;
+		_bIsExterior = _lastTextureSelected->is_Exterior;
 		//bIsDAT = lastTextureSelected->is_DAT;
 		//bIsActiveCockpit = lastTextureSelected->ActiveCockpitIdx > -1;
 		_bIsBlastMark = _lastTextureSelected->is_BlastMark;
@@ -3711,7 +3711,10 @@ void EffectsRenderer::MainSceneHook(const SceneCompData* scene)
 		!_lastTextureSelected->is_LightTexture)
 	{
 		bool bSkipCockpit = _bIsCockpit && !g_bRTEnabledInCockpit;
-		bool bCoalesce = _bIsCockpit;
+		// bCoalesce is set to true if the current Face Group must be coalesced with other
+		// face groups in the same mesh. FGs belonging to different LODs should not be
+		// coalesced, but we know that cockpit and exterior OPTs don't have LODs.
+		bool bCoalesce = _bIsCockpit || _bIsExterior;
 		//bool bRaytrace = _lastTextureSelected->material.Raytrace;
 		if (!bSkipCockpit && !_bIsLaser && !_bIsExplosion && !_bIsGunner &&
 			!(g_bIsFloating3DObject || g_isInRenderMiniature))

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -33,7 +33,6 @@ bool g_bRTEnabledInTechRoom = true;
 bool g_bRTEnabled = false; // In-flight RT switch.
 bool g_bRTEnabledInCockpit = false;
 bool g_bEnablePBRShading = false;
-bool g_bRTCoalesceEverything = false;
 bool g_bRTCaptureCameraAABB = true;
 // Used for in-flight RT, to create the BVH buffer that will store all the
 // individual BLASes needed for the current frame.
@@ -1090,6 +1089,7 @@ void EffectsRenderer::SceneBegin(DeviceResources* deviceResources)
 {
 	D3dRenderer::SceneBegin(deviceResources);
 
+#ifdef DISABLED
 	{
 		if (g_bDumpOptNodes)
 		{
@@ -1148,8 +1148,8 @@ void EffectsRenderer::SceneBegin(DeviceResources* deviceResources)
 			g_bDumpOptNodes = false;
 		}
 	}
+#endif
 
-	_BLASNeedsUpdate = false;
 	/*
 	log_debug("[DBG] [BVH] g_iDebugFGChecker.size(): %d", g_iDebugFGChecker.size());
 	for (auto &it : g_iDebugFGChecker) {
@@ -1238,27 +1238,16 @@ void EffectsRenderer::SceneBegin(DeviceResources* deviceResources)
 	if (PlayerDataTable->missionTime == 0)
 		ApplyCustomHUDColor();
 
-	if (g_bKeepMouseInsideWindow)
+	if (g_bKeepMouseInsideWindow && !g_bInTechRoom)
 	{
 		// I'm a bit tired of clicking the mouse outside the window when debugging.
 		// I. shall. end. this. now.
 		SetCursorPos(0, 0);
 	}
 
+	_BLASNeedsUpdate = false;
 	if (g_bRTEnabled)
 	{
-		// DEBUG
-		{
-			static bool bPrevRTCoalesceEverything = false;
-			if (bPrevRTCoalesceEverything != g_bRTCoalesceEverything)
-			{
-				log_debug("[DBG] [BVH] REGEN ALL BLASES");
-				ClearGlobalLBVHMap();
-				_BLASNeedsUpdate = true;
-			}
-			bPrevRTCoalesceEverything = g_bRTCoalesceEverything;
-		}
-
 		// Restart the TLAS for the frame that is about to begin
 		g_iRTMeshesInThisFrame = 0;
 		g_GlobalAABB.SetInfinity();

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -104,7 +104,7 @@ int32_t MakeMeshKey(const SceneCompData* scene)
 
 int32_t MakeFaceGroupKey(const SceneCompData* scene)
 {
-	return (uint32_t)scene->FaceIndices;
+	return (int32_t)scene->FaceIndices;
 }
 
 void RTResetMatrixSlotCounter()
@@ -3743,13 +3743,24 @@ void EffectsRenderer::MainSceneHook(const SceneCompData* scene)
 		if (!bSkipCockpit && !_bIsLaser && !_bIsExplosion && !_bIsGunner &&
 			!(g_bIsFloating3DObject || g_isInRenderMiniature))
 		{
+			// DEBUG
 			/*
 			char OPTname[120];
 			GetOPTNameFromLastTextureSelected(OPTname);
-			if (stristr(OPTname, "MediumTransport") != NULL && _currentOptMeshIndex == 0) {
-				auto& it = g_iDebugFGChecker.find((int)scene->FaceIndices);
-				if (it == g_iDebugFGChecker.end())
-					g_iDebugFGChecker[(int)scene->FaceIndices] = scene->FacesCount;
+			if (stristr(OPTname, "MediumTransport") != NULL && _currentOptMeshIndex == 0)
+			{
+				{
+					int faceGroupID = MakeFaceGroupKey(scene);
+					auto& it = g_FGToSetMap.find(faceGroupID);
+					if (it != g_FGToSetMap.end())
+					{
+						log_debug("[DBG] [OPT] %s FG 0x%x --> %d",
+							OPTname, faceGroupID, it->second);
+					}
+				}
+				//auto& it = g_iDebugFGChecker.find((int)scene->FaceIndices);
+				//if (it == g_iDebugFGChecker.end())
+				//	g_iDebugFGChecker[(int)scene->FaceIndices] = scene->FacesCount;
 				//log_debug("[DBG] [BVH] MediumTransport, FG: 0x%x", scene->FaceIndices);
 			}
 			*/

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -1415,6 +1415,7 @@ void EffectsRenderer::BuildMultipleBLASFromCurrentBLASMap()
 		}
 
 		// DEBUG: Skip meshes we don't care about
+#undef DEBUG_RT
 #ifdef DEBUG_RT
 		if (false)
 		{

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -1090,6 +1090,65 @@ void EffectsRenderer::SceneBegin(DeviceResources* deviceResources)
 {
 	D3dRenderer::SceneBegin(deviceResources);
 
+	{
+		if (g_bDumpOptNodes)
+		{
+			int numLights = *s_XwaGlobalLightsCount;
+			log_debug("[DBG] ------------------------------");
+			for (int i = 0; i < numLights; i++)
+			{
+				log_debug("[DBG] light: %d: [%0.3f, %0.3f, %0.3f]",
+					i,
+					s_XwaGlobalLights[i].PositionX / 32768.0f,
+					s_XwaGlobalLights[i].PositionY / 32768.0f,
+					s_XwaGlobalLights[i].PositionZ / 32768.0f);
+			}
+			log_debug("[DBG] ------------------------------");
+
+			constexpr int CraftId_183_9001_1100_ResData_Backdrop = 183;
+			const XwaMission* mission = *(XwaMission**)0x09EB8E0;
+
+			for (int i = 0; i < 192; i++)
+			{
+				int CraftId = mission->FlightGroups[i].CraftId;
+				int PlanetId = mission->FlightGroups[i].PlanetId;
+
+				if (CraftId == CraftId_183_9001_1100_ResData_Backdrop && PlanetId < 104)
+				{
+					short SX = mission->FlightGroups[i].StartPoints->X;
+					short SY = mission->FlightGroups[i].StartPoints->Y;
+					short SZ = mission->FlightGroups[i].StartPoints->Z;
+					int region = mission->FlightGroups[i].StartPointRegions[0];
+					int currentRegion = PlayerDataTable[*g_playerIndex].currentRegion;
+
+					int ModelIndex = g_XwaPlanets[PlanetId].ModelIndex;
+					//log_debug("[DBG]     ModelIndex: %d", ModelIndex);
+					if (ModelIndex < 557)
+					{
+						int data1 = g_ExeObjectsTable[ModelIndex].DataIndex1;
+						int data2 = g_ExeObjectsTable[ModelIndex].DataIndex2;
+						Vector3 S = Vector3((float)SX, (float)-SY, (float)SZ);
+						S = S.normalize();
+						if (data1 >= 9001)
+						{
+							log_debug("[DBG] [%s], CraftId: %d, PlanetId: %d, S:[%0.3f, %0.3f, %0.3f]",
+								mission->FlightGroups[i].Name, CraftId, PlanetId, S.x, S.y, S.z);
+							//log_debug("[DBG]     ShipCategory: %d, ObjectCategory: %d",
+							//	g_ExeObjectsTable[ModelIndex].ShipCategory,
+							//	g_ExeObjectsTable[ModelIndex].ObjectCategory);
+							log_debug("[DBG]     region: %d, curRegion: %d, Group-Id: %d-%d",
+								region, currentRegion,
+								g_ExeObjectsTable[ModelIndex].DataIndex1,
+								g_ExeObjectsTable[ModelIndex].DataIndex2);
+						}
+					}
+				}
+			}
+
+			g_bDumpOptNodes = false;
+		}
+	}
+
 	_BLASNeedsUpdate = false;
 	/*
 	log_debug("[DBG] [BVH] g_iDebugFGChecker.size(): %d", g_iDebugFGChecker.size());

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -1233,6 +1233,7 @@ LBVH* EffectsRenderer::BuildBVH(const std::vector<XwaVector3>& vertices, const s
 		// 1-step LBVH build: QBVH is built and encoded in one step.
 		return LBVH::BuildFastQBVH(vertices.data(), vertices.size(), indices.data(), indices.size());
 	}
+	return nullptr;
 }
 
 // Build a single BVH from the contents of the g_LBVHMap and put it into _lbvh.

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -988,6 +988,7 @@ void ApplyGimbalLockFix(float elapsedTime, CraftInstance *craftInstance)
 	if (g_pSharedDataJoystick == NULL || !g_SharedMemJoystick.IsDataReady())
 		return;
 	bool RMouseDown = GetAsyncKeyState(VK_RBUTTON);
+	bool CtrlKey = (GetAsyncKeyState(VK_CONTROL) & 0x8000) == 0x8000;
 	float DesiredYawRate_s = 0, DesiredPitchRate_s = 0, DesiredRollRate_s = 0;
 
 	const float RollFromYawScale = g_fRollFromYawScale;
@@ -1027,7 +1028,7 @@ void ApplyGimbalLockFix(float elapsedTime, CraftInstance *craftInstance)
 	DesiredPitchRate_s = g_pSharedDataJoystick->JoystickPitch * MaxPitchRate_s;
 	if (g_config.JoystickEmul)
 	{
-		if (!RMouseDown)
+		if (!RMouseDown && !CtrlKey)
 		{
 			DesiredYawRate_s = g_pSharedDataJoystick->JoystickYaw * MaxYawRate_s;
 			// Apply a little roll when yaw is applied

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -3641,7 +3641,12 @@ void EffectsRenderer::MainSceneHook(const SceneCompData* scene)
 	{
 		g_RTConstantsBuffer.bRTEnable = g_bRTEnabled &&	(!*g_playerInHangar) &&
 			(g_HyperspacePhaseFSM == HS_INIT_ST);
-		g_RTConstantsBuffer.bRTEnabledInCockpit = g_bRTEnabledInCockpit;
+		// g_RTConstantsBuffer.bRTEnabledInCockpit = g_bRTEnabledInCockpit;
+		g_RTConstantsBuffer.bRTAllowShadowMapping =
+			// Allow shadow mapping if we're in the hangar
+			*g_playerInHangar ||
+			// Or if we're not in the hangar, not in external view and RTCockpit is off
+			(!*g_playerInHangar && !_bExternalCamera && !g_bRTEnabledInCockpit);
 		//g_RTConstantsBuffer.bEnablePBRShading = g_bEnablePBRShading;
 		g_RTConstantsBuffer.bEnablePBRShading = g_bRTEnabled; // Let's force PBR shading when RT is on, at least for now
 		resources->InitPSRTConstantsBuffer(resources->_RTConstantsBuffer.GetAddressOf(), &g_RTConstantsBuffer);

--- a/impl11/ddraw/EffectsRenderer.h
+++ b/impl11/ddraw/EffectsRenderer.h
@@ -140,7 +140,7 @@ public:
 	void ApplyRTShadows(const SceneCompData* scene);
 	//void AddAABBToTLAS(const Matrix4& WorldViewTransform, int meshID, AABB aabb, int matrixSlot);
 	void GetOPTNameFromLastTextureSelected(char* OPTname);
-	void UpdateBVHMaps(const SceneCompData* scene, bool isCoalesced);
+	void UpdateBVHMaps(const SceneCompData* scene, int LOD);
 
 	// Per-texture, per-instance effects
 	CraftInstance *ObjectIDToCraftInstance(int objectId, MobileObjectEntry** mobileObject_out);

--- a/impl11/ddraw/EffectsRenderer.h
+++ b/impl11/ddraw/EffectsRenderer.h
@@ -132,14 +132,14 @@ public:
 
 	// Raytracing
 	void BuildSingleBLASFromCurrentBVHMap();
-	void BuildMultipleBLASFromCurrentBVHMap();
+	void BuildMultipleBLASFromCurrentBLASMap();
 	void ReAllocateAndPopulateBvhBuffers(const int numNodes);
 	void ReAllocateAndPopulateTLASBvhBuffers();
 	void ReAllocateAndPopulateMatrixBuffer();
 	void ApplyRTShadows(const SceneCompData* scene);
 	//void AddAABBToTLAS(const Matrix4& WorldViewTransform, int meshID, AABB aabb, int matrixSlot);
 	void GetOPTNameFromLastTextureSelected(char* OPTname);
-	void UpdateGlobalBVH(const SceneCompData* scene);
+	void UpdateBVHMaps(const SceneCompData* scene);
 
 	// Per-texture, per-instance effects
 	CraftInstance *ObjectIDToCraftInstance(int objectId, MobileObjectEntry** mobileObject_out);

--- a/impl11/ddraw/EffectsRenderer.h
+++ b/impl11/ddraw/EffectsRenderer.h
@@ -131,6 +131,7 @@ public:
 	void ApplyNormalMapping();
 
 	// Raytracing
+	LBVH* BuildBVH(const std::vector<XwaVector3>& vertices, const std::vector<int>& indices);
 	void BuildSingleBLASFromCurrentBVHMap();
 	void BuildMultipleBLASFromCurrentBLASMap();
 	void ReAllocateAndPopulateBvhBuffers(const int numNodes);
@@ -139,7 +140,7 @@ public:
 	void ApplyRTShadows(const SceneCompData* scene);
 	//void AddAABBToTLAS(const Matrix4& WorldViewTransform, int meshID, AABB aabb, int matrixSlot);
 	void GetOPTNameFromLastTextureSelected(char* OPTname);
-	void UpdateBVHMaps(const SceneCompData* scene);
+	void UpdateBVHMaps(const SceneCompData* scene, bool isCoalesced);
 
 	// Per-texture, per-instance effects
 	CraftInstance *ObjectIDToCraftInstance(int objectId, MobileObjectEntry** mobileObject_out);

--- a/impl11/ddraw/EffectsRenderer.h
+++ b/impl11/ddraw/EffectsRenderer.h
@@ -44,7 +44,7 @@ Matrix4 ComputeLightViewMatrix(int idx, Matrix4 &Heading, bool invert);
 class EffectsRenderer : public D3dRenderer
 {
 protected:
-	bool _bLastTextureSelectedNotNULL, _bLastLightmapSelectedNotNULL, _bIsLaser, _bIsCockpit;
+	bool _bLastTextureSelectedNotNULL, _bLastLightmapSelectedNotNULL, _bIsLaser, _bIsCockpit, _bIsExterior;
 	bool _bIsGunner, _bIsExplosion, _bIsBlastMark, _bHasMaterial, _bDCIsTransparent, _bDCElemAlwaysVisible;
 	bool _bModifiedShaders, _bModifiedPixelShader, _bModifiedBlendState, _bModifiedSamplerState;
 	bool _bIsNoisyHolo, _bWarheadLocked, _bIsTargetHighlighted, _bIsHologram, _bRenderingLightingEffect;

--- a/impl11/ddraw/EffectsRenderer.h
+++ b/impl11/ddraw/EffectsRenderer.h
@@ -138,6 +138,7 @@ public:
 	void ReAllocateAndPopulateMatrixBuffer();
 	void ApplyRTShadows(const SceneCompData* scene);
 	//void AddAABBToTLAS(const Matrix4& WorldViewTransform, int meshID, AABB aabb, int matrixSlot);
+	void GetOPTNameFromLastTextureSelected(char* OPTname);
 	void UpdateGlobalBVH(const SceneCompData* scene);
 
 	// Per-texture, per-instance effects

--- a/impl11/ddraw/LBVH.cpp
+++ b/impl11/ddraw/LBVH.cpp
@@ -1386,15 +1386,13 @@ int TLASEncodeLeafNode(BVHNode* buffer, std::vector<TLASLeafItem>& leafItems, in
 	uint32_t* ubuffer = (uint32_t*)buffer;
 	float* fbuffer    = (float*)buffer;
 	auto& leafItem    = leafItems[leafIdx];
-	int ID            = TLASGetID(leafItem);
+	int blasID        = TLASGetID(leafItem);
 	int matrixSlot    = TLASGetMatrixSlot(leafItem);
 	AABB obb          = TLASGetOBB(leafItem);
 	AABB aabb         = TLASGetAABBFromOBB(leafItem); // This is OBB * WorldViewTransform
 	int BLASBaseNodeOffset = -1;
 
-	// ID can be either a FaceGroupID, or a meshKey. Either way, it
-	// should have an entry in g_BLASMap.
-	const auto& it = g_BLASMap.find(ID);
+	const auto& it = g_BLASMap.find(blasID);
 	if (it != g_BLASMap.end())
 	{
 		BLASData& blasData = it->second;
@@ -1411,7 +1409,7 @@ int TLASEncodeLeafNode(BVHNode* buffer, std::vector<TLASLeafItem>& leafItems, in
 	//	leafIdx, TriID, (EncodeOfs * 4) / 64);
 
 	// Encode the current TLAS leaf into the QBVH buffer, in the leaf section
-	ubuffer[EncodeOfs++] = ID;
+	ubuffer[EncodeOfs++] = blasID;
 	ubuffer[EncodeOfs++] = -1; // parent
 	ubuffer[EncodeOfs++] = matrixSlot;
 	ubuffer[EncodeOfs++] = BLASBaseNodeOffset;

--- a/impl11/ddraw/LBVH.cpp
+++ b/impl11/ddraw/LBVH.cpp
@@ -1386,18 +1386,18 @@ int TLASEncodeLeafNode(BVHNode* buffer, std::vector<TLASLeafItem>& leafItems, in
 	uint32_t* ubuffer = (uint32_t*)buffer;
 	float* fbuffer    = (float*)buffer;
 	auto& leafItem    = leafItems[leafIdx];
-	int MeshID        = TLASGetID(leafItem);
+	int faceGroupID   = TLASGetID(leafItem);
 	int matrixSlot    = TLASGetMatrixSlot(leafItem);
 	AABB obb          = TLASGetOBB(leafItem);
 	AABB aabb         = TLASGetAABBFromOBB(leafItem); // This is OBB * WorldViewTransform
 	int BLASBaseNodeOffset = -1;
-	const auto &it = g_LBVHMap.find(MeshID);
-	if (it != g_LBVHMap.end())
+	const auto &it = g_BLASMap.find(faceGroupID);
+	if (it != g_BLASMap.end())
 	{
-		MeshData& meshData = it->second;
-		BLASBaseNodeOffset = GetBaseNodeOffset(meshData);
+		BLASData& blasData = it->second;
+		BLASBaseNodeOffset = BLASGetBaseNodeOffset(blasData);
 		// Disable this leaf if the BVH does not exist
-		if (std::get<2>(meshData) == nullptr)
+		if (BLASGetBVH(blasData) == nullptr)
 		{
 			BLASBaseNodeOffset = -1;
 		}
@@ -1408,7 +1408,7 @@ int TLASEncodeLeafNode(BVHNode* buffer, std::vector<TLASLeafItem>& leafItems, in
 	//	leafIdx, TriID, (EncodeOfs * 4) / 64);
 
 	// Encode the current TLAS leaf into the QBVH buffer, in the leaf section
-	ubuffer[EncodeOfs++] = MeshID;
+	ubuffer[EncodeOfs++] = faceGroupID;
 	ubuffer[EncodeOfs++] = -1; // parent
 	ubuffer[EncodeOfs++] = matrixSlot;
 	ubuffer[EncodeOfs++] = BLASBaseNodeOffset;

--- a/impl11/ddraw/LBVH.cpp
+++ b/impl11/ddraw/LBVH.cpp
@@ -1386,12 +1386,15 @@ int TLASEncodeLeafNode(BVHNode* buffer, std::vector<TLASLeafItem>& leafItems, in
 	uint32_t* ubuffer = (uint32_t*)buffer;
 	float* fbuffer    = (float*)buffer;
 	auto& leafItem    = leafItems[leafIdx];
-	int faceGroupID   = TLASGetID(leafItem);
+	int ID            = TLASGetID(leafItem);
 	int matrixSlot    = TLASGetMatrixSlot(leafItem);
 	AABB obb          = TLASGetOBB(leafItem);
 	AABB aabb         = TLASGetAABBFromOBB(leafItem); // This is OBB * WorldViewTransform
 	int BLASBaseNodeOffset = -1;
-	const auto &it = g_BLASMap.find(faceGroupID);
+
+	// ID can be either a FaceGroupID, or a meshKey. Either way, it
+	// should have an entry in g_BLASMap.
+	const auto& it = g_BLASMap.find(ID);
 	if (it != g_BLASMap.end())
 	{
 		BLASData& blasData = it->second;
@@ -1408,7 +1411,7 @@ int TLASEncodeLeafNode(BVHNode* buffer, std::vector<TLASLeafItem>& leafItems, in
 	//	leafIdx, TriID, (EncodeOfs * 4) / 64);
 
 	// Encode the current TLAS leaf into the QBVH buffer, in the leaf section
-	ubuffer[EncodeOfs++] = faceGroupID;
+	ubuffer[EncodeOfs++] = ID;
 	ubuffer[EncodeOfs++] = -1; // parent
 	ubuffer[EncodeOfs++] = matrixSlot;
 	ubuffer[EncodeOfs++] = BLASBaseNodeOffset;

--- a/impl11/ddraw/LBVH.h
+++ b/impl11/ddraw/LBVH.h
@@ -209,7 +209,7 @@ public:
 using MortonCode_t = uint32_t;
 // 0: Morton Code, 1: Bounding Box, 2: TriID
 using LeafItem = std::tuple<MortonCode_t, AABB, int>;
-// 0: Morton Code, 1: aabbFromOBB, 2: MeshKey, 3: Centroid, 4: MatrixSlot, 5: Oriented Bounding Box
+// 0: Morton Code, 1: aabbFromOBB, 2: FaceGroupID, 3: Centroid, 4: MatrixSlot, 5: Oriented Bounding Box
 using TLASLeafItem = std::tuple<MortonCode_t, AABB, int, XwaVector3, int, AABB>;
 
 inline MortonCode_t &GetMortonCode(LeafItem& X) { return std::get<0>(X); }

--- a/impl11/ddraw/LBVH.h
+++ b/impl11/ddraw/LBVH.h
@@ -209,8 +209,8 @@ public:
 using MortonCode_t = uint32_t;
 // 0: Morton Code, 1: Bounding Box, 2: TriID
 using LeafItem = std::tuple<MortonCode_t, AABB, int>;
-// 0: Morton Code, 1: aabbFromOBB, 2: ID, 3: Centroid, 4: MatrixSlot, 5: Oriented Bounding Box, 6: Coalesced Mesh
-using TLASLeafItem = std::tuple<MortonCode_t, AABB, int, XwaVector3, int, AABB, bool>;
+// 0: Morton Code, 1: aabbFromOBB, 2: ID, 3: Centroid, 4: MatrixSlot, 5: Oriented Bounding Box
+using TLASLeafItem = std::tuple<MortonCode_t, AABB, int, XwaVector3, int, AABB>;
 
 inline MortonCode_t &GetMortonCode(LeafItem& X) { return std::get<0>(X); }
 inline MortonCode_t &GetMortonCode(TLASLeafItem& X) { return std::get<0>(X); }
@@ -227,7 +227,6 @@ inline int& TLASGetID(TLASLeafItem& X) { return std::get<2>(X); }
 inline XwaVector3& TLASGetCentroid(TLASLeafItem& X) { return std::get<3>(X); }
 inline int& TLASGetMatrixSlot(TLASLeafItem& X) { return std::get<4>(X); }
 inline AABB& TLASGetOBB(TLASLeafItem& X) { return std::get<5>(X); }
-inline bool& TLASGetCoalescedFlag(TLASLeafItem& X) { return std::get<6>(X); }
 
 struct InnerNode
 {

--- a/impl11/ddraw/LBVH.h
+++ b/impl11/ddraw/LBVH.h
@@ -209,8 +209,8 @@ public:
 using MortonCode_t = uint32_t;
 // 0: Morton Code, 1: Bounding Box, 2: TriID
 using LeafItem = std::tuple<MortonCode_t, AABB, int>;
-// 0: Morton Code, 1: aabbFromOBB, 2: FaceGroupID, 3: Centroid, 4: MatrixSlot, 5: Oriented Bounding Box
-using TLASLeafItem = std::tuple<MortonCode_t, AABB, int, XwaVector3, int, AABB>;
+// 0: Morton Code, 1: aabbFromOBB, 2: ID, 3: Centroid, 4: MatrixSlot, 5: Oriented Bounding Box, 6: Coalesced Mesh
+using TLASLeafItem = std::tuple<MortonCode_t, AABB, int, XwaVector3, int, AABB, bool>;
 
 inline MortonCode_t &GetMortonCode(LeafItem& X) { return std::get<0>(X); }
 inline MortonCode_t &GetMortonCode(TLASLeafItem& X) { return std::get<0>(X); }
@@ -227,6 +227,7 @@ inline int& TLASGetID(TLASLeafItem& X) { return std::get<2>(X); }
 inline XwaVector3& TLASGetCentroid(TLASLeafItem& X) { return std::get<3>(X); }
 inline int& TLASGetMatrixSlot(TLASLeafItem& X) { return std::get<4>(X); }
 inline AABB& TLASGetOBB(TLASLeafItem& X) { return std::get<5>(X); }
+inline bool& TLASGetCoalescedFlag(TLASLeafItem& X) { return std::get<6>(X); }
 
 struct InnerNode
 {

--- a/impl11/ddraw/LBVH.h
+++ b/impl11/ddraw/LBVH.h
@@ -209,7 +209,7 @@ public:
 using MortonCode_t = uint32_t;
 // 0: Morton Code, 1: Bounding Box, 2: TriID
 using LeafItem = std::tuple<MortonCode_t, AABB, int>;
-// 0: Morton Code, 1: aabbFromOBB, 2: ID, 3: Centroid, 4: MatrixSlot, 5: Oriented Bounding Box
+// 0: Morton Code, 1: aabbFromOBB, 2: BlasID, 3: Centroid, 4: MatrixSlot, 5: Oriented Bounding Box
 using TLASLeafItem = std::tuple<MortonCode_t, AABB, int, XwaVector3, int, AABB>;
 
 inline MortonCode_t &GetMortonCode(LeafItem& X) { return std::get<0>(X); }

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -6932,7 +6932,7 @@ void PrimarySurface::TagXWALights()
 	// Don't tag anything in external view (I don't know if y_center needs to be used)
 	if (bExternal)
 		return;
-#define RT_SIDE_LIGHTS
+#undef RT_SIDE_LIGHTS
 #ifdef RT_SIDE_LIGHTS
 	return;
 #endif

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -6931,12 +6931,10 @@ void PrimarySurface::TagXWALights()
 	float x0, y0, x1, y1;
 	bool bExternal = PlayerDataTable[*g_playerIndex].Camera.ExternalCamera;
 	// Don't bother tagging lights if we're parked in the hangar.
-	if (*g_playerInHangar)
-		return;
 	// Don't tag anything in external view if the y_center hasn't been fixed
 	// A few lines below, we use projectMetric() and that uses y_center.
-	//if (bExternal && !g_bYCenterHasBeenFixed)
-	if (bExternal)
+	if (*g_playerInHangar || (bExternal && !g_bYCenterHasBeenFixed))
+	//if (bExternal)
 		return;
 #undef RT_SIDE_LIGHTS
 #ifdef RT_SIDE_LIGHTS

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -8812,6 +8812,8 @@ HRESULT PrimarySurface::Flip(
 
 						g_bDumpSSAOBuffers = false;
 					}
+					if (g_bDumpOptNodes)
+						g_bDumpOptNodes = false;
 
 					if (g_iDelayedDumpDebugBuffers) {
 						g_iDelayedDumpDebugBuffers--;
@@ -9754,6 +9756,8 @@ HRESULT PrimarySurface::Flip(
 				//*g_playerInHangar = 0;
 				if (g_bDumpSSAOBuffers)
 					g_bDumpSSAOBuffers = false;
+				if (g_bDumpOptNodes)
+					g_bDumpOptNodes = false;
 
 				// Reset the laser pointer intersection
 				if (g_bActiveCockpitEnabled) {

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -6933,8 +6933,8 @@ void PrimarySurface::TagXWALights()
 	// Don't bother tagging lights if we're parked in the hangar.
 	// Don't tag anything in external view if the y_center hasn't been fixed
 	// A few lines below, we use projectMetric() and that uses y_center.
-	if (*g_playerInHangar || (bExternal && !g_bYCenterHasBeenFixed))
-	//if (bExternal)
+	//if (*g_playerInHangar || (bExternal && !g_bYCenterHasBeenFixed))
+	if (*g_playerInHangar || bExternal)
 		return;
 #undef RT_SIDE_LIGHTS
 #ifdef RT_SIDE_LIGHTS

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -40,6 +40,7 @@ bool rayTriangleIntersect(
 	const Vector3 &orig, const Vector3 &dir,
 	const Vector3 &v0, const Vector3 &v1, const Vector3 &v2,
 	float &t, Vector3 &P, float &u, float &v);
+void ResetXWALightInfo();
 
 void SetPresentCounter(int val, int bResetReticle) {
 	g_iPresentCounter = val;
@@ -6929,8 +6930,13 @@ void PrimarySurface::TagXWALights()
 	// Get the screen limits, we'll need them to tell when a light is visible on the screen
 	float x0, y0, x1, y1;
 	bool bExternal = PlayerDataTable[*g_playerIndex].Camera.ExternalCamera;
-	// Don't tag anything in external view (I don't know if y_center needs to be used)
-	if (bExternal)
+	// Don't bother tagging lights if we're parked in the hangar.
+	if (*g_playerInHangar)
+		return;
+	// Don't tag anything in external view if the y_center hasn't been fixed
+	// A few lines below, we use projectMetric() and that uses y_center.
+	if (bExternal && !g_bYCenterHasBeenFixed)
+	//if (bExternal)
 		return;
 #undef RT_SIDE_LIGHTS
 #ifdef RT_SIDE_LIGHTS
@@ -9717,6 +9723,7 @@ HRESULT PrimarySurface::Flip(
 				// Reset the frame counter if we just exited the hangar
 				if (!(*g_playerInHangar) && g_bPrevPlayerInHangar) {
 					SetPresentCounter(0, 0);
+					ResetXWALightInfo();
 					log_debug("[DBG] EXITED HANGAR");
 				}
 				g_bPrevPlayerInHangar = *g_playerInHangar;

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -6917,6 +6917,10 @@ void IncreaseSMZFactor(float Delta) {
 }
 
 /*
+ * WE CANNOT DELETE THIS FUNCTION YET.
+ * Tagging using the FlightGroup info does not work during film playback, so we need
+ * to use this version for that case.
+ *
  * For each Sun Centroid stored in the previous frame, check if they match any of
  * XWA's lights. If there's a match, we have found the global sun and we can stop
  * computing shadows from the other lights.
@@ -6924,7 +6928,7 @@ void IncreaseSMZFactor(float Delta) {
  * then we know that this light doesn't correspond to a sun, so we can stop computing
  * shadows for that light.
  */
-void PrimarySurface::TagXWALights()
+void PrimarySurface::OldTagXWALights()
 {
 	int NumTagged = 0;
 	// Get the screen limits, we'll need them to tell when a light is visible on the screen
@@ -7058,6 +7062,134 @@ void PrimarySurface::TagXWALights()
 }
 
 /*
+ * Tag the lights by looking at the Flight Groups and checking the GroupId-ImageId.
+ */
+void PrimarySurface::TagXWALights()
+{
+	int numSuns = 0;
+	const int numLights = *s_XwaGlobalLightsCount;
+	const int curRegion = PlayerDataTable[*g_playerIndex].currentRegion;
+
+	constexpr int MAX_FLIGHT_GROUPS = 192;
+	constexpr int MAX_PLANET_IDS    = 104;
+	constexpr int MAX_MODEL_IDX     = 557;
+	constexpr int CraftId_183_9001_1100_ResData_Backdrop = 183;
+	const XwaMission* mission = *(XwaMission**)0x09EB8E0;
+
+	log_debug("[DBG] ------------------------------");
+	log_debug("[DBG] Tagging Lights");
+
+	// Clear all previous tags so that we can start from scratch.
+	for (int i = 0; i < numLights; i++)
+	{
+		g_XWALightInfo[i].bIsSun = false;
+		g_XWALightInfo[i].bTagged = false;
+	}
+
+	for (int FGIdx = 0; FGIdx < MAX_FLIGHT_GROUPS; FGIdx++)
+	{
+		if (g_ShadowMapping.bAllLightsTagged)
+			break;
+
+		const int CraftId  = mission->FlightGroups[FGIdx].CraftId;
+		const int PlanetId = mission->FlightGroups[FGIdx].PlanetId;
+
+		if (CraftId == CraftId_183_9001_1100_ResData_Backdrop && PlanetId < MAX_PLANET_IDS)
+		{
+			const short SX   = mission->FlightGroups[FGIdx].StartPoints->X;
+			const short SY   = mission->FlightGroups[FGIdx].StartPoints->Y;
+			const short SZ   = mission->FlightGroups[FGIdx].StartPoints->Z;
+			const int region = mission->FlightGroups[FGIdx].StartPointRegions[0];
+
+			const int ModelIndex = g_XwaPlanets[PlanetId].ModelIndex;
+			if (region == curRegion && ModelIndex < MAX_MODEL_IDX)
+			{
+				const int GroupId = g_ExeObjectsTable[ModelIndex].DataIndex1;
+				const int ImageId = g_ExeObjectsTable[ModelIndex].DataIndex2;
+
+				Vector3 S = Vector3((float)SX, (float)-SY, (float)SZ);
+				S = S.normalize();
+
+				// We only care about the GroupIds that correspond to suns.
+				if (9001 <= GroupId && GroupId <= 9010)
+				{
+					log_debug("[DBG] [%s], CraftId: %d, PlanetId: %d, S:[%0.3f, %0.3f, %0.3f]",
+						mission->FlightGroups[FGIdx].Name, CraftId, PlanetId, S.x, S.y, S.z);
+					log_debug("[DBG]     region: %d, curRegion: %d, Group-Id: %d-%d",
+						region, curRegion, GroupId, ImageId);
+
+					// Now check the lights in this region to find a match
+					for (int LightIdx = 0; LightIdx < numLights; LightIdx++)
+					{
+						if (!g_XWALightInfo[LightIdx].bTagged)
+						{
+							Vector3 L = Vector3(
+								s_XwaGlobalLights[LightIdx].PositionX / 32768.0f,
+								s_XwaGlobalLights[LightIdx].PositionY / 32768.0f,
+								s_XwaGlobalLights[LightIdx].PositionZ / 32768.0f);
+							L = L.normalize();
+							float dot = L.dot(S);
+
+							log_debug("[DBG] light: %d: [%0.3f, %0.3f, %0.3f], dot: %0.3f, %s",
+								LightIdx, L.x, L.y, L.z, dot, (dot > 0.975f) ? "SUN" : "");
+							if (dot > 0.975f)
+							{
+								// There may be missions with multiple suns, so, let's tag this one as a sun
+								// but let's keep tagging.
+								g_XWALightInfo[LightIdx].bIsSun = true;
+								g_XWALightInfo[LightIdx].bTagged = true;
+								numSuns++;
+							}
+						}
+					}
+
+				}
+			}
+		}
+	}
+
+	// Finish tagging all the other lights
+	for (int i = 0; i < numLights; i++)
+	{
+		g_XWALightInfo[i].bTagged = true;
+	}
+	g_ShadowMapping.bAllLightsTagged = true;
+
+	// Disable multiple suns if necessary
+	if (!g_ShadowMapping.bMultipleSuns && numSuns > 1)
+	{
+		for (int i = numLights - 1; i >= 0; i--)
+		{
+			if (g_XWALightInfo[i].bIsSun)
+			{
+				g_XWALightInfo[i].bIsSun = false;
+				numSuns--;
+				if (numSuns == 1)
+					break;
+			}
+		}
+	}
+
+	// Check how many suns we have left after all the tagging and leave at least one
+	numSuns = 0;
+	for (int i = 0; i < numLights; i++)
+	{
+		if (g_XWALightInfo[i].bIsSun)
+		{
+			log_debug("[DBG] Light: %d is a SUN", i);
+			numSuns++;
+		}
+	}
+
+	if (numSuns == 0)
+	{
+		log_debug("[DBG] WARNING: No suns after tagging! Enabling first light");
+		g_XWALightInfo[0].bIsSun = true;
+	}
+	log_debug("[DBG] ------------------------------");
+}
+
+/*
  * Calls TagXWALights and then fades the lights if necessary.
  */
 void PrimarySurface::TagAndFadeXWALights()
@@ -7073,7 +7205,15 @@ void PrimarySurface::TagAndFadeXWALights()
 	// the right places and the FOV hasn't been computed, so let's wait until the FOV has been computed
 	// to tag anything and we've finished rendering a few frames
 	if (g_bCustomFOVApplied && !g_ShadowMapping.bAllLightsTagged && g_iPresentCounter > 5)
-		TagXWALights();
+	{
+		if (!(*viewingFilmState))
+			TagXWALights();
+		else
+		{
+			// When viewinig a film, the lights are apparently not in the right position (!)
+			OldTagXWALights();
+		}
+	}
 
 	// Display debug information on g_XWALightInfo (are the lights tagged, are they suns?)
 	if (g_bDumpSSAOBuffers) {
@@ -7085,16 +7225,20 @@ void PrimarySurface::TagAndFadeXWALights()
 		}
 	}
 
-	// Fade all non-sun lights
+	// Turn lights on or off
 	for (int j = 0; j < *s_XwaGlobalLightsCount; j++) 
 	{
+		// Instantaneous:
+		//g_ShadowMapVSCBuffer.sm_black_levels[j] = g_XWALightInfo[j].bIsSun ? g_ShadowMapping.black_level : 1.0f;
+
+		// Soft transition:
 		if (g_ShadowMapVSCBuffer.sm_black_levels[j] >= 0.95f)
 			continue;
 
 		// If this light has been tagged and isn't a sun, then fade it!
 		if (g_XWALightInfo[j].bTagged && !g_XWALightInfo[j].bIsSun) {
 			//g_XWALightInfo[j].fadeout += 0.01f;
-			g_ShadowMapVSCBuffer.sm_black_levels[j] += 0.01f;
+			g_ShadowMapVSCBuffer.sm_black_levels[j] += 0.02f;
 			if (g_ShadowMapVSCBuffer.sm_black_levels[j] > 0.95f)
 				log_debug("[DBG] [SHW] Light %d FADED", j);
 		}

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -6932,6 +6932,7 @@ void PrimarySurface::TagXWALights()
 	// Don't tag anything in external view (I don't know if y_center needs to be used)
 	if (bExternal)
 		return;
+#define RT_SIDE_LIGHTS
 #ifdef RT_SIDE_LIGHTS
 	return;
 #endif

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -6935,8 +6935,8 @@ void PrimarySurface::TagXWALights()
 		return;
 	// Don't tag anything in external view if the y_center hasn't been fixed
 	// A few lines below, we use projectMetric() and that uses y_center.
-	if (bExternal && !g_bYCenterHasBeenFixed)
-	//if (bExternal)
+	//if (bExternal && !g_bYCenterHasBeenFixed)
+	if (bExternal)
 		return;
 #undef RT_SIDE_LIGHTS
 #ifdef RT_SIDE_LIGHTS

--- a/impl11/ddraw/PrimarySurface.h
+++ b/impl11/ddraw/PrimarySurface.h
@@ -142,6 +142,8 @@ public:
 
 	//Matrix4 GetShadowMapLimits(Matrix4 L, float *OBJrange, float *OBJminZ);
 
+	void OldTagXWALights();
+
 	void TagXWALights();
 
 	void TagAndFadeXWALights();

--- a/impl11/ddraw/VRConfig.cpp
+++ b/impl11/ddraw/VRConfig.cpp
@@ -311,6 +311,12 @@ float g_fLevelsBlackPoint = 16.0f;
 
 #include "D3dRenderer.h"
 
+void SetHDRState(bool state)
+{
+	g_bHDREnabled = state;
+	g_ShadingSys_PSBuffer.HDREnabled = g_bHDREnabled;
+}
+
 /* Loads the VR parameters from vrparams.cfg */
 void LoadVRParams() {
 	log_debug("[DBG] Loading view params...");
@@ -2033,6 +2039,9 @@ bool LoadSSAOParams() {
 			}
 			if (_stricmp(param, "raytracing_enabled") == 0) {
 				g_bRTEnabled = (bool)fValue;
+				// Force the Deferred Rendering mode and enable HDR if RT is enabled.
+				if (g_bRTEnabled) g_SSAO_Type = SSO_DEFERRED;
+				SetHDRState(g_bRTEnabled);
 			}
 			if (_stricmp(param, "raytracing_enabled_in_cockpit") == 0) {
 				g_bRTEnabledInCockpit = (bool)fValue;
@@ -2341,8 +2350,7 @@ bool LoadSSAOParams() {
 				g_bDumpOBJEnabled = (bool)fValue;
 			}
 			else if (_stricmp(param, "HDR_enabled") == 0) {
-				g_bHDREnabled = (bool)fValue;
-				g_ShadingSys_PSBuffer.HDREnabled = g_bHDREnabled;
+				SetHDRState((bool)fValue);
 			}
 			else if (_stricmp(param, "HDR_lights_intensity") == 0) {
 				g_fHDRLightsMultiplier = fValue;

--- a/impl11/ddraw/VRConfig.cpp
+++ b/impl11/ddraw/VRConfig.cpp
@@ -198,6 +198,9 @@ int g_iBloomPasses[MAX_BLOOM_PASSES + 1] = {
 
 //extern FILE *colorFile, *lightFile;
 
+// Debugging (personal): I'm tired of the mouse moving outside the window!
+bool g_bKeepMouseInsideWindow = false;
+
 // SSAO
 float g_fMoireOffsetDir = 0.02f, g_fMoireOffsetInd = 0.1f;
 SSAOTypeEnum g_SSAO_Type = SSO_AMBIENT;
@@ -2045,6 +2048,10 @@ bool LoadSSAOParams() {
 			}
 			if (_stricmp(param, "raytracing_enabled_in_cockpit") == 0) {
 				g_bRTEnabledInCockpit = (bool)fValue;
+			}
+
+			if (_stricmp(param, "keep_mouse_inside_window") == 0) {
+				g_bKeepMouseInsideWindow = (bool)fValue;
 			}
 
 			if (_stricmp(param, "disable_xwa_diffuse") == 0) {

--- a/impl11/ddraw/XwaD3dRendererHook.cpp
+++ b/impl11/ddraw/XwaD3dRendererHook.cpp
@@ -1309,19 +1309,19 @@ void D3dRenderer::RenderGlowMarks()
 	_glowMarksTriangles.clear();
 }
 
-// Clears g_LBVHMap
+// Clears g_LBVHMap and g_BLASMap
 void ClearGlobalLBVHMap()
 {
-	// The following code is for the Tech Room:
+	// The following code is for the Tech Room/Cockpit/Coalesced BVHs:
 	// Release any BLASes that may be stored in the BVH map
 	for (auto& it : g_LBVHMap)
 	{
 		MeshData& meshData = it.second;
-		LBVH* bvh = (LBVH*)std::get<2>(meshData);
+		LBVH* bvh = (LBVH*)GetLBVH(meshData);
 		if (bvh != nullptr) {
 			delete bvh;
 		}
-		std::get<2>(meshData) = nullptr;
+		GetLBVH(meshData) = nullptr;
 	}
 	g_LBVHMap.clear();
 
@@ -1330,11 +1330,11 @@ void ClearGlobalLBVHMap()
 	for (auto& it : g_BLASMap)
 	{
 		BLASData& blasData = it.second;
-		LBVH* bvh = (LBVH*)std::get<3>(blasData);
+		LBVH* bvh = (LBVH*)BLASGetBVH(blasData);
 		if (bvh != nullptr) {
 			delete bvh;
 		}
-		std::get<3>(blasData) = nullptr;
+		BLASGetBVH(blasData) = nullptr;
 	}
 	g_BLASMap.clear();
 

--- a/impl11/ddraw/XwaD3dRendererHook.cpp
+++ b/impl11/ddraw/XwaD3dRendererHook.cpp
@@ -194,10 +194,11 @@ RendererType g_rendererType = RendererType_Unknown;
 bool g_bDumpOptNodes = false;
 char g_curOPTLoaded[MAX_OPT_NAME];
 std::map<int, int> g_OptHeaderMap;
-std::map<int, int> g_FGToSetMap;
+std::map<int, int> g_FGToLODMap;
 
 int DumpTriangle(const std::string& name, FILE* file, int OBJindex, const XwaVector3& v0, const XwaVector3& v1, const XwaVector3& v2);
 int32_t MakeMeshKey(const SceneCompData* scene);
+void RTResetBlasIDs();
 void ComputeTreeStats(IGenericTreeNode* root);
 
 XwaVector3 cross(const XwaVector3 &v0, const XwaVector3 &v1)
@@ -1343,6 +1344,9 @@ void ClearGlobalLBVHMap()
 	}
 	g_BLASMap.clear();
 
+	g_BLASIdMap.clear();
+	RTResetBlasIDs();
+
 #undef DEBUG_RT
 #ifdef DEBUG_RT
 	g_DebugMeshToNameMap.clear();
@@ -1864,7 +1868,7 @@ void ParseOptNode(OptNode* node, std::string prefix)
 
 void ClearFaceGroupMap()
 {
-	g_FGToSetMap.clear();
+	g_FGToLODMap.clear();
 }
 
 void ParseOptFaceGrouping(OptNode* outerNode)
@@ -1900,7 +1904,7 @@ void ParseOptFaceGrouping(OptNode* outerNode)
 					// This is not an error, the actual pointer to the scene->FaceIndices starts
 					// 4 bytes after Parameter2
 					int faceGroupID = subnode->Parameter2 + 4;
-					g_FGToSetMap[faceGroupID] = lodID;
+					g_FGToLODMap[faceGroupID] = lodID;
 #if VERBOSE_OPT_OUTPUT
 					if (g_bDumpOptNodes)
 					{

--- a/impl11/ddraw/XwaD3dRendererHook.cpp
+++ b/impl11/ddraw/XwaD3dRendererHook.cpp
@@ -1312,6 +1312,7 @@ void D3dRenderer::RenderGlowMarks()
 // Clears g_LBVHMap
 void ClearGlobalLBVHMap()
 {
+	// The following code is for the Tech Room:
 	// Release any BLASes that may be stored in the BVH map
 	for (auto& it : g_LBVHMap)
 	{
@@ -1322,8 +1323,21 @@ void ClearGlobalLBVHMap()
 		}
 		std::get<2>(meshData) = nullptr;
 	}
-
 	g_LBVHMap.clear();
+
+	// The following code is for regular flight:
+	// Release any BLASes that may be stored in the BLAS map
+	for (auto& it : g_BLASMap)
+	{
+		BLASData& blasData = it.second;
+		LBVH* bvh = (LBVH*)std::get<3>(blasData);
+		if (bvh != nullptr) {
+			delete bvh;
+		}
+		std::get<3>(blasData) = nullptr;
+	}
+	g_BLASMap.clear();
+
 #ifdef DEBUG_RT
 	g_DebugMeshToNameMap.clear();
 #endif

--- a/impl11/ddraw/dllmain.cpp
+++ b/impl11/ddraw/dllmain.cpp
@@ -808,6 +808,12 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 			//	return 0;
 			//}
 
+			case 'E': {
+				g_bRTCoalesceEverything = !g_bRTCoalesceEverything;
+				log_debug("[DBG] [BVH] g_bRTCoalesceEverything: %d", g_bRTCoalesceEverything);
+				return 0;
+			}
+
 			case 'F': {
 				CycleFOVSetting();
 				return 0;

--- a/impl11/ddraw/dllmain.cpp
+++ b/impl11/ddraw/dllmain.cpp
@@ -511,7 +511,7 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 			// Ctrl + Alt + Key
 			// Toggle Debug buffers
 			case 'D':
-				g_bDumpOptNodes = !g_bDumpOptNodes;
+				g_bDumpOptNodes = true;
 
 				//g_bFadeLights = !g_bFadeLights;
 				//log_debug("[DBG] g_bFadeLights: %d", g_bFadeLights);

--- a/impl11/ddraw/dllmain.cpp
+++ b/impl11/ddraw/dllmain.cpp
@@ -809,12 +809,6 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 			//	return 0;
 			//}
 
-			case 'E': {
-				g_bRTCoalesceEverything = !g_bRTCoalesceEverything;
-				log_debug("[DBG] [BVH] g_bRTCoalesceEverything: %d", g_bRTCoalesceEverything);
-				return 0;
-			}
-
 			case 'F': {
 				CycleFOVSetting();
 				return 0;

--- a/impl11/ddraw/dllmain.cpp
+++ b/impl11/ddraw/dllmain.cpp
@@ -44,6 +44,7 @@ extern bool g_bTriggerReticleCapture;
 extern bool g_bEnableAnimations;
 extern bool g_bFadeLights;
 extern bool g_bEnableQBVHwSAH;
+extern bool g_bDumpOptNodes;
 
 void Normalize(float4 *Vector) {
 	float x = Vector->x;
@@ -528,7 +529,10 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 				return 0;
 			// Dump Debug buffers
 			case 'X':
-				g_bDumpSSAOBuffers = true;
+				if (!g_bInTechRoom)
+					g_bDumpSSAOBuffers = true;
+				else
+					g_bDumpOptNodes = true;
 				return 0;
 			//case 'G':
 			//	DumpGlobalLights();
@@ -768,6 +772,7 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 				//g_config.EnableSoftHangarShadows = !g_config.EnableSoftHangarShadows;
 				//log_debug("[DBG] EnableSoftHangarShadows: %d", g_config.EnableSoftHangarShadows);
 
+#undef DEBUG_RT
 #ifdef DEBUG_RT
 				if (g_bInTechRoom) {
 					g_bEnableQBVHwSAH = !g_bEnableQBVHwSAH;

--- a/impl11/ddraw/dllmain.cpp
+++ b/impl11/ddraw/dllmain.cpp
@@ -44,7 +44,6 @@ extern bool g_bTriggerReticleCapture;
 extern bool g_bEnableAnimations;
 extern bool g_bFadeLights;
 extern bool g_bEnableQBVHwSAH;
-extern bool g_bDumpOptNodes;
 
 void Normalize(float4 *Vector) {
 	float x = Vector->x;
@@ -512,8 +511,11 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 			// Ctrl + Alt + Key
 			// Toggle Debug buffers
 			case 'D':
-				g_bFadeLights = !g_bFadeLights;
-				log_debug("[DBG] g_bFadeLights: %d", g_bFadeLights);
+				g_bDumpOptNodes = !g_bDumpOptNodes;
+
+				//g_bFadeLights = !g_bFadeLights;
+				//log_debug("[DBG] g_bFadeLights: %d", g_bFadeLights);
+
 				//g_bDisplayGlowMarks = !g_bDisplayGlowMarks;
 				//log_debug("[DBG] g_bDisplayGlowMarks: %d", g_bDisplayGlowMarks);
 				//g_bShowSSAODebug = !g_bShowSSAODebug;
@@ -529,10 +531,7 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 				return 0;
 			// Dump Debug buffers
 			case 'X':
-				if (!g_bInTechRoom)
-					g_bDumpSSAOBuffers = true;
-				else
-					g_bDumpOptNodes = true;
+				g_bDumpSSAOBuffers = true;
 				return 0;
 			//case 'G':
 			//	DumpGlobalLights();

--- a/impl11/ddraw/dllmain.cpp
+++ b/impl11/ddraw/dllmain.cpp
@@ -99,6 +99,7 @@ void IncreaseLensK2(float Delta);
 
 // CSM
 void ToggleCSM();
+void SetHDRState(bool state);
 
 void IncreaseReticleScale(float delta) {
 	g_fReticleScale += delta;
@@ -777,6 +778,9 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 				g_bRTEnabled = !g_bRTEnabled;
 				log_debug("[DBG] [BVH] g_bRTEnabled: %d", g_bRTEnabled);
 				DisplayTimedMessage(3, 0, g_bRTEnabled ? "Raytracing Enabled" : "Raytracing Disabled");
+				SetHDRState(g_bRTEnabled);
+				// Force the Deferred rendering mode when RT is enabled
+				if (g_bRTEnabled) g_SSAO_Type = SSO_DEFERRED;
 
 				return 0;
 			}

--- a/impl11/ddraw/dllmain.cpp
+++ b/impl11/ddraw/dllmain.cpp
@@ -573,13 +573,6 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 					DisplayTimedMessage(3, 0, "Animations Disabled");
 				*/
 				return 0;
-			// Ctrl+Alt+C: Toggle Raytraced Cockpit Shadows
-			case 'C':
-				g_bRTEnabledInCockpit = !g_bRTEnabledInCockpit;
-				log_debug("[DBG] Raytraced Cockpit Shadows: %d", g_bRTEnabledInCockpit);
-				DisplayTimedMessage(3, 0, g_bRTEnabledInCockpit ?
-					"Raytraced Cockpit Shadows" : "Shadow Mapped Cockpit Shadows");
-				return 0;
 			// Ctrl+Alt+O
 			case 'O':
 				g_bAOEnabled = !g_bAOEnabled;
@@ -1026,7 +1019,13 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 					return 0;
 				}
 				*/
-
+			// Ctrl+Shift+R: Toggle Raytraced Cockpit Shadows
+			case 'R':
+				g_bRTEnabledInCockpit = !g_bRTEnabledInCockpit;
+				log_debug("[DBG] Raytraced Cockpit Shadows: %d", g_bRTEnabledInCockpit);
+				DisplayTimedMessage(3, 0, g_bRTEnabledInCockpit ?
+					"Raytraced Cockpit Shadows" : "Shadow Mapped Cockpit Shadows");
+				return 0;
 			case VK_UP:
 				IncreaseFloatingGUIParallax(0.05f);
 				return 0;

--- a/impl11/ddraw/dllmain.cpp
+++ b/impl11/ddraw/dllmain.cpp
@@ -198,7 +198,7 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 	bool AltKey   = (GetAsyncKeyState(VK_MENU)		& 0x8000) == 0x8000;
 	bool CtrlKey  = (GetAsyncKeyState(VK_CONTROL)	& 0x8000) == 0x8000;
 	bool ShiftKey = (GetAsyncKeyState(VK_SHIFT)		& 0x8000) == 0x8000;
-	bool UpKey	  = (GetAsyncKeyState(VK_UP)			& 0x8000) == 0x8000;
+	bool UpKey    = (GetAsyncKeyState(VK_UP)		& 0x8000) == 0x8000;
 	bool DownKey  = (GetAsyncKeyState(VK_DOWN)		& 0x8000) == 0x8000;
 	bool LeftKey  = (GetAsyncKeyState(VK_LEFT)		& 0x8000) == 0x8000;
 	bool RightKey = (GetAsyncKeyState(VK_RIGHT)		& 0x8000) == 0x8000;
@@ -893,6 +893,10 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 				case 2:
 					//IncreaseScreenScale(0.1f);
 					//SaveVRParams();
+
+					//IncreaseAspectRatio(0.05f);
+					IncreaseReticleScale(0.1f);
+					SaveVRParams();
 					break;
 				case 3:
 					g_LaserPointDebug.z += 0.1f;
@@ -928,6 +932,10 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 				case 2:
 					//IncreaseScreenScale(-0.1f);
 					//SaveVRParams();
+
+					//IncreaseAspectRatio(-0.05f);
+					IncreaseReticleScale(-0.1f);
+					SaveVRParams();
 					break;
 				case 3:
 					g_LaserPointDebug.z -= 0.1f;
@@ -959,9 +967,6 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 			case VK_LEFT:
 				switch (g_KeySet) {
 				case 2:
-					//IncreaseAspectRatio(-0.05f);
-					IncreaseReticleScale(-0.1f);
-					SaveVRParams();
 					break;
 				case 11:
 					g_contOriginWorldSpace.x -= 0.02f;
@@ -973,9 +978,6 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 			case VK_RIGHT:
 				switch (g_KeySet) {
 				case 2:
-					//IncreaseAspectRatio(0.05f);
-					IncreaseReticleScale(0.1f);
-					SaveVRParams();
 					break;
 				case 11:
 					g_contOriginWorldSpace.x += 0.02f;

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -14,7 +14,7 @@ extern bool g_bYCenterHasBeenFixed;
 
 extern bool g_bDisableBarrelEffect, g_bEnableVR, g_bResetHeadCenter, g_bBloomEnabled, g_bAOEnabled, g_bCustomFOVApplied;
 extern bool g_b3DVisionEnabled, g_b3DVisionForceFullScreen;
-extern bool g_bDumpSSAOBuffers, g_bEnableSSAOInShader, g_bEnableIndirectSSDO, g_bResetDC, g_bProceduralSuns, g_bEnableHeadLights;
+extern bool g_bEnableSSAOInShader, g_bEnableIndirectSSDO, g_bResetDC, g_bProceduralSuns, g_bEnableHeadLights;
 extern bool g_bShowSSAODebug, g_bShowNormBufDebug, g_bFNEnable, g_bGlobalSpecToggle, g_bToggleSkipDC, g_bFadeLights, g_bDisplayGlowMarks;
 extern Vector4 g_LightVector[2];
 extern float g_fSpecIntensity, g_fSpecBloomIntensity, g_fFocalDist, g_fFakeRoll, g_fMinLightIntensity, g_fGlowMarkZOfs;
@@ -264,6 +264,9 @@ extern bool g_bThrottleModulationEnabled;
 // Gimbal lock debug settings
 extern float g_fMouseRangeX, g_fMouseRangeY;
 extern float g_fMouseDecelRate_s;
+
+// OPT Debugging
+extern bool g_bDumpOptNodes;
 
 // *****************************************************
 // Global functions

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -231,7 +231,6 @@ extern bool g_bRTEnabledInTechRoom;
 extern bool g_bRTEnabled;
 extern bool g_bRTEnabledInCockpit;
 extern bool g_bEnablePBRShading;
-extern bool g_bRTCoalesceEverything;
 extern int g_iRTTotalBLASNodesInFrame, g_iRTMaxBLASNodesSoFar, g_iRTMaxTLASNodesSoFar;
 extern uint32_t g_iRTMaxMeshesSoFar;
 extern int g_iRTMatricesNextSlot;

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -231,6 +231,7 @@ extern bool g_bRTEnabledInTechRoom;
 extern bool g_bRTEnabled;
 extern bool g_bRTEnabledInCockpit;
 extern bool g_bEnablePBRShading;
+extern bool g_bRTCoalesceEverything;
 extern int g_iRTTotalBLASNodesInFrame, g_iRTMaxBLASNodesSoFar, g_iRTMaxTLASNodesSoFar;
 extern uint32_t g_iRTMaxMeshesSoFar;
 extern int g_iRTMatricesNextSlot;

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -236,7 +236,6 @@ extern uint32_t g_iRTMaxMeshesSoFar;
 extern int g_iRTMatricesNextSlot;
 extern bool g_bRTReAllocateBvhBuffer;
 extern bool g_bRTCaptureCameraAABB;
-#undef DEBUG_RT
 
 // Levels.fx
 extern bool g_bEnableLevelsShader;

--- a/impl11/ddraw/joystick.cpp
+++ b/impl11/ddraw/joystick.cpp
@@ -378,8 +378,8 @@ UINT WINAPI emulJoyGetPosEx(UINT joy, struct joyinfoex_tag *pji)
 
 	pji->dwXpos = 256; // This is the center position for this axis
 	pji->dwYpos = 256;
-	pji->dwZpos = 256;
-	pji->dwRpos = 256;
+	pji->dwZpos = 256; // Throttle
+	pji->dwRpos = 256; // Rudder (roll)
 
 	// Mouse input
 	{
@@ -467,14 +467,13 @@ UINT WINAPI emulJoyGetPosEx(UINT joy, struct joyinfoex_tag *pji)
 	log_debug("[DBG] dwXpos,dwRpos: %d, %d", pji->dwZpos, pji->dwRpos);
 	*/
 	
-	// dwZpos is the throttle
 	if (GetAsyncKeyState(VK_LEFT) & 0x8000) {
 		pji->dwXpos = static_cast<DWORD>(std::max(256 - 256 * g_config.KbdSensitivity, 0.0f));
 	}
 	if (GetAsyncKeyState(VK_RIGHT) & 0x8000) {
 		pji->dwXpos = static_cast<DWORD>(std::min(256 + 256 * g_config.KbdSensitivity, 512.0f));
 	}
-	
+
 	if (GetAsyncKeyState(VK_UP) & 0x8000) {
 		pji->dwYpos = static_cast<DWORD>(std::max(256 - 256 * g_config.KbdSensitivity, 0.0f));
 	}

--- a/impl11/ddraw/xwa_structures.h
+++ b/impl11/ddraw/xwa_structures.h
@@ -44,22 +44,54 @@ enum OptNodeEnum : unsigned int
 	OptNode_EngineGlow = 28,
 };
 
+struct TieFlightGroup
+{
+	/* 0x0000 */ char Name[20];
+	/* 0x006B */ unsigned char CraftId;
+	/* 0x0E12 */ int PlanetId;
+};
+
+struct TieFlightGroupEx
+{
+	/* 0x0000 */ TieFlightGroup FlightGroup;
+	/* 0x0E3E */ int PlayerIndex;
+};
+
+// V0x0080DC80
+//Array<TieFlightGroupEx, 192> s_XwaTieFlightGroups;
+extern TieFlightGroupEx* g_XwaTieFlightGroups;
+
+struct XwaPlanet
+{
+	/* 0x0000 */ unsigned short ModelIndex;
+	/* 0x0002 */ unsigned char BackdropFlags;
+};
+
+// V0x005B1140
+//Array<XwaPlanet, 104> s_XwaPlanets
+extern XwaPlanet* g_XwaPlanets;
+
 struct ExeEnableEntry
 {
-	unsigned char ExeEnableEntry_m00; // flags
-	unsigned char ExeEnableEntry_m01; // flags
-	unsigned char ObjectCategory;
-	unsigned char ShipCategory;
-	unsigned int ObjectSize;
-	void* pData1;
-	void* pData2;
-	unsigned short ExeEnableEntry_m10; // flags
-	unsigned short CraftIndex;
-	short DataIndex1;
-	short DataIndex2;
+	/* 0x0000 */ char EnableOptions;    // flags ExeEnable00Enum
+	/* 0x0001 */ char RessourceOptions; // flags ExeEnable01Enum
+	/* 0x0002 */ char ObjectCategory;   // ObjectCategoryEnum
+	/* 0x0003 */ char ShipCategory;     // ShipCategoryEnum
+	/* 0x0004 */ unsigned int ObjectSize;
+	/* 0x0008 */ void* pData1;
+	/* 0x000C */ void* pData2;
+	/* 0x0010 */ unsigned short GameOptions; // flags ExeEnable10Enum
+	/* 0x0012 */ short CraftIndex; // CraftIndexEnum
+	/* 0x0014 */ short DataIndex1;
+	/* 0x0016 */ short DataIndex2;
 };
 
 static_assert(sizeof(ExeEnableEntry) == 24, "size of ExeEnableEntry must be 24");
+
+// ExeObjectsTable:
+// V0x005FB240
+//Array<ExeObjectEntry, 557> s_ExeObjectsTable;
+extern ExeEnableEntry* g_ExeObjectsTable;
 
 // This is the same as ObjectEntry
 struct XwaObject

--- a/impl11/ddraw/xwa_structures.h
+++ b/impl11/ddraw/xwa_structures.h
@@ -44,22 +44,50 @@ enum OptNodeEnum : unsigned int
 	OptNode_EngineGlow = 28,
 };
 
-struct TieFlightGroup
+struct TieFlightGroupWaypoint
 {
-	/* 0x0000 */ char Name[20];
-	/* 0x006B */ unsigned char CraftId;
-	/* 0x0E12 */ int PlanetId;
+	short X;
+	short Y;
+	short Z;
+	short m06;
 };
 
-struct TieFlightGroupEx
+static_assert(sizeof(TieFlightGroupWaypoint) == 8, "size of TieFlightGroupWaypoint must be 8");
+
+struct TieFlightGroup
 {
-	/* 0x0000 */ TieFlightGroup FlightGroup;
-	/* 0x0E3E */ int PlayerIndex;
+	char Name[20];
+	char unk014[5];
+	unsigned char GlobalCargoIndex;
+	char unk01A[14];
+	char Cargo[20];
+	char SpecialCargo[20];
+	char unk050[27];
+	unsigned char CraftId;
+	unsigned char CraftsCount;
+	char unk06D[3];
+	unsigned char Iff;
+	unsigned char Team;
+	char unk072[6];
+	unsigned char GlobalGroupId;
+	char unk079[1];
+	unsigned char WavesCount;
+	char unk07B[47];
+	unsigned char ArrivalDelayMinutes;
+	unsigned char ArrivalDelaySeconds;
+	char unk0AC[3294];
+	TieFlightGroupWaypoint StartPoints[4];
+	char StartPointRegions[4];
+	char unkDAE[100];
+	int PlanetId;
+	char unkE16[40];
 };
+
+static_assert(sizeof(TieFlightGroup) == 3646, "size of TieFlightGroup must be 3646");
 
 // V0x0080DC80
 //Array<TieFlightGroupEx, 192> s_XwaTieFlightGroups;
-extern TieFlightGroupEx* g_XwaTieFlightGroups;
+extern TieFlightGroup* g_XwaTieFlightGroups;
 
 struct XwaPlanet
 {
@@ -91,7 +119,35 @@ static_assert(sizeof(ExeEnableEntry) == 24, "size of ExeEnableEntry must be 24")
 // ExeObjectsTable:
 // V0x005FB240
 //Array<ExeObjectEntry, 557> s_ExeObjectsTable;
-extern ExeEnableEntry* g_ExeObjectsTable;
+const extern ExeEnableEntry* g_ExeObjectsTable;
+
+struct TieHeader
+{
+	char unk0000[9128];
+	unsigned char TimeLimit;
+	char unk23A9[65];
+};
+
+static_assert(sizeof(TieHeader) == 9194, "size of TieHeader must be 9194");
+
+struct XwaMission
+{
+	TieFlightGroup FlightGroups[192];
+	char unkAAE80[18780];
+	TieHeader Header;
+	char unkB1BC6[562426];
+};
+
+static_assert(sizeof(XwaMission) == 1290432, "size of XwaMission must be 1290432");
+
+struct XwaPlayer
+{
+	char unk0000[16];
+	unsigned char Region;
+	char unk0011[3006];
+};
+
+static_assert(sizeof(XwaPlayer) == 3023, "size of XwaPlayer must be 3023");
 
 // This is the same as ObjectEntry
 struct XwaObject

--- a/impl11/shaders/PBRShading.h
+++ b/impl11/shaders/PBRShading.h
@@ -50,7 +50,7 @@ float3 ToneMapFilmic_Hejl2015(float3 hdr, float whitePt) {
 // L: is the light direction, from the current point (position) to the light
 // position: the current 3D position to be shaded
 float3 computePBRLighting(in float3 L, in float3 light_color, in float3 position, in float3 N, in float3 V,
-	in float3 albedo, in float roughness, in float3 F0)
+	in float3 albedo, in float roughness, in float3 F0, in float shadowFactor)
 {
 	float rough_sqr = roughness * roughness;
 	//float3 L = normalize(light.pos.xyz - position);
@@ -77,7 +77,7 @@ float3 computePBRLighting(in float3 L, in float3 light_color, in float3 position
 	float k = rough_sqr / 2.0;
 	vis = G1V(dotNL, k) * G1V(dotNV, k);
 
-	float3 specular = /*dotNL **/ D * F * vis;
+	float3 specular = /*dotNL **/ D * F * vis * shadowFactor;
 
 	//const float3 ambient = 0.01;
 	const float3 diffuse = (albedo * INV_PI);
@@ -130,7 +130,7 @@ float3 addPBR_RT_TechRoom(in float3 position, in float3 N, in float3 FlatN, in f
 		if (dotLFlatN <= 0) shadow = 0.0;
 
 		float3 col = computePBRLighting(L, light_color, position,
-			N, V, albedo, roughness, F0);
+			N, V, albedo, roughness, F0, shadow);
 		color += col;
 
 		// shadow += softshadow(position, normalize(lights[i].pos.xyz - position), 0.02, 2.5);
@@ -185,7 +185,7 @@ float3 addPBR(in float3 position, in float3 N, in float3 FlatN, in float3 V,
 		if (dotLFlatN <= 0) shadow = 0.0;
 
 		float3 col = computePBRLighting(L, light_color, position,
-			N, V, albedo, roughness, F0);
+			N, V, albedo, roughness, F0, shadowFactor);
 		color += col;
 
 		// shadow += softshadow(position, normalize(lights[i].pos.xyz - position), 0.02, 2.5);
@@ -234,7 +234,7 @@ float3 addPBR_RT_TLAS(in float3 position, in float3 N, in float3 FlatN, in float
 		if (dotLFlatN <= 0) shadow = 0.0;
 
 		float3 col = computePBRLighting(L, light_color, position,
-			N, V, albedo, roughness, F0);
+			N, V, albedo, roughness, F0, shadow);
 		color += col;
 
 		// shadow += softshadow(position, normalize(lights[i].pos.xyz - position), 0.02, 2.5);

--- a/impl11/shaders/PBRShading.h
+++ b/impl11/shaders/PBRShading.h
@@ -50,7 +50,8 @@ float3 ToneMapFilmic_Hejl2015(float3 hdr, float whitePt) {
 // L: is the light direction, from the current point (position) to the light
 // position: the current 3D position to be shaded
 float3 computePBRLighting(in float3 L, in float3 light_color, in float3 position, in float3 N, in float3 V,
-	in float3 albedo, in float roughness, in float3 F0, in float shadowFactor, in float lightIntensity)
+	in float3 albedo, in float roughness, in float3 F0, in float shadowFactor, in float lightIntensity,
+	out float3 specular_out)
 {
 	float rough_sqr = roughness * roughness;
 	//float3 L = normalize(light.pos.xyz - position);
@@ -77,13 +78,13 @@ float3 computePBRLighting(in float3 L, in float3 light_color, in float3 position
 	float k = rough_sqr / 2.0;
 	vis = G1V(dotNL, k) * G1V(dotNV, k);
 
-	float3 specular = /*dotNL **/ D * F * vis * shadowFactor * lightIntensity;
+	specular_out = /*dotNL **/ D * F * vis * shadowFactor * lightIntensity;
 
 	//const float3 ambient = 0.01;
 	const float3 diffuse = (albedo * INV_PI);
 
 	//return ambient + (diffuse + specular) * light_color.xyz * dotNL;
-	return (diffuse + specular) * light_color.xyz * dotNL;
+	return (diffuse + specular_out) * light_color.xyz * dotNL;
 }
 
 // Main entry point for PBR shading with Ray-tracing. This is used in
@@ -129,8 +130,9 @@ float3 addPBR_RT_TechRoom(in float3 position, in float3 N, in float3 FlatN, in f
 		}
 		if (dotLFlatN <= 0) shadow = 0.0;
 
+		float3 specular_out;
 		float3 col = computePBRLighting(L, light_color, position,
-			N, V, albedo, roughness, F0, shadow, lightColor.w);
+			N, V, albedo, roughness, F0, shadow, lightColor.w, specular_out);
 		color += col;
 
 		// shadow += softshadow(position, normalize(lights[i].pos.xyz - position), 0.02, 2.5);
@@ -156,7 +158,8 @@ float3 addPBR_RT_TechRoom(in float3 position, in float3 N, in float3 FlatN, in f
 float3 addPBR(in float3 position, in float3 N, in float3 FlatN, in float3 V,
 	in float3 baseColor, in float3 lightDir, in float4 lightColor,
 	in float metalMask, in float glossiness, in float reflectance,
-	in float ambient, float shadowFactor)
+	in float ambient, float shadowFactor,
+	out float3 specular_out)
 {
 	float3 color = 0.0;
 	float roughness = 1.0 - glossiness * glossiness;
@@ -188,7 +191,7 @@ float3 addPBR(in float3 position, in float3 N, in float3 FlatN, in float3 V,
 		L = normalize(L);
 
 		float3 col = computePBRLighting(L, light_color, position,
-			N, V, albedo, roughness, F0, shadowFactor, lightColor.w);
+			N, V, albedo, roughness, F0, shadowFactor, lightColor.w, specular_out);
 		color += col;
 
 		// shadow += softshadow(position, normalize(lights[i].pos.xyz - position), 0.02, 2.5);
@@ -236,8 +239,9 @@ float3 addPBR_RT_TLAS(in float3 position, in float3 N, in float3 FlatN, in float
 		}
 		if (dotLFlatN <= 0) shadow = 0.0;
 
+		float3 specular_out;
 		float3 col = computePBRLighting(L, light_color, position,
-			N, V, albedo, roughness, F0, shadow, lightColor.w);
+			N, V, albedo, roughness, F0, shadow, lightColor.w, specular_out);
 		color += col;
 
 		// shadow += softshadow(position, normalize(lights[i].pos.xyz - position), 0.02, 2.5);

--- a/impl11/shaders/RT/RTCommon.h
+++ b/impl11/shaders/RT/RTCommon.h
@@ -8,7 +8,7 @@
 // RTConstantsBuffer
 cbuffer ConstantBuffer : register(b10) {
 	bool bRTEnabled;
-	bool bRTEnabledInCockpit;
+	bool bRTAllowShadowMapping;
 	bool bEnablePBRShading;
 	uint g_RTUnused;
 	// 16 bytes

--- a/impl11/shaders/RT/RTCommon.h
+++ b/impl11/shaders/RT/RTCommon.h
@@ -430,7 +430,8 @@ Intersection _TLASTraceRaySimpleHit(Ray ray) {
 	return blank_inters;
 }
 
-// Trace a ray and return as soon as we hit geometry
+// Trace a ray and return as soon as we hit geometry.
+// The Intersection's ID isn't actually used to index anything -- it might as well be a bool.
 Intersection TLASTraceRaySimpleHit(Ray ray) {
 	float3 pos3D = ray.origin;
 	// ray.origin is in the pos3D frame (Metric, Y+ is up, Z+ is forward)

--- a/impl11/shaders/RT/RTCommon.h
+++ b/impl11/shaders/RT/RTCommon.h
@@ -10,7 +10,7 @@ cbuffer ConstantBuffer : register(b10) {
 	bool bRTEnabled;
 	bool bRTAllowShadowMapping;
 	bool bEnablePBRShading;
-	uint g_RTUnused;
+	bool RTUnused;
 	// 16 bytes
 };
 

--- a/impl11/shaders/SSDO/SSDOAdd.hlsl
+++ b/impl11/shaders/SSDO/SSDOAdd.hlsl
@@ -18,7 +18,7 @@
 #undef PBR_SHADING
 #undef PBR_DYN_LIGHTS
 
-#define RT_SIDE_LIGHTS
+#undef RT_SIDE_LIGHTS
 
 //#define PBR_SHADING
 //#define PBR_DYN_LIGHTS

--- a/impl11/shaders/SSDO/SSDOAdd.hlsl
+++ b/impl11/shaders/SSDO/SSDOAdd.hlsl
@@ -546,7 +546,7 @@ PixelShaderOutput main(PixelShaderInput input)
 				continue;
 
 			const float3 L = LightVector[i].xyz;
-			const float dotLFlatN = dot(L, N); // The "flat" normal is needed here (instead of the smooth one)
+			const float dotLFlatN = dot(L, N); // The "flat" normal is needed here (without Normal Mapping)
 			// "hover" prevents noise by displacing the origin of the ray away from the surface
 			// The displacement is directly proportional to the depth of the surface
 			// The position buffer's Z increases with depth
@@ -571,7 +571,7 @@ PixelShaderOutput main(PixelShaderInput input)
 	float total_shadow_factor = rt_shadow_factor;
 	//float idx = 1.0;
 	// Don't compute shadow mapping if Raytraced shadows are enabled in the cockpit... it's redundant.
-	if (sm_enabled && !bRTEnabledInCockpit)
+	if (sm_enabled && bRTAllowShadowMapping)
 	{
 		//float3 P_bias = P + sm_bias * N;
 		[loop]

--- a/impl11/shaders/SSDO/SSDOAdd.hlsl
+++ b/impl11/shaders/SSDO/SSDOAdd.hlsl
@@ -18,6 +18,8 @@
 #undef PBR_SHADING
 #undef PBR_DYN_LIGHTS
 
+#define RT_SIDE_LIGHTS
+
 //#define PBR_SHADING
 //#define PBR_DYN_LIGHTS
 

--- a/impl11/shaders/SSDO/SSDOAdd.hlsl
+++ b/impl11/shaders/SSDO/SSDOAdd.hlsl
@@ -866,11 +866,11 @@ PixelShaderOutput main(PixelShaderInput input)
 			// Branchless version of the block above:
 			const float spec_val = dot(0.333, specular_out);
 			float glass_interpolator = lerp(0, saturate(spec_val), bIsGlass);
-			float excess_energy = smoothstep(0.95, 2.0, spec_val); // approximate: saturate(spec_val - 1.0);
+			float excess_energy = smoothstep(0.95, 4.0, spec_val); // approximate: saturate(spec_val - 1.0);
 			tmp_color += lerp(col, specular_out, glass_interpolator);
 			// Add some bloom where appropriate:
 			// only-shadow-casters-emit-bloom * Glass-blooms-more-than-other-surfaces * excess-specular-energy
-			float spec_bloom = is_shadow_caster * lerp(0.5, 1.5, bIsGlass) * excess_energy;
+			float spec_bloom = is_shadow_caster * lerp(0.4, 1.25, bIsGlass) * excess_energy;
 			tmp_bloom += total_shadow_factor * spec_bloom;
 
 			//tmp_color += linear_to_srgb(ToneMapFilmic_Hejl2015(col * exposure, 1.0));


### PR DESCRIPTION
* The In-Flight Raytracer is now LOD aware. Meaning that it will correctly identify which Face Groups belong to different LODs even if they are in the same mesh. This fixes several artifacts that appeared when a lower LOD was casting shadows on a higher LOD.
* Light tagging is now done by examination of the Flight Groups. This means that lights can be tagged even in external views, but films don't quite behave very well, so I kept the old code.
* Fixes to the PBR shader to enable glass and bloom. Also, artifacts due to multiple light sources where only a subset is a shadow caster are now fixed.