### PR TITLE
DirectBVH2 Builder

### DIFF
--- a/impl11/ddraw/D3dRenderer.h
+++ b/impl11/ddraw/D3dRenderer.h
@@ -147,6 +147,7 @@ protected:
 	std::map<int, XwaVector3*> _tangentMap;
 	std::map<int, ComPtr<ID3D11ShaderResourceView>> _meshTextureCoordsViews;
 	std::map<int, AABB> _AABBs;
+	std::map<int, XwaVector3> _centers; // Center-of-mass for each mesh, *not* the centroids.
 	std::map<int, LBVH*> _LBVHs;
 	XwaVector3* _lastMeshVertices;
 	ID3D11ShaderResourceView* _lastMeshVerticesView;

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -769,7 +769,7 @@ void BuildTLAS()
 	for (uint32_t i = 0; i < numLeaves; i++)
 	{
 		auto& leaf = tlasLeaves[i];
-		XwaVector3 centroid = TLASGetCentroid(leaf);
+		Vector3 centroid = TLASGetCentroid(leaf);
 		Normalize(centroid, g_GlobalAABB, g_GlobalRange);
 		TLASGetMortonCode(leaf) = GetMortonCode(centroid);
 	}
@@ -3717,11 +3717,11 @@ void EffectsRenderer::UpdateBVHMaps(const SceneCompData* scene, int LOD)
 		// Fetch the AABB for this mesh
 		auto aabb_it = _AABBs.find(meshKey);
 		if (aabb_it != _AABBs.end()) {
-			AABB obb = aabb_it->second;					// The AABB in object space
-			obb.UpdateLimits();							// Generate all the vertices (8) so that we can transform them.
-			obb.TransformLimits(W);						// Now it's an OBB in WorldView space...
-			AABB aabb = obb.GetAABBFromCurrentLimits(); // so we get the AABB from this OBB...
-			XwaVector3 centroid = aabb.GetCentroid();   // and its centroid.
+			AABB obb = aabb_it->second;                   // The AABB in object space
+			obb.UpdateLimits();                           // Generate all the vertices (8) so that we can transform them.
+			obb.TransformLimits(W);                       // Now it's an OBB in WorldView space...
+			AABB aabb = obb.GetAABBFromCurrentLimits();   // so we get the AABB from this OBB...
+			Vector3 centroid = aabb.GetCentroidVector3(); // and its centroid.
 
 			IDCentroid_t IDCentroidKey = IDCentroid_t(blasID, centroid.x, centroid.y, centroid.z);
 			auto it = g_TLASMap.find(IDCentroidKey);
@@ -3743,7 +3743,7 @@ void EffectsRenderer::UpdateBVHMaps(const SceneCompData* scene, int LOD)
 				// Add a new entry to tlasLeaves and update the global centroid
 				//AddAABBToTLAS(W, meshKey, obb, centroid, matrixSlot);
 				g_GlobalAABB.Expand(aabb);
-				tlasLeaves.push_back(TLASLeafItem(0, aabb, blasID, centroid, matrixSlot, obb));
+				tlasLeaves.push_back({ 0, centroid, aabb, blasID, matrixSlot, obb });
 			}
 			else
 			{

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -1544,6 +1544,9 @@ LBVH* EffectsRenderer::BuildBVH(const std::vector<XwaVector3>& vertices, const s
 
 	case BVHBuilderType_Embree:
 		return LBVH::BuildEmbree(vertices.data(), vertices.size(), indices.data(), indices.size());
+
+	case BVHBuilderType_DirectBVH2:
+		return LBVH::BuildDirectBVH2(vertices.data(), vertices.size(), indices.data(), indices.size());
 	}
 	return nullptr;
 }

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -14,17 +14,19 @@ extern char g_curOPTLoaded[MAX_OPT_NAME];
 extern bool g_bEnableQBVHwSAH;
 //BVHBuilderType g_BVHBuilderType = BVHBuilderType_BVH2;
 //BVHBuilderType g_BVHBuilderType = BVHBuilderType_QBVH;
-BVHBuilderType g_BVHBuilderType = BVHBuilderType_FastQBVH;
+//BVHBuilderType g_BVHBuilderType = BVHBuilderType_FastQBVH;
 //BVHBuilderType g_BVHBuilderType = BVHBuilderType_Embree;
+BVHBuilderType g_BVHBuilderType = DEFAULT_BVH_BUILDER;
 
 RTCDevice g_rtcDevice = nullptr;
 RTCScene g_rtcScene = nullptr;
 
 char* g_sBVHBuilderTypeNames[BVHBuilderType_MAX] = {
-	"    BVH2",
-	"    QBVH",
-	"FastQBVH",
-	"  Embree",
+	"      BVH2",
+	"      QBVH",
+	"  FastQBVH",
+	"    Embree",
+	"DirectBVH2",
 };
 
 bool g_bRTEnabledInTechRoom = true;

--- a/impl11/ddraw/LBVH.h
+++ b/impl11/ddraw/LBVH.h
@@ -245,38 +245,34 @@ using MortonCode_t = uint32_t;
 using MortonCode_t = uint64_t;
 #endif
 // 0: Morton Code, 1: Bounding Box, 2: TriID
-using LeafItem = std::tuple<MortonCode_t, AABB, int>;
+//using LeafItem = std::tuple<MortonCode_t, AABB, int>;
 // 0: Morton Code, 1: aabbFromOBB, 2: BlasID, 3: Centroid, 4: MatrixSlot, 5: Oriented Bounding Box
-using TLASLeafItem = std::tuple<MortonCode_t, AABB, int, XwaVector3, int, AABB>;
+//using TLASLeafItem = std::tuple<MortonCode_t, AABB, int, XwaVector3, int, AABB>;
 // Used in the DirectBVH algorithms
-struct LeafItemCentroid
+struct LeafItem
 {
+	MortonCode_t code;
 	Vector3 centroid;
 	AABB aabb;
 	int PrimID;
 };
 // Used in the DirectBVH algorithms
-struct TLASLeafItemCentroid : LeafItemCentroid
+struct TLASLeafItem : LeafItem
 {
 	int matrixSlot;
 	AABB obb;
 };
 
-inline MortonCode_t &GetMortonCode(LeafItem& X) { return std::get<0>(X); }
-inline MortonCode_t &GetMortonCode(TLASLeafItem& X) { return std::get<0>(X); }
+inline MortonCode_t &GetMortonCode(LeafItem& X) { return X.code; }
+inline AABB &GetAABB(LeafItem& X) { return X.aabb; }
+inline int& GetID(LeafItem& X) { return X.PrimID; }
 
-inline AABB &GetAABB(LeafItem& X) { return std::get<1>(X); }
-inline AABB &GetAABB(TLASLeafItem& X) { return std::get<1>(X); }
-
-inline int& GetID(LeafItem& X) { return std::get<2>(X); }
-inline int& GetID(TLASLeafItem& X) { return std::get<2>(X); }
-
-inline MortonCode_t& TLASGetMortonCode(TLASLeafItem& X) { return std::get<0>(X); }
-inline AABB& TLASGetAABBFromOBB(TLASLeafItem& X) { return std::get<1>(X); }
-inline int& TLASGetID(TLASLeafItem& X) { return std::get<2>(X); }
-inline XwaVector3& TLASGetCentroid(TLASLeafItem& X) { return std::get<3>(X); }
-inline int& TLASGetMatrixSlot(TLASLeafItem& X) { return std::get<4>(X); }
-inline AABB& TLASGetOBB(TLASLeafItem& X) { return std::get<5>(X); }
+inline MortonCode_t& TLASGetMortonCode(TLASLeafItem& X) { return X.code; }
+inline AABB& TLASGetAABBFromOBB(TLASLeafItem& X) { return X.aabb; }
+inline int& TLASGetID(TLASLeafItem& X) { return X.PrimID; }
+inline Vector3& TLASGetCentroid(TLASLeafItem& X) { return X.centroid; }
+inline int& TLASGetMatrixSlot(TLASLeafItem& X) { return X.matrixSlot; }
+inline AABB& TLASGetOBB(TLASLeafItem& X) { return X.obb; }
 
 struct InnerNode
 {
@@ -754,9 +750,9 @@ using NodeChildKey = std::tuple<uint32_t, int>;
 
 int CalcNumInnerQBVHNodes(int numPrimitives);
 
-void Normalize(XwaVector3& A, const AABB& sceneBox, const XwaVector3& range);
+void Normalize(Vector3& A, const AABB& sceneBox, const XwaVector3& range);
 
-MortonCode_t GetMortonCode(const XwaVector3& V);
+MortonCode_t GetMortonCode(const Vector3& V);
 
 // Red-Black balanced insertion
 TreeNode* InsertRB(TreeNode* T, int TriID, MortonCode_t code, const AABB& box, const Matrix4& m);

--- a/impl11/ddraw/LBVH.h
+++ b/impl11/ddraw/LBVH.h
@@ -112,6 +112,16 @@ public:
 		if (v.z > max.z) max.z = v.z;
 	}
 
+	inline void Expand(const Vector3& v) {
+		if (v.x < min.x) min.x = v.x;
+		if (v.y < min.y) min.y = v.y;
+		if (v.z < min.z) min.z = v.z;
+
+		if (v.x > max.x) max.x = v.x;
+		if (v.y > max.y) max.y = v.y;
+		if (v.z > max.z) max.z = v.z;
+	}
+
 	inline void Expand(const float3& v) {
 		if (v.x < min.x) min.x = v.x;
 		if (v.y < min.y) min.y = v.y;

--- a/impl11/ddraw/VRConfig.cpp
+++ b/impl11/ddraw/VRConfig.cpp
@@ -2094,7 +2094,7 @@ bool LoadSSAOParams() {
 			if (_stricmp(param, "raytracing_enable_embree") == 0) {
 				//g_bRTEnableEmbree = (bool)fValue;
 				g_bRTEnableEmbree = false;
-				g_BVHBuilderType = g_bRTEnableEmbree ? BVHBuilderType_Embree : BVHBuilderType_FastQBVH;
+				g_BVHBuilderType = g_bRTEnableEmbree ? BVHBuilderType_Embree : DEFAULT_BVH_BUILDER;
 			}
 
 			if (_stricmp(param, "keep_mouse_inside_window") == 0) {

--- a/impl11/ddraw/XwaD3dRendererHook.cpp
+++ b/impl11/ddraw/XwaD3dRendererHook.cpp
@@ -322,6 +322,7 @@ void D3dRenderer::FlightStart()
 	_triangleBuffers.clear();
 	_vertexCounters.clear();
 	_AABBs.clear();
+	_centers.clear();
 	_LBVHs.clear();
 	_tangentMap.clear();
 	g_meshToFGMap.clear();
@@ -595,11 +596,17 @@ void D3dRenderer::UpdateMeshBuffers(const SceneCompData* scene)
 
 			AABB aabb;
 			aabb.SetInfinity();
+			XwaVector3 center(0, 0, 0);
 			for (int i = 0; i < verticesCount; i++)
+			{
 				aabb.Expand(vertices[i]);
+				center = center + vertices[i];
+			}
+			center = center * (1.0f / (float)verticesCount);
 
 			_meshVerticesViews.insert(std::make_pair((int)vertices, meshVerticesView));
 			_AABBs.insert(std::make_pair((int)vertices, aabb));
+			_centers.insert(std::make_pair((int)vertices, center));
 			_lastMeshVerticesView = meshVerticesView;
 
 			// Compute the RTScale for this OPT

--- a/impl11/ddraw/dllmain.cpp
+++ b/impl11/ddraw/dllmain.cpp
@@ -46,6 +46,7 @@ extern bool g_bTriggerReticleCapture;
 extern bool g_bEnableAnimations;
 extern bool g_bFadeLights;
 extern bool g_bEnableQBVHwSAH;
+extern bool g_bUseCentroids;
 
 void Normalize(float4 *Vector) {
 	float x = Vector->x;
@@ -821,19 +822,30 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 			// Ctrl+S
 			case 'S': {
 #define BENCHMARK_MODE 0
-#if BENCHMARK_MODE
-				g_BVHBuilderType = (BVHBuilderType)(((int)g_BVHBuilderType + 1) % BVHBuilderType_MAX);
-				log_debug("[DBG] [BVH] Builder type set to: %s", g_sBVHBuilderTypeNames[g_BVHBuilderType]);
-#else
+#if BENCHMARK_MODE == 0
 				g_bRTEnabledInTechRoom = !g_bRTEnabledInTechRoom;
 				log_debug("[DBG] [BVH] g_bRTEnabledInTechRoom: %d", g_bRTEnabledInTechRoom);
-#endif
+
 				/*g_bRTEnabled = !g_bRTEnabled;
 				log_debug("[DBG] [BVH] g_bRTEnabled: %s", g_bRTEnabled ? "Enabled" : "Disabled");
 				DisplayTimedMessage(3, 0, g_bRTEnabled ? "Raytracing Enabled" : "Raytracing Disabled");*/
 
 				g_bShadowMapEnable = !g_bShadowMapEnable;
 				DisplayTimedMessage(3, 0, g_bShadowMapEnable ? "Shadow Mapping Enabled" : "Shadow Mapping Disabled");
+#elif BENCHMARK_MODE == 1
+				g_BVHBuilderType = (BVHBuilderType)(((int)g_BVHBuilderType + 1) % BVHBuilderType_MAX);
+				log_debug("[DBG] [BVH] Builder type set to: %s", g_sBVHBuilderTypeNames[g_BVHBuilderType]);
+#elif BENCHMARK_MODE == 2
+				g_bUseCentroids = !g_bUseCentroids;
+				if (g_bUseCentroids)
+				{
+					DisplayTimedMessage(3, 0, "Using Centroids for TLAS");
+				}
+				else
+				{
+					DisplayTimedMessage(3, 0, "Using Center-of-Mass for TLAS");
+				}
+#endif
 				return 0;
 			}
 			//case 'E': {

--- a/impl11/ddraw/dllmain.cpp
+++ b/impl11/ddraw/dllmain.cpp
@@ -1421,8 +1421,8 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
 		//}
 		{
 			g_bRTEnableEmbree = false;
-			g_BVHBuilderType = BVHBuilderType_FastQBVH;
-			log_debug("[DBG] [BVH] [EMB] Embree was not loaded. Using FastLQBVH instead");
+			g_BVHBuilderType = DEFAULT_BVH_BUILDER;
+			log_debug("[DBG] [BVH] [EMB] Embree was not loaded. Using DEFAULT_BVH_BUILDER instead");
 		}
 
 		if (IsXwaExe())

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -236,7 +236,7 @@ enum BVHBuilderType
 	BVHBuilderType_DirectBVH2,
 	BVHBuilderType_MAX,
 };
-constexpr BVHBuilderType DEFAULT_BVH_BUILDER = BVHBuilderType_DirectBVH2;
+constexpr BVHBuilderType DEFAULT_BVH_BUILDER = BVHBuilderType_FastQBVH;
 extern BVHBuilderType g_BVHBuilderType;
 extern char* g_sBVHBuilderTypeNames[BVHBuilderType_MAX];
 

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -233,6 +233,7 @@ enum BVHBuilderType
 	BVHBuilderType_QBVH,
 	BVHBuilderType_FastQBVH,
 	BVHBuilderType_Embree,
+	BVHBuilderType_DirectBVH2,
 	BVHBuilderType_MAX,
 };
 extern BVHBuilderType g_BVHBuilderType;

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -236,6 +236,7 @@ enum BVHBuilderType
 	BVHBuilderType_DirectBVH2,
 	BVHBuilderType_MAX,
 };
+constexpr BVHBuilderType DEFAULT_BVH_BUILDER = BVHBuilderType_DirectBVH2;
 extern BVHBuilderType g_BVHBuilderType;
 extern char* g_sBVHBuilderTypeNames[BVHBuilderType_MAX];
 

--- a/impl11/ddraw/xwa_structures.h
+++ b/impl11/ddraw/xwa_structures.h
@@ -259,6 +259,14 @@ struct XwaVector3
 		this->z = z;
 	}
 
+	friend XwaVector3 operator+(XwaVector3 lhs, const XwaVector3& rhs)
+	{
+		lhs.x += rhs.x;
+		lhs.y += rhs.y;
+		lhs.z += rhs.z;
+		return lhs;
+	}
+
 	friend XwaVector3 operator-(XwaVector3 lhs, const XwaVector3& rhs)
 	{
 		lhs.x -= rhs.x;


### PR DESCRIPTION
This BVH builder does not use Morton Codes (so it also won't sort any primitives) but builds a BVH2 (so it must be converted to a QBVH). It's probably a bit faster to build and it appears to have better traversal performance than the LBVH version.