### PR TITLE
Fix some project configuration for out-of-the-box compilation

### DIFF
--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -152,7 +152,7 @@
 #endif
 
 #include <WICTextureLoader.h>
-#include <headers/openvr.h>
+#include <openvr.h>
 #include <vector>
 #include "SteamVR.h"
 #include "globals.h"

--- a/impl11/ddraw/DirectSBS.cpp
+++ b/impl11/ddraw/DirectSBS.cpp
@@ -4,7 +4,7 @@
 #include "utils.h"
 #include "commonVR.h"
 #include "DirectSBS.h"
-#include <headers/openvr.h>
+#include <openvr.h>
 #include "FreePIE.h"
 #include "effects.h"
 

--- a/impl11/ddraw/SteamVR.cpp
+++ b/impl11/ddraw/SteamVR.cpp
@@ -5,7 +5,7 @@
 #include "commonVR.h"
 #include "SteamVR.h"
 #include "globals.h"
-#include <headers/openvr.h>
+#include <openvr.h>
 #include "FreePIE.h"
 #include "SharedMem.h"
 #include "XWAFramework.h"

--- a/impl11/ddraw/SteamVR.h
+++ b/impl11/ddraw/SteamVR.h
@@ -5,7 +5,7 @@
 #include "Vectors.h"
 #include "Matrices.h"
 #include "config.h"
-#include <headers/openvr.h>
+#include <openvr.h>
 
 constexpr float DEFAULT_STEAMVR_OVERLAY_WIDTH = 5.0f;
 

--- a/impl11/ddraw/commonVR.h
+++ b/impl11/ddraw/commonVR.h
@@ -2,7 +2,7 @@
 
 #include <Windows.h>
 #include <stdio.h>
-#include <headers/openvr.h>
+#include <openvr.h>
 #include "common.h"
 #include "utils.h"
 #include "config.h"

--- a/impl11/ddraw/ddraw.vcxproj
+++ b/impl11/ddraw/ddraw.vcxproj
@@ -33,11 +33,11 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="PropertySheetDebug.props" />
+    <Import Project="PropertySheetDebug.props" Condition="exists('PropertySheetDegut.props')" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="PropertySheetRelease.props" />
+    <Import Project="PropertySheetRelease.props" Condition="exists('PropertySheetRelease.props')"/>
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/impl11/ddraw/ddraw.vcxproj
+++ b/impl11/ddraw/ddraw.vcxproj
@@ -37,11 +37,12 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="PropertySheetRelease.props" Condition="exists('PropertySheetRelease.props')"/>
+    <Import Project="PropertySheetRelease.props" Condition="exists('PropertySheetRelease.props')" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
+    <IncludePath>$(SolutionDir)dependencies\embree\include;$(SolutionDir)dependencies\openvr\headers;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
@@ -66,7 +67,7 @@
       <ModuleDefinitionFile>ddraw.def</ModuleDefinitionFile>
       <UACUIAccess>true</UACUIAccess>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);DirectXTK.lib;Windowscodecs.lib;openvr_api.lib;winmm.lib</AdditionalDependencies>
-      <AdditionalLibraryDirectories>.\embree\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)dependencies\openvr\lib;$(SolutionDir)dependencies\embree\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent />
   </ItemDefinitionGroup>

--- a/impl11/ddraw/utils.cpp
+++ b/impl11/ddraw/utils.cpp
@@ -12,7 +12,7 @@
 #include <shellapi.h>
 
 // SteamVR
-#include <headers/openvr.h>
+#include <openvr.h>
 
 #pragma comment(lib, "Gdiplus")
 


### PR DESCRIPTION
With this, the project should build correctly after cloning, with no required dependencies or local changes to the files.