### PR TITLE
Unify include paths between Debug and Release in ddraw.vcxproj

### DIFF
--- a/impl11/ddraw/ddraw.vcxproj
+++ b/impl11/ddraw/ddraw.vcxproj
@@ -46,6 +46,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(SolutionDir)dependencies\embree\include;$(SolutionDir)dependencies\openvr\headers;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -89,7 +90,6 @@
       <UndefinePreprocessorDefinitions>
       </UndefinePreprocessorDefinitions>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>..\dependencies\embree\include;..\dependencies\openvr;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -99,10 +99,8 @@
       <ModuleDefinitionFile>ddraw.def</ModuleDefinitionFile>
       <UACUIAccess>true</UACUIAccess>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);DirectXTK.lib;Windowscodecs.lib;winmm.lib;openvr_api.lib</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\dependencies\openvr\lib;..\dependencies\embree\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)dependencies\openvr\lib;$(SolutionDir)dependencies\embree\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
-    <PostBuildEvent />
-    <PostBuildEvent />
     <PostBuildEvent />
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
I think I found the issue with the openvr.h path.
This is untested, changed it from the phone. @Prof-Butts please test it before merging 😅 You will need to revert back the includes to <openvr.h>