### PR TITLE
Mission briefing and dark screen fixes

### DIFF
--- a/impl11/ddraw/Effects.cpp
+++ b/impl11/ddraw/Effects.cpp
@@ -196,6 +196,7 @@ int g_iDraw2DCounter = 0;
 bool g_bRendering3D = false; // Set to true when the system is about to render in 3D
 bool g_bPrevPlayerInHangar = false;
 bool g_bInTechRoom = false; // Set to true in PrimarySurface Present 2D (Flip)
+bool g_bInBriefingRoom = false;
 
 D3DTLVERTEX g_SpeedParticles2D[MAX_SPEED_PARTICLES * 12];
 
@@ -928,9 +929,24 @@ CraftInstance* GetPlayerCraftInstanceSafe(ObjectEntry** object, MobileObjectEntr
 // This code is courtesy of Jeremy.
 bool InTechGlobe()
 {
-	int currentGameState = *(int*)(0x09F60E0 + 0x25FA9);
-	int updateCallback = *(int*)(0x09F60E0 + 0x25FB1 + currentGameState * 0x850 + 0x0844);
-	int XwaTechLibraryGameStateUpdate = 0x00574D70;
-	g_bInTechRoom = (updateCallback == XwaTechLibraryGameStateUpdate);
+	const int currentGameState = *(int*)(0x09F60E0 + 0x25FA9);
+	const int updateCallback = *(int*)(0x09F60E0 + 0x25FB1 + currentGameState * 0x850 + 0x0844);
+	const int XwaTechLibraryGameStateUpdate = 0x00574D70;
+	const int XwaMissionBriefingGameStateUpdate = 0x00564E90;
+	//g_bInTechRoom = (updateCallback == XwaTechLibraryGameStateUpdate);
+	// For functional purposes, "Tech Room" has been used everywhere where 2D rendering is done,
+	// and that includes the briefing room too.
+	g_bInTechRoom = (updateCallback == XwaTechLibraryGameStateUpdate) ||
+		(updateCallback == XwaMissionBriefingGameStateUpdate);
 	return g_bInTechRoom;
+}
+
+// Also courtesy of Jeremy -- of course.
+bool InBriefingRoom()
+{
+	const int currentGameState = *(int*)(0x009F60E0 + 0x25FA9);
+	const int updateCallback = *(int*)(0x009F60E0 + 0x25FB1 + currentGameState * 0x850 + 0x0844);
+	const int XwaMissionBriefingGameStateUpdate = 0x00564E90;
+	g_bInBriefingRoom = (updateCallback == XwaMissionBriefingGameStateUpdate);
+	return g_bInBriefingRoom;
 }

--- a/impl11/ddraw/Effects.h
+++ b/impl11/ddraw/Effects.h
@@ -247,3 +247,4 @@ CraftInstance *GetPlayerCraftInstanceSafe(ObjectEntry** object);
 CraftInstance* GetPlayerCraftInstanceSafe(ObjectEntry** object, MobileObjectEntry** mobileObject);
 // Also updates g_bInTechGlobe when called.
 bool InTechGlobe();
+bool InBriefingRoom();

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -2134,18 +2134,21 @@ void EffectsRenderer::SceneEnd()
 
 	if (_BLASNeedsUpdate)
 	{
-		if (g_bRTEnabledInTechRoom && g_bInTechRoom)
+		if (g_bRTEnabled || g_bRTEnabledInTechRoom)
 		{
-			// Build a single BVH from the contents of g_LBVHMap and put it in _lbvh
-			BuildSingleBLASFromCurrentBVHMap();
-		}
-		else if (g_bRTEnabled && !(*g_playerInHangar))
-		{
-			// Build multiple BLASes and put them in g_LBVHMap
-			BuildMultipleBLASFromCurrentBLASMap();
-			// Encode the BLASes in g_LBVHMap into the SRVs and resize them if necessary
-			ReAllocateAndPopulateBvhBuffers(g_iRTTotalBLASNodesInFrame);
-			g_bRTReAllocateBvhBuffer = false;
+			if (InTechGlobe())
+			{
+				// Build a single BVH from the contents of g_LBVHMap and put it in _lbvh
+				BuildSingleBLASFromCurrentBVHMap();
+			}
+			else if (!(*g_playerInHangar))
+			{
+				// Build multiple BLASes and put them in g_LBVHMap
+				BuildMultipleBLASFromCurrentBLASMap();
+				// Encode the BLASes in g_LBVHMap into the SRVs and resize them if necessary
+				ReAllocateAndPopulateBvhBuffers(g_iRTTotalBLASNodesInFrame);
+				g_bRTReAllocateBvhBuffer = false;
+			}
 		}
 		_BLASNeedsUpdate = false;
 	}

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -2454,7 +2454,6 @@ void EffectsRenderer::DoStateManagement(const SceneCompData* scene)
 	g_bSkyBoxJustFinished = true;
 
 	_bIsTargetHighlighted = false;
-	bool bIsGUI = false, bIsLensFlare = false;
 	//bool bIsExterior = false, bIsDAT = false;
 	//bool bIsActiveCockpit = false,
 	//bool bIsDS2CoreExplosion = false;
@@ -2513,7 +2512,7 @@ void EffectsRenderer::DoStateManagement(const SceneCompData* scene)
 	g_bIsFloating3DObject = g_bTargetCompDrawn && _bLastTextureSelectedNotNULL &&
 		!_lastTextureSelected->is_Text && !_lastTextureSelected->is_TrianglePointer &&
 		!_lastTextureSelected->is_Reticle && !_lastTextureSelected->is_Floating_GUI &&
-		!_lastTextureSelected->is_TargetingComp && !bIsLensFlare;
+		!_lastTextureSelected->is_TargetingComp;
 
 	// The GUI starts rendering whenever we detect a GUI element, or Text, or a bracket.
 	// ... or not at all if we're in external view mode with nothing targeted.
@@ -2525,7 +2524,7 @@ void EffectsRenderer::DoStateManagement(const SceneCompData* scene)
 	//g_bStartedGUI |= bIsGUI || bIsText || bIsBracket || bIsFloatingGUI || bIsReticle;
 	// bIsScaleableGUIElem is true when we're about to render a HUD element that can be scaled down with Ctrl+Z
 	g_bPrevIsScaleableGUIElem = g_bIsScaleableGUIElem;
-	g_bIsScaleableGUIElem = g_bStartedGUI && !g_bIsTrianglePointer && !bIsLensFlare;
+	g_bIsScaleableGUIElem = g_bStartedGUI && !g_bIsTrianglePointer;
 }
 
 // Apply specific material properties for the current texture

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -7381,6 +7381,28 @@ void PrimarySurface::ProjectCentroidToPostProc(Vector3 Centroid, float *u, float
 	*u *= g_fCurScreenWidth / g_fCurScreenHeight;
 }
 
+// This is a crutch: I'm using this to temporarily fix the black screen bug that happens
+// in external view. But other stuff is still wrong (the illumination, for instance, disappears).
+void PrimarySurface::FixViewport()
+{
+	auto& resources = this->_deviceResources;
+	float x0, y0, x1, y1;
+	const bool bExternalView = PlayerDataTable[*g_playerIndex].Camera.ExternalCamera;
+	GetScreenLimitsInUVCoords(&x0, &y0, &x1, &y1);
+	g_ShadertoyBuffer.x0 = x0;
+	g_ShadertoyBuffer.y0 = y0;
+	g_ShadertoyBuffer.x1 = x1;
+	g_ShadertoyBuffer.y1 = y1;
+	g_ShadertoyBuffer.iTime = 0.0f;
+	g_ShadertoyBuffer.y_center = bExternalView ? 0.0f : g_fYCenter;
+	g_ShadertoyBuffer.VRmode = g_bEnableVR;
+	g_ShadertoyBuffer.iResolution[0] = g_fCurScreenWidth;
+	g_ShadertoyBuffer.iResolution[1] = g_fCurScreenHeight;
+	resources->InitPSConstantBufferHyperspace(resources->_hyperspaceConstantBuffer.GetAddressOf(), &g_ShadertoyBuffer);
+	// We need this to ensure backface culling is disabled
+	resources->InitRasterizerState(resources->_rasterizerState); // This line fixes the black screen bug -- not sure why, though
+}
+
 void PrimarySurface::RenderSunFlare()
 {
 	this->_deviceResources->_d3dAnnotation->BeginEvent(L"RenderSunFlare");
@@ -9512,6 +9534,35 @@ HRESULT PrimarySurface::Flip(
 				resources->InitDepthStencilState(depthState, &desc);
 
 				RenderSunFlare();
+			}
+			else
+			{
+				// We need to set the blend state properly for Bloom, or else we might get
+				// different results when brackets are rendered because they alter the 
+				// blend state
+				D3D11_BLEND_DESC blendDesc{};
+				blendDesc.AlphaToCoverageEnable = FALSE;
+				blendDesc.IndependentBlendEnable = FALSE;
+				blendDesc.RenderTarget[0].BlendEnable = TRUE;
+				blendDesc.RenderTarget[0].SrcBlend = D3D11_BLEND_SRC_ALPHA;
+				blendDesc.RenderTarget[0].DestBlend = D3D11_BLEND_INV_SRC_ALPHA;
+				blendDesc.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;
+				blendDesc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_SRC_ALPHA;
+				blendDesc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_INV_SRC_ALPHA;
+				blendDesc.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
+				blendDesc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
+				hr = resources->InitBlendState(nullptr, &blendDesc);
+
+				// Temporarily disable ZWrite: we won't need it for post-proc effects
+				D3D11_DEPTH_STENCIL_DESC desc;
+				ComPtr<ID3D11DepthStencilState> depthState;
+				desc.DepthEnable = FALSE;
+				desc.DepthWriteMask = D3D11_DEPTH_WRITE_MASK_ZERO;
+				desc.DepthFunc = D3D11_COMPARISON_ALWAYS;
+				desc.StencilEnable = FALSE;
+				resources->InitDepthStencilState(depthState, &desc);
+
+				FixViewport();
 			}
 
 			//if (g_bDumpSSAOBuffers) {

--- a/impl11/ddraw/PrimarySurface.h
+++ b/impl11/ddraw/PrimarySurface.h
@@ -155,6 +155,8 @@ public:
 
 	void ProjectCentroidToPostProc(Vector3 Centroid, float *u, float *v);
 
+	void FixViewport();
+
 	void RenderSunFlare();
 
 	void RenderLaserPointer(D3D11_VIEWPORT * lastViewport, ID3D11PixelShader * lastPixelShader, Direct3DTexture * lastTextureSelected, ID3D11Buffer * lastVertexBuffer, UINT * lastVertexBufStride, UINT * lastVertexBufOffset);

--- a/impl11/ddraw/VRConfig.cpp
+++ b/impl11/ddraw/VRConfig.cpp
@@ -2097,7 +2097,7 @@ bool LoadSSAOParams() {
 			}
 			if (_stricmp(param, "raytracing_enable_embree") == 0) {
 				g_bRTEnableEmbree = (bool)fValue;
-				g_BVHBuilderType = BVHBuilderType_Embree;
+				g_BVHBuilderType = g_bRTEnableEmbree ? BVHBuilderType_Embree : BVHBuilderType_FastQBVH;
 			}
 
 			if (_stricmp(param, "keep_mouse_inside_window") == 0) {

--- a/impl11/ddraw/XwaD3dRendererHook.cpp
+++ b/impl11/ddraw/XwaD3dRendererHook.cpp
@@ -868,7 +868,7 @@ void D3dRenderer::UpdateMeshBuffers(const SceneCompData* scene)
 
 			D3D11_BUFFER_DESC desc;
 			ZeroMemory(&desc, sizeof(desc));
-			int numMatrices = 1;
+			const int numMatrices = 1;
 			desc.ByteWidth = sizeof(Matrix4) * numMatrices;
 			desc.Usage = D3D11_USAGE_DYNAMIC; // CPU: Write, GPU: Read
 			desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;

--- a/impl11/ddraw/XwaD3dRendererHook.cpp
+++ b/impl11/ddraw/XwaD3dRendererHook.cpp
@@ -296,6 +296,7 @@ void D3dRenderer::SceneBegin(DeviceResources* deviceResources)
 	GetViewportScale(_constants.viewportScale);
 	// Update g_bInTechGlobe
 	InTechGlobe();
+	InBriefingRoom();
 
 #if LOGGER_DUMP
 	DumpFrame();

--- a/impl11/ddraw/commonVR.h
+++ b/impl11/ddraw/commonVR.h
@@ -27,6 +27,7 @@ extern float g_fVR_FOV;
 extern float g_fIPD;
 extern float g_fHalfIPD;
 extern bool g_bInTechRoom; // Set to true in PrimarySurface Present 2D (Flip)
+extern bool g_bInBriefingRoom;
 
 extern float g_fPitchMultiplier, g_fYawMultiplier, g_fRollMultiplier;
 extern float g_fYawOffset, g_fPitchOffset;

--- a/impl11/shaders/PBRShading.h
+++ b/impl11/shaders/PBRShading.h
@@ -87,8 +87,8 @@ float3 computePBRLighting(in float3 L, in float3 light_color, in float3 position
 	return (diffuse + specular_out) * light_color.xyz * dotNL;
 }
 
-// Main entry point for PBR shading with Ray-tracing. This is used in
-// the Tech Room (there's no TLAS and the single BLAS contains all the meshes)
+// Tech Room main entry point for PBR shading with Ray-tracing.
+// There's no TLAS and the single BLAS contains all the meshes.
 float3 addPBR_RT_TechRoom(in float3 position, in float3 N, in float3 FlatN, in float3 V,
 	in float3 baseColor, in float3 lightDir, in float4 lightColor,
 	in float metalMask, in float glossiness, in float reflectance, in float ambient)
@@ -117,7 +117,8 @@ float3 addPBR_RT_TechRoom(in float3 position, in float3 N, in float3 FlatN, in f
 		// Only do raytraced shadows for surfaces that face towards the light source.
 		// If the current surface faces away, we already know it's shadowed
 		const float dotLFlatN = dot(L, FlatN);
-		if (bDoRaytracing && dotLFlatN > 0) {
+		if (bDoRaytracing && dotLFlatN > 0)
+		{
 			Ray ray;
 			ray.origin = position; // position comes from pos3D. Metric, Y+ is up, Z+ is forward.
 			//ray.origin = position + 0.01f * FlatN; // position comes from pos3D. Metric, Y+ is up, Z+ is forward.


### PR DESCRIPTION
The 3D display should no longer crash when displaying 3D models and RT is on.

Also coded a quick temporary fix for the dark screen that happens in TFTC when the sun flare isn't visible (the whole screen goes dark). This isn't a great fix, but it gets the job done while I work on a more permanent fix.