### PR TITLE
Instanced stereo

### DIFF
--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -419,10 +419,9 @@ HRESULT DeviceResources::Initialize()
 	UINT numFeatureLevels = ARRAYSIZE(featureLevels);
 
 	UINT createDeviceFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
-	createDeviceFlags |= D3D11_CREATE_DEVICE_DEBUG;
 
 #ifdef _DEBUG
-	//createDeviceFlags |= D3D11_CREATE_DEVICE_DEBUG;
+	createDeviceFlags |= D3D11_CREATE_DEVICE_DEBUG;
 #endif
 
 

--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -3107,7 +3107,7 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 				DXGI_FORMAT oldFormat = shaderResourceViewDesc.Format;
 				shaderResourceViewDesc.Format = RT_SHADOW_FORMAT;
 				shaderResourceViewDesc.Texture2D.MipLevels = 1;
-				shaderResourceViewDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+				shaderResourceViewDesc.ViewDimension = curDimension;
 				shaderResourceViewDesc.Texture2D.MostDetailedMip = 0;
 
 				step = "_rtShadowMaskSRV";

--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -2780,6 +2780,7 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 				}
 
 				// This buffer is needed in all cases, not only SteamVR/stereo rendering, since it is used later as Indirect SSDO buffer
+				desc.Format = HDR_FORMAT;
 				step = "_ssaoBufR";
 				hr = this->_d3dDevice->CreateTexture2D(&desc, nullptr, &this->_ssaoBufR);
 				if (FAILED(hr)) {
@@ -3527,15 +3528,15 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 
 		// Raytracing Shadow Mask RTVs
 		if (g_bRTEnabled && g_bRTEnableSoftShadows) {
-			renderTargetViewDescNoMSAA.Format = RT_SHADOW_FORMAT;
+			//renderTargetViewDescNoMSAA.Format = RT_SHADOW_FORMAT;
 			step = "_rtShadowMaskRTV";
-			hr = this->_d3dDevice->CreateRenderTargetView(this->_rtShadowMask, &renderTargetViewDescNoMSAA, &this->_rtShadowMaskRTV);
+			hr = this->_d3dDevice->CreateRenderTargetView(this->_rtShadowMask, &GetRtvDesc(false, g_bUseSteamVR, RT_SHADOW_FORMAT), &this->_rtShadowMaskRTV);
 			if (FAILED(hr)) goto out;
 
 			if (g_bUseSteamVR) {
-				renderTargetViewDescNoMSAA.Format = RT_SHADOW_FORMAT;
+				//renderTargetViewDescNoMSAA.Format = RT_SHADOW_FORMAT;
 				step = "_rtShadowMaskRTV_R";
-				hr = this->_d3dDevice->CreateRenderTargetView(this->_rtShadowMaskR, &renderTargetViewDescNoMSAA, &this->_rtShadowMaskRTV_R);
+				hr = this->_d3dDevice->CreateRenderTargetView(this->_rtShadowMaskR, &GetRtvDesc(false, g_bUseSteamVR, RT_SHADOW_FORMAT), &this->_rtShadowMaskRTV_R);
 				if (FAILED(hr)) goto out;
 			}
 		}

--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -2902,7 +2902,7 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 					goto out;
 				}
 			}
-			shaderResourceViewDesc.ViewDimension = g_bUseSteamVR ? D3D11_SRV_DIMENSION_TEXTURE2DARRAY : D3D11_SRV_DIMENSION_TEXTURE2D;
+			shaderResourceViewDesc.ViewDimension = curDimension;
 
 			if (g_bUseSteamVR) {
 				// Create the shader resource view for offscreenBufferAsInputR
@@ -3231,7 +3231,7 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 				}
 			}
 
-			shaderResourceViewDesc.ViewDimension = g_bUseSteamVR ? D3D11_SRV_DIMENSION_TEXTURE2DARRAY : D3D11_SRV_DIMENSION_TEXTURE2D;
+			shaderResourceViewDesc.ViewDimension = curDimension;
 		}
 	}
 
@@ -4997,7 +4997,7 @@ HRESULT DeviceResources::RenderMain(char* src, DWORD width, DWORD height, DWORD 
 	ID3D11Texture2D* tex = nullptr;
 	ID3D11ShaderResourceView* texView = nullptr;
 
-	this->_d3dAnnotation->BeginEvent(L"RenderMain");
+	BeginAnnotatedEvent(L"RenderMain");
 
 	/*
 	if (g_bUseSteamVR) {
@@ -5526,7 +5526,7 @@ HRESULT DeviceResources::RenderMain(char* src, DWORD width, DWORD height, DWORD 
 		messageShown = true;
 	}
 
-	this->_d3dAnnotation->EndEvent();
+	this->EndAnnotatedEvent();
 
 	return hr;
 }

--- a/impl11/ddraw/DeviceResources.h
+++ b/impl11/ddraw/DeviceResources.h
@@ -218,7 +218,7 @@ public:
 	ComPtr<ID3D11Texture2D> _DCTextMSAA;				   // "RTV" to render text
 	ComPtr<ID3D11Texture2D> _DCTextAsInput;				   // Resolved from DCTextMSAA for use in shaders
 	ComPtr<ID3D11Texture2D> _ReticleBufMSAA;			   // "RTV" to render the HUD in VR mode
-	ComPtr<ID3D11Texture2D> _ReticleBufAsInput;			   // Resolved from DCTextMSAA for use in shaders
+	ComPtr<ID3D11Texture2D> _ReticleBufAsInput;			   // Resolved from _ReticleBufMSAA for use in shaders
 	// Barrel effect
 	ComPtr<ID3D11Texture2D> _offscreenBufferPost;  // This is the output of the barrel effect
 	ComPtr<ID3D11Texture2D> _offscreenBufferPostR; // This is the output of the barrel effect for the right image when using SteamVR
@@ -248,8 +248,8 @@ public:
 	ComPtr<ID3D11Texture2D> _depthBufR;
 	ComPtr<ID3D11Texture2D> _depthBufAsInput;
 	ComPtr<ID3D11Texture2D> _depthBufAsInputR; // Used in SteamVR mode
-	ComPtr<ID3D11Texture2D> _bentBuf;		// No MSAA
-	ComPtr<ID3D11Texture2D> _bentBufR;		// No MSAA
+	//ComPtr<ID3D11Texture2D> _bentBuf;		// No MSAA
+	//ComPtr<ID3D11Texture2D> _bentBufR;		// No MSAA
 	ComPtr<ID3D11Texture2D> _ssaoBuf;		// No MSAA
 	ComPtr<ID3D11Texture2D> _ssaoBufR;		// No MSAA
 	// Shading System
@@ -365,8 +365,8 @@ public:
 	// Ambient Occlusion
 	ComPtr<ID3D11ShaderResourceView> _depthBufSRV;    // SRV for depthBufAsInput
 	ComPtr<ID3D11ShaderResourceView> _depthBufSRV_R;  // SRV for depthBufAsInputR
-	ComPtr<ID3D11ShaderResourceView> _bentBufSRV;     // SRV for bentBuf
-	ComPtr<ID3D11ShaderResourceView> _bentBufSRV_R;   // SRV for bentBufR
+	//ComPtr<ID3D11ShaderResourceView> _bentBufSRV;     // SRV for bentBuf
+	//ComPtr<ID3D11ShaderResourceView> _bentBufSRV_R;   // SRV for bentBufR
 	ComPtr<ID3D11ShaderResourceView> _ssaoBufSRV;     // SRV for ssaoBuf
 	ComPtr<ID3D11ShaderResourceView> _ssaoBufSRV_R;   // SRV for ssaoBuf
 	// Shading System

--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -2735,7 +2735,8 @@ HRESULT Direct3DDevice::Execute(
 	DWORD dwFlags
 )
 {
-	_deviceResources->_d3dAnnotation->BeginEvent(L"Execute");
+	bool bStateD3dAnnotationOpen = false; // To keep track of the d3dannotation event state so that we close it at the end of Execute()
+	_deviceResources->BeginAnnotatedEvent(L"Execute");
 
 #if LOGGER
 	std::ostringstream str;
@@ -3259,7 +3260,7 @@ HRESULT Direct3DDevice::Execute(
 				/*********************************************************************
 					 State management begins here
 				 *********************************************************************
-
+				 
 				   Unfortunately, we need to maintain a number of flags to tell what the
 				   engine is about to render. If we had access to the engine, we could do
 				   away with all these flags.
@@ -3677,11 +3678,9 @@ HRESULT Direct3DDevice::Execute(
 				}
 				//if (g_bHyperspaceFirstFrame)
 				//	goto out;
-
 				/*************************************************************************
 					State management ends here, special state management starts
 				 *************************************************************************/
-				_deviceResources->_d3dAnnotation->BeginEvent(L"SpecialStateManagement");
 				// Resolve the depth buffers. Capture the current screen to shadertoyAuxBuf
 				if (!g_bPrevStartedGUI && g_bStartedGUI) {
 					g_bSwitchedToGUI = true;
@@ -3695,13 +3694,13 @@ HRESULT Direct3DDevice::Execute(
 					RenderDeferredDrawCalls();
 
 					// Resolve the Depth Buffers
-					_deviceResources->_d3dAnnotation->BeginEvent(L"ResolveDepthBuffers");
+					_deviceResources->BeginAnnotatedEvent(L"ResolveDepthBuffers");
 					if (g_bAOEnabled) {
 						g_bDepthBufferResolved = true;
 						context->ResolveSubresource(resources->_depthBufAsInput, 0, resources->_depthBuf, 0, AO_DEPTH_BUFFER_FORMAT);
 						if (g_bUseSteamVR)
-							context->ResolveSubresource(resources->_depthBufAsInput, 1,
-								resources->_depthBuf, 1, AO_DEPTH_BUFFER_FORMAT);
+							context->ResolveSubresource(resources->_depthBufAsInput, D3D11CalcSubresource(0, 1, 1),
+								resources->_depthBuf, D3D11CalcSubresource(0, 1, 1), AO_DEPTH_BUFFER_FORMAT);
 
 						// DEBUG
 						//if (g_iPresentCounter == 100) {
@@ -3714,11 +3713,11 @@ HRESULT Direct3DDevice::Execute(
 						//}
 						// DEBUG
 					}
-					_deviceResources->_d3dAnnotation->EndEvent();
+					_deviceResources->EndAnnotatedEvent();
 
 					// Capture the current-frame-so-far (cockpit+background) for the new hyperspace effect; but only if we're
 					// not travelling through hyperspace:
-					_deviceResources->_d3dAnnotation->BeginEvent(L"CaptureFrameForHyperspace");
+					_deviceResources->BeginAnnotatedEvent(L"CaptureFrameForHyperspace");
 					{
 						if (g_bHyperDebugMode || g_HyperspacePhaseFSM == HS_INIT_ST || g_HyperspacePhaseFSM == HS_POST_HYPER_EXIT_ST)
 						{
@@ -3730,13 +3729,14 @@ HRESULT Direct3DDevice::Execute(
 
 							context->ResolveSubresource(resources->_shadertoyAuxBuf, 0, resources->_offscreenBuffer, 0, BACKBUFFER_FORMAT);
 							if (g_bUseSteamVR) {
-								context->ResolveSubresource(resources->_shadertoyAuxBuf, 1, resources->_offscreenBuffer, 1, BACKBUFFER_FORMAT);
+								context->ResolveSubresource(
+									resources->_shadertoyAuxBuf, D3D11CalcSubresource(0, 1, 1),
+									resources->_offscreenBuffer, D3D11CalcSubresource(0, 1, 1), BACKBUFFER_FORMAT);
 							}
 						}
 					}
-					_deviceResources->_d3dAnnotation->EndEvent();
+					_deviceResources->EndAnnotatedEvent();
 				}
-				_deviceResources->_d3dAnnotation->EndEvent();
 				/*************************************************************************
 					Special state management ends here
 				 *************************************************************************/
@@ -4730,7 +4730,10 @@ HRESULT Direct3DDevice::Execute(
 				}
 
 				if (bIsDS2CoreExplosion) {
-					_deviceResources->_d3dAnnotation->BeginEvent(L"DrawDS2CoreExplosion");
+					if (!bStateD3dAnnotationOpen) {
+						_deviceResources->BeginAnnotatedEvent(L"DrawDS2CoreExplosion");
+						bStateD3dAnnotationOpen = true;
+					}
 					g_iReactorExplosionCount++;
 					// The reactor's core explosion is rendered 4 times per frame. We only need one now:
 					if (g_iReactorExplosionCount > 1)
@@ -5145,6 +5148,10 @@ HRESULT Direct3DDevice::Execute(
 					(bRenderToDynCockpitBuffer || bRenderToDynCockpitBGBuffer) || bRenderReticleToBuffer
 				   )
 				{	
+					if (!bStateD3dAnnotationOpen) {
+						_deviceResources->BeginAnnotatedEvent(L"RenderHUD");
+						bStateD3dAnnotationOpen = true;
+					}
 					// Restore the non-VR dimensions:
 					g_VSCBuffer.viewportScale[0] =  2.0f / displayWidth;
 					g_VSCBuffer.viewportScale[1] = -2.0f / displayHeight;
@@ -5161,7 +5168,8 @@ HRESULT Direct3DDevice::Execute(
 					}
 					else if (bRenderToDynCockpitBGBuffer) {
 						context->OMSetRenderTargets(1, resources->_renderTargetViewDynCockpitBG.GetAddressOf(),
-							resources->_depthStencilViewL.Get());
+							//resources->_depthStencilViewL.Get());
+							NULL);
 					}
 					else {
 						//context->OMSetRenderTargets(1, resources->_renderTargetViewDynCockpit.GetAddressOf(),
@@ -5169,7 +5177,8 @@ HRESULT Direct3DDevice::Execute(
 
 						if (g_config.Text2DRendererEnabled)
 							context->OMSetRenderTargets(1, resources->_renderTargetViewDynCockpit.GetAddressOf(),
-								resources->_depthStencilViewL.Get());
+								//resources->_depthStencilViewL.Get());
+								NULL);
 						else 
 						{
 							// The new Text Renderer is not enabled; but we can still render the text to its own
@@ -5177,10 +5186,12 @@ HRESULT Direct3DDevice::Execute(
 							// from the targeted object
 							if (bIsText)
 								context->OMSetRenderTargets(1, resources->_DCTextRTV.GetAddressOf(),
-									resources->_depthStencilViewL.Get());
+									//resources->_depthStencilViewL.Get());
+									NULL);
 							else
 								context->OMSetRenderTargets(1, resources->_renderTargetViewDynCockpit.GetAddressOf(),
-									resources->_depthStencilViewL.Get());
+									//resources->_depthStencilViewL.Get());
+									NULL);
 						}
 					}
 					// Enable Z-Buffer if we're drawing the targeted craft
@@ -5255,17 +5266,29 @@ HRESULT Direct3DDevice::Execute(
 						bModifiedShaders = true;
 						g_PSCBuffer.fBloomStrength = g_BloomConfig.fEngineGlowStrength;
 						g_PSCBuffer.bIsEngineGlow = g_config.EnhanceEngineGlow ? 2 : 1;
+						if (!bStateD3dAnnotationOpen) {
+							_deviceResources->BeginAnnotatedEvent(L"EngineGlow");
+							bStateD3dAnnotationOpen = true;
+						}
 					}
 					else if (lastTextureSelected->is_Electricity || bIsExplosion)
 					{
 						bModifiedShaders = true;
 						g_PSCBuffer.fBloomStrength = g_BloomConfig.fExplosionsStrength;
 						g_PSCBuffer.bIsEngineGlow = g_config.EnhanceExplosions ? 2 : 1;
+						if (!bStateD3dAnnotationOpen) {
+							_deviceResources->BeginAnnotatedEvent(L"ElectricityOrExplosion");
+							bStateD3dAnnotationOpen = true;
+						}
 					}
 					else if (lastTextureSelected->is_LensFlare) {
 						bModifiedShaders = true;
 						g_PSCBuffer.fBloomStrength = g_BloomConfig.fLensFlareStrength;
 						g_PSCBuffer.bIsEngineGlow = 1;
+						if (!bStateD3dAnnotationOpen) {
+							_deviceResources->BeginAnnotatedEvent(L"LensFlare");
+							bStateD3dAnnotationOpen = true;
+						}
 					}
 					else if (bIsSun) {
 						bModifiedShaders = true;
@@ -5786,7 +5809,11 @@ HRESULT Direct3DDevice::Execute(
 	g_iDumpOBJIdx = 1; g_iDumpLaserOBJIdx = 1;
 	// DEBUG
 
-	_deviceResources->_d3dAnnotation->EndEvent();
+	if (bStateD3dAnnotationOpen) {
+		_deviceResources->EndAnnotatedEvent(); //We need to close the special state annotation event
+		bStateD3dAnnotationOpen = false;
+	}
+	_deviceResources->EndAnnotatedEvent();
 
 	if (FAILED(hr))
 	{
@@ -6087,7 +6114,7 @@ HRESULT Direct3DDevice::DeleteMatrix(
 HRESULT Direct3DDevice::BeginScene()
 {
 
-	_deviceResources->_d3dAnnotation->BeginEvent(L"Direct3DDeviceScene");
+	_deviceResources->BeginAnnotatedEvent(L"Direct3DDeviceScene");
 
 #if LOGGER
 	std::ostringstream str;
@@ -6481,7 +6508,7 @@ HRESULT Direct3DDevice::EndScene()
 	// Animate all materials
 	AnimateMaterials();
 
-	_deviceResources->_d3dAnnotation->EndEvent();
+	_deviceResources->EndAnnotatedEvent();
 
 	return D3D_OK;
 }

--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -5589,7 +5589,7 @@ HRESULT Direct3DDevice::Execute(
 					viewport.MaxDepth = D3D11_MAX_DEPTH;
 					resources->InitViewport(&viewport);
 					// Set the left projection matrix
-					g_VSMatrixCB.projEye = g_FullProjMatrixLeft;
+					g_VSMatrixCB.projEye[0] = g_FullProjMatrixLeft;
 					// The viewMatrix is set at the beginning of the frame
 					resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
 					// Draw the Left Image
@@ -5661,7 +5661,7 @@ HRESULT Direct3DDevice::Execute(
 					viewport.MaxDepth = D3D11_MAX_DEPTH;
 					resources->InitViewport(&viewport);
 					// Set the right projection matrix
-					g_VSMatrixCB.projEye = g_FullProjMatrixRight;
+					g_VSMatrixCB.projEye[0] = g_FullProjMatrixRight;
 					resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
 					// Draw the Right Image
 					context->DrawIndexed(3 * instruction->wCount, currentIndexLocation, 0);

--- a/impl11/ddraw/DirectSBSRenderer.cpp
+++ b/impl11/ddraw/DirectSBSRenderer.cpp
@@ -134,7 +134,7 @@ void DirectSBSRenderer::RenderScene()
 		context->OMSetRenderTargets(6, rtvs, resources->_depthStencilViewL.Get());
 
 		// Set the left projection matrix
-		g_VSMatrixCB.projEye = g_FullProjMatrixLeft;
+		g_VSMatrixCB.projEye[0] = g_FullProjMatrixLeft;
 		// The viewMatrix is set at the beginning of the frame
 		resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
 
@@ -168,7 +168,7 @@ void DirectSBSRenderer::RenderScene()
 		context->OMSetRenderTargets(6, rtvs, resources->_depthStencilViewL.Get());
 
 		// Set the right projection matrix
-		g_VSMatrixCB.projEye = g_FullProjMatrixRight;
+		g_VSMatrixCB.projEye[0] = g_FullProjMatrixRight;
 		// The viewMatrix is set at the beginning of the frame
 		resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
 

--- a/impl11/ddraw/DirectSBSRenderer.cpp
+++ b/impl11/ddraw/DirectSBSRenderer.cpp
@@ -56,8 +56,6 @@ void DirectSBSRenderer::RenderScene()
 		// resources->InitVertexShader(_shadowVertexShaderVR);
 		return;
 
-	_deviceResources->_d3dAnnotation->BeginEvent(L"RenderScene");
-
 	auto &resources = _deviceResources;
 	auto &context = resources->_d3dDeviceContext;
 
@@ -179,5 +177,4 @@ void DirectSBSRenderer::RenderScene()
 	g_iD3DExecuteCounter++;
 	g_iDrawCounter++; // We need this counter to enable proper Tech Room detection
 
-	_deviceResources->_d3dAnnotation->EndEvent();
 }

--- a/impl11/ddraw/EffectsCommon.h
+++ b/impl11/ddraw/EffectsCommon.h
@@ -192,12 +192,12 @@ typedef struct VertexShaderCBStruct {
 } VertexShaderCBuffer;
 
 typedef struct VertexShaderMatrixCBStruct {
-	Matrix4 projEye;
+	Matrix4 projEye[2];
 	Matrix4 viewMat;
 	Matrix4 fullViewMat;
-	// 192 bytes
+	// 256 bytes
 	float Znear, Zfar, DeltaX, DeltaY;
-	// 208 bytes
+	// 272 bytes
 } VertexShaderMatrixCB;
 
 typedef struct PSShadingSystemCBStruct {

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -4503,7 +4503,8 @@ void EffectsRenderer::DCCaptureMiniature()
 	_deviceResources->InitPixelShader(_pixelShader);
 	// Select the proper RTV
 	context->OMSetRenderTargets(1, resources->_renderTargetViewDynCockpit.GetAddressOf(),
-		resources->_depthStencilViewL.Get());
+		//resources->_depthStencilViewL.Get());
+		NULL);
 
 	// Enable Z-Buffer since we're drawing the targeted craft
 	QuickSetZWriteEnabled(TRUE);
@@ -4515,7 +4516,8 @@ void EffectsRenderer::DCCaptureMiniature()
 	// Restore the regular texture, RTV, shaders, etc:
 	context->PSSetShaderResources(0, 1, _lastTextureSelected->_textureView.GetAddressOf());
 	context->OMSetRenderTargets(1, resources->_renderTargetView.GetAddressOf(),
-		resources->_depthStencilViewL.Get());
+		//resources->_depthStencilViewL.Get());
+		NULL);
 	/*
 	if (g_bEnableVR) {
 		resources->InitVertexShader(resources->_sbsVertexShader);
@@ -4734,7 +4736,7 @@ void EffectsRenderer::RenderLasers()
 {
 	if (_LaserDrawCommands.size() == 0)
 		return;
-	_deviceResources->_d3dAnnotation->BeginEvent(L"RenderLasers");
+	_deviceResources->BeginAnnotatedEvent(L"RenderLasers");
 	auto &resources = _deviceResources;
 	auto &context = resources->_d3dDeviceContext;
 	//log_debug("[DBG] Rendering %d deferred draw calls", _LaserDrawCommands.size());
@@ -4819,7 +4821,7 @@ void EffectsRenderer::RenderLasers()
 	// Clear the command list and restore the previous state
 	_LaserDrawCommands.clear();
 	RestoreContext();
-	_deviceResources->_d3dAnnotation->EndEvent();
+	_deviceResources->EndAnnotatedEvent();
 }
 
 void EffectsRenderer::RenderTransparency()
@@ -4827,7 +4829,7 @@ void EffectsRenderer::RenderTransparency()
 	if (_TransparentDrawCommands.size() == 0)
 		return;
 
-	_deviceResources->_d3dAnnotation->BeginEvent(L"RenderTransparency");
+	_deviceResources->BeginAnnotatedEvent(L"RenderTransparencyAndDC");
 
 	auto &resources = _deviceResources;
 	auto &context = resources->_d3dDeviceContext;
@@ -4905,7 +4907,7 @@ void EffectsRenderer::RenderTransparency()
 	_TransparentDrawCommands.clear();
 	RestoreContext();
 
-	_deviceResources->_d3dAnnotation->EndEvent();
+	_deviceResources->EndAnnotatedEvent();
 }
 
 /*
@@ -5074,7 +5076,7 @@ Matrix4 EffectsRenderer::GetShadowMapLimits(const AABB &aabb, float *range, floa
 
 void EffectsRenderer::RenderCockpitShadowMap()
 {
-	_deviceResources->_d3dAnnotation->BeginEvent(L"RenderCockpitShadowMap");
+	_deviceResources->BeginAnnotatedEvent(L"RenderCockpitShadowMap");
 	auto &resources = _deviceResources;
 	auto &context = resources->_d3dDeviceContext;
 	D3D11_DEPTH_STENCIL_DESC desc;
@@ -5205,12 +5207,12 @@ void EffectsRenderer::RenderCockpitShadowMap()
 	_bShadowsRenderedInCurrentFrame = true;
 
 out:
-	_deviceResources->_d3dAnnotation->EndEvent();
+	_deviceResources->EndAnnotatedEvent();
 }
 
 void EffectsRenderer::RenderHangarShadowMap()
 {
-	_deviceResources->_d3dAnnotation->BeginEvent(L"RenderHangarShadowMap");
+	_deviceResources->BeginAnnotatedEvent(L"RenderHangarShadowMap");
 	auto &resources = _deviceResources;
 	auto &context = resources->_d3dDeviceContext;
 	D3D11_DEPTH_STENCIL_DESC desc;
@@ -5351,7 +5353,7 @@ void EffectsRenderer::RenderHangarShadowMap()
 	_ShadowMapDrawCommands.clear();
 
 out:
-	_deviceResources->_d3dAnnotation->EndEvent();
+	_deviceResources->EndAnnotatedEvent();
 }
 
 void EffectsRenderer::StartCascadedShadowMap()
@@ -5596,12 +5598,12 @@ void EffectsRenderer::HangarShadowSceneHook(const SceneCompData* scene)
  */
 void EffectsRenderer::RenderDeferredDrawCalls()
 {
-	_deviceResources->_d3dAnnotation->BeginEvent(L"RenderDeferredDrawCalls");
+	_deviceResources->BeginAnnotatedEvent(L"RenderDeferredDrawCalls");
 	// All the calls below should be rendered with RendererType_Main
 	g_rendererType = RendererType_Main;
 	RenderCockpitShadowMap();
 	RenderHangarShadowMap();
 	RenderLasers();
 	RenderTransparency();
-	_deviceResources->_d3dAnnotation->EndEvent();
+	_deviceResources->EndAnnotatedEvent();
 }

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -4680,8 +4680,6 @@ void EffectsRenderer::RenderScene()
 	if (g_rendererType == RendererType_Shadow && !g_config.HangarShadowsEnabled)
 		return;
 
-	_deviceResources->_d3dAnnotation->BeginEvent(L"RenderScene");
-
 	auto &context = _deviceResources->_d3dDeviceContext;
 
 	unsigned short scissorLeft = *(unsigned short*)0x07D5244;
@@ -4730,7 +4728,6 @@ void EffectsRenderer::RenderScene()
 	g_iD3DExecuteCounter++;
 	g_iDrawCounter++; // We need this counter to enable proper Tech Room detection
 
-	_deviceResources->_d3dAnnotation->EndEvent();
 }
 
 void EffectsRenderer::RenderLasers()

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -4425,11 +4425,12 @@ out:
 
 	// Decrease the refcount of all the objects we queried at the prologue. (Is this
 	// really necessary? They live on the stack, so maybe they are auto-released?)
+	/*
 	oldVSConstantBuffer.Release();
 	oldPSConstantBuffer.Release();
 	for (int i = 0; i < 3; i++)
 		oldVSSRV[i].Release();
-
+	*/
 	/*
 	if (bModifiedBlendState) {
 		RestoreBlendState();

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -3059,7 +3059,9 @@ void PrimarySurface::DeferredPass()
 		context->DrawInstanced(6, g_bUseSteamVR ? 2 : 1, 0, 0);
 	}
 
-
+	// Clear RT SRVs slots that are only used for the shadows to avoid DirectX errors
+	ID3D11ShaderResourceView* srvs[] = { NULL, NULL, NULL, NULL };
+	context->PSSetShaderResources(14, 4, srvs);
 
 	// Restore previous rendertarget, etc
 	// TODO: Is this really needed?

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -990,7 +990,7 @@ void PrimarySurface::barrelEffect3D() {
 		wchar_t filename[120];
 
 		swprintf_s(filename, 120, L"c:\\temp\\offscreenBuf-%d.jpg", frame);
-		capture(0, this->_deviceResources->_offscreenBuffer, filename);
+		capture(0, this->_deviceresources->_offscreenBuffer, filename);
 
 		swprintf_s(filename, 120, L"c:\\temp\\offscreenBuf2-%d.jpg", frame);
 		capture(0, this->_deviceResources->_offscreenBuffer2, filename);
@@ -1077,7 +1077,7 @@ void PrimarySurface::barrelEffectSteamVR() {
 
 		log_debug("[DBG] Capturing buffers");
 		swprintf_s(filename, 120, L"c:\\temp\\offscreenBuf-%d.jpg", frame);
-		capture(0, this->_deviceResources->_offscreenBuffer, filename);
+		capture(0, this->_deviceresources->_offscreenBuffer, filename);
 
 		swprintf_s(filename, 120, L"c:\\temp\\offscreenBufAsInput-%d.jpg", frame);
 		capture(0, this->_deviceResources->_offscreenBufferAsInput, filename);
@@ -1274,8 +1274,9 @@ void PrimarySurface::resizeForSteamVR(int iteration, bool is_2D) {
 	resources->InitPixelShader(resources->_steamVRMirrorPixelShader);
 
 	context->ClearRenderTargetView(resources->_renderTargetViewSteamVRResize, bgColor);
-	context->OMSetRenderTargets(1, resources->_renderTargetViewSteamVRResize.GetAddressOf(),
-		resources->_depthStencilViewL.Get());
+	/*context->OMSetRenderTargets(1, resources->_renderTargetViewSteamVRResize.GetAddressOf(),
+		resources->_depthStencilViewL.Get());*/
+	context->OMSetRenderTargets(1, resources->_renderTargetViewSteamVRResize.GetAddressOf(),nullptr);
 	if (g_bSteamVRMirrorWindowLeftEye) {
 		resources->InitPSShaderResourceView(resources->_offscreenAsInputShaderResourceView);
 	}
@@ -1298,8 +1299,9 @@ void PrimarySurface::resizeForSteamVR(int iteration, bool is_2D) {
 			resources->InitPixelShader(resources->_steamVRMirrorPixelShader);
 
 			context->ClearRenderTargetView(resources->_renderTargetViewSteamVROverlayResize, bgColor);
-			context->OMSetRenderTargets(1, resources->_renderTargetViewSteamVROverlayResize.GetAddressOf(),
-				resources->_depthStencilViewL.Get());
+			/*context->OMSetRenderTargets(1, resources->_renderTargetViewSteamVROverlayResize.GetAddressOf(),
+				resources->_depthStencilViewL.Get());*/
+			context->OMSetRenderTargets(1, resources->_renderTargetViewSteamVROverlayResize.GetAddressOf(),nullptr);
 			context->DrawIndexed(6, 0, 0);
 		}
 	}
@@ -1329,7 +1331,7 @@ void PrimarySurface::resizeForSteamVR(int iteration, bool is_2D) {
 		static int frame = 0;
 		wchar_t filename[120];
 		swprintf_s(filename, 120, L"c:\\temp\\offscreenBuf-%d.jpg", frame);
-		capture(0, this->_deviceResources->_offscreenBuffer, filename);
+		capture(0, this->_deviceresources->_offscreenBuffer, filename);
 
 		swprintf_s(filename, 120, L"c:\\temp\\offscreenBufAsInput-%d.jpg", frame);
 		capture(0, this->_deviceResources->_offscreenBufferAsInput, filename);
@@ -1930,7 +1932,7 @@ void PrimarySurface::DrawHUDVertices() {
 	viewport.MaxDepth = D3D11_MAX_DEPTH;
 	resources->InitViewport(&viewport);
 	// Set the left projection matrix
-	g_VSMatrixCB.projEye = g_FullProjMatrixLeft;
+	g_VSMatrixCB.projEye[0] = g_FullProjMatrixLeft;
 	// The viewMatrix is set at the beginning of the frame
 	resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
 	// Set the HUD foreground, background and Text textures:
@@ -1972,7 +1974,7 @@ void PrimarySurface::DrawHUDVertices() {
 	viewport.MaxDepth = D3D11_MAX_DEPTH;
 	resources->InitViewport(&viewport);
 	// Set the right projection matrix
-	g_VSMatrixCB.projEye = g_FullProjMatrixRight;
+	g_VSMatrixCB.projEye[0] = g_FullProjMatrixRight;
 	resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
 	// Draw the Right Image
 	//if (RenderHUD)
@@ -2806,27 +2808,27 @@ void PrimarySurface::SSDOPass(float fZoomFactor, float fZoomFactor2) {
 
 		//context->ClearRenderTargetView(resources->_renderTargetViewEmissionMask.Get(), black);
 		if (g_bShowSSAODebug && !g_bBlurSSAO && !g_bEnableIndirectSSDO) {
-			ID3D11RenderTargetView *rtvs[2] = {
+			ID3D11RenderTargetView *rtvs[1] = {
 				resources->_renderTargetView.Get(),
-				resources->_renderTargetViewBentBuf.Get(),
+				//resources->_renderTargetViewBentBuf.Get(),
 				//resources->_renderTargetViewEmissionMask.Get(),
 			};
 			context->ClearRenderTargetView(resources->_renderTargetView, black);
-			context->ClearRenderTargetView(resources->_renderTargetViewBentBuf, black);
-			context->OMSetRenderTargets(2, rtvs, NULL);
+			//context->ClearRenderTargetView(resources->_renderTargetViewBentBuf, black);
+			context->OMSetRenderTargets(1, rtvs, NULL);
 			context->PSSetShaderResources(0, 5, srvs_pass1);
 			context->Draw(6, 0);
 			goto out1;
 		}
 		else {
-			ID3D11RenderTargetView *rtvs[2] = {
+			ID3D11RenderTargetView *rtvs[1] = {
 				resources->_renderTargetViewSSAO.Get(),
-				resources->_renderTargetViewBentBuf.Get(),
+				//resources->_renderTargetViewBentBuf.Get(),
 				//resources->_renderTargetViewEmissionMask.Get(),
 			};
 			context->ClearRenderTargetView(resources->_renderTargetViewSSAO, black);
-			context->ClearRenderTargetView(resources->_renderTargetViewBentBuf, black);
-			context->OMSetRenderTargets(2, rtvs, NULL);
+			//context->ClearRenderTargetView(resources->_renderTargetViewBentBuf, black);
+			context->OMSetRenderTargets(1, rtvs, NULL);
 			context->PSSetShaderResources(0, 5, srvs_pass1);
 			context->Draw(6, 0);
 		}
@@ -2873,16 +2875,17 @@ void PrimarySurface::SSDOPass(float fZoomFactor, float fZoomFactor2) {
 			//context->CopyResource(resources->_offscreenBufferAsInput, resources->_ssEmissionMask);
 			// Here I'm reusing bentBufR as a temporary buffer for bentBuf, in the SteamVR path I'll do
 			// the opposite. This is just to avoid having to make a temporary buffer to blur the bent normals.
-			context->CopyResource(resources->_bentBufR, resources->_bentBuf);
-			// Clear the destination buffers: the blur will re-populate them
+			//context->CopyResource(resources->_bentBufR, resources->_bentBuf);
+
+			//Clear the destination buffers: the blur will re-populate them
 			context->ClearRenderTargetView(resources->_renderTargetViewSSAO.Get(), black);
-			context->ClearRenderTargetView(resources->_renderTargetViewBentBuf.Get(), black);
+			//context->ClearRenderTargetView(resources->_renderTargetViewBentBuf.Get(), black);
 			ID3D11ShaderResourceView *srvs[4] = {
 					//resources->_offscreenAsInputShaderResourceView.Get(), // LDR
 					resources->_bloomOutput1SRV.Get(), // HDR
 					resources->_depthBufSRV.Get(),
 					resources->_normBufSRV.Get(),
-					resources->_bentBufSRV_R.Get(),
+					//resources->_bentBufSRV_R.Get(),
 					//resources->_offscreenAsInputShaderResourceView.Get(), // emission mask
 			};
 			if (g_bShowSSAODebug && i == g_iSSAOBlurPasses - 1 && !g_bEnableIndirectSSDO && 	g_SSAO_Type != SSO_BENT_NORMALS) {
@@ -2893,7 +2896,7 @@ void PrimarySurface::SSDOPass(float fZoomFactor, float fZoomFactor2) {
 				// Alternatively, we could change renderTargetViewBentBuf to be MSAA too, just like I did for ssMaskMSAA, etc; but... eh...
 				ID3D11RenderTargetView *rtvs[2] = {
 					resources->_renderTargetView.Get(), // resources->_renderTargetViewSSAO.Get(),
-					resources->_useMultisampling ? NULL : resources->_renderTargetViewBentBuf.Get(),
+					//resources->_useMultisampling ? NULL : resources->_renderTargetViewBentBuf.Get(),
 					//resources->_useMultisampling ? NULL : resources->_renderTargetViewEmissionMask.Get(),
 				};
 				context->OMSetRenderTargets(2, rtvs, NULL);
@@ -2909,7 +2912,7 @@ void PrimarySurface::SSDOPass(float fZoomFactor, float fZoomFactor2) {
 			else {
 				ID3D11RenderTargetView *rtvs[2] = {
 					resources->_renderTargetViewSSAO.Get(),
-					resources->_renderTargetViewBentBuf.Get(),
+					//resources->_renderTargetViewBentBuf.Get(),
 					//resources->_renderTargetViewEmissionMask.Get(),
 				};
 				context->OMSetRenderTargets(2, rtvs, NULL);
@@ -3076,7 +3079,7 @@ void PrimarySurface::SSDOPass(float fZoomFactor, float fZoomFactor2) {
 
 			resources->_depthBufSRV.Get(),							// Depth buffer
 			resources->_normBufSRV.Get(),							// Normals buffer
-			resources->_bentBufSRV.Get(),							// Bent Normals
+			//resources->_bentBufSRV.Get(),							// Bent Normals
 			resources->_ssMaskSRV.Get(),							// Shading System Mask buffer
 
 			g_ShadowMapping.bEnabled ? 
@@ -3120,7 +3123,7 @@ out1:
 			if (g_bShowSSAODebug && !g_bBlurSSAO && !g_bEnableIndirectSSDO) {
 				ID3D11RenderTargetView *rtvs[2] = {
 					resources->_renderTargetViewR.Get(),
-					resources->_renderTargetViewBentBufR.Get(),
+					//resources->_renderTargetViewBentBufR.Get(),
 				};
 				context->ClearRenderTargetView(resources->_renderTargetViewR, black);
 				context->ClearRenderTargetView(resources->_renderTargetViewBentBufR, black);
@@ -3132,10 +3135,10 @@ out1:
 			else {
 				ID3D11RenderTargetView *rtvs[2] = {
 					resources->_renderTargetViewSSAO_R.Get(),
-					resources->_renderTargetViewBentBufR.Get()
+					//resources->_renderTargetViewBentBufR.Get()
 				};
 				context->ClearRenderTargetView(resources->_renderTargetViewSSAO_R, black);
-				context->ClearRenderTargetView(resources->_renderTargetViewBentBufR, black);
+				//context->ClearRenderTargetView(resources->_renderTargetViewBentBufR, black);
 				context->OMSetRenderTargets(2, rtvs, NULL);
 				context->PSSetShaderResources(0, 5, srvs_pass1);
 				context->Draw(6, 0);
@@ -3181,23 +3184,24 @@ out1:
 				context->CopyResource(resources->_bloomOutput1, resources->_ssaoBufR);
 				// Here I'm reusing bentBuf as a temporary buffer for bentBufR
 				// This is just to avoid having to make a temporary buffer to blur the bent normals.
-				context->CopyResource(resources->_bentBuf, resources->_bentBufR);
+				//context->CopyResource(resources->_bentBuf, resources->_bentBufR);
+
 				// Clear the destination buffers: the blur will re-populate them
 				context->ClearRenderTargetView(resources->_renderTargetViewSSAO_R.Get(), black);
-				context->ClearRenderTargetView(resources->_renderTargetViewBentBufR.Get(), black);
+				//context->ClearRenderTargetView(resources->_renderTargetViewBentBufR.Get(), black);
 				ID3D11ShaderResourceView *srvs[4] = {
 						//resources->_offscreenAsInputShaderResourceViewR.Get(), // LDR
 						resources->_bloomOutput1SRV.Get(), // HDR
 						resources->_depthBufSRV_R.Get(),
 						resources->_normBufSRV_R.Get(),
-						resources->_bentBufSRV.Get(),
+						//resources->_bentBufSRV.Get(),
 				};
 				if (g_bShowSSAODebug && i == g_iSSAOBlurPasses - 1 && !g_bEnableIndirectSSDO) {
 					context->ClearRenderTargetView(resources->_renderTargetViewR, black);
 					// Don't mix MSAA and non-MSAA RTVs:
 					ID3D11RenderTargetView *rtvs[2] = {
 						resources->_renderTargetViewR.Get(), // resources->_renderTargetViewSSAO_R.Get(),
-						resources->_useMultisampling ? NULL : resources->_renderTargetViewBentBufR.Get(),
+						//resources->_useMultisampling ? NULL : resources->_renderTargetViewBentBufR.Get(),
 					};
 					context->OMSetRenderTargets(2, rtvs, NULL);
 					context->PSSetShaderResources(0, 4, srvs);
@@ -3211,7 +3215,7 @@ out1:
 				else {
 					ID3D11RenderTargetView *rtvs[2] = {
 						resources->_renderTargetViewSSAO_R.Get(),
-						resources->_renderTargetViewBentBufR.Get()
+						//resources->_renderTargetViewBentBufR.Get()
 					};
 					context->OMSetRenderTargets(2, rtvs, NULL);
 					context->PSSetShaderResources(0, 4, srvs);
@@ -3365,7 +3369,7 @@ out1:
 
 				resources->_depthBufSRV_R.Get(),						// Depth buffer
 				resources->_normBufSRV_R.Get(),							// Normals buffer
-				resources->_bentBufSRV_R.Get(),							// Bent Normals
+				//resources->_bentBufSRV_R.Get(),							// Bent Normals
 				resources->_ssMaskSRV_R.Get(),							// Shading System Mask buffer
 
 				g_ShadowMapping.bEnabled ?
@@ -4823,7 +4827,7 @@ void PrimarySurface::RenderHyperspaceEffect(D3D11_VIEWPORT *lastViewport,
 		g_VSCBuffer.scale_override = 1.0f;
 
 		// Set the left projection matrix (the viewMatrix is set at the beginning of the frame)
-		g_VSMatrixCB.projEye = g_FullProjMatrixLeft;
+		g_VSMatrixCB.projEye[0] = g_FullProjMatrixLeft;
 
 		resources->InitVSConstantBuffer3D(resources->_VSConstantBuffer.GetAddressOf(), &g_VSCBuffer);
 		resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
@@ -4859,7 +4863,7 @@ void PrimarySurface::RenderHyperspaceEffect(D3D11_VIEWPORT *lastViewport,
 			viewport.MaxDepth = D3D11_MAX_DEPTH;
 			resources->InitViewport(&viewport);
 			// Set the right projection matrix
-			g_VSMatrixCB.projEye = g_FullProjMatrixRight;
+			g_VSMatrixCB.projEye[0] = g_FullProjMatrixRight;
 			resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
 
 			context->OMSetRenderTargets(1, resources->_renderTargetViewPostR.GetAddressOf(), NULL);
@@ -4926,7 +4930,7 @@ void PrimarySurface::RenderHyperspaceEffect(D3D11_VIEWPORT *lastViewport,
 		g_VSCBuffer.scale_override	= 1.0f;
 
 		// Set the left projection matrix (the viewMatrix is set at the beginning of the frame)
-		g_VSMatrixCB.projEye = g_FullProjMatrixLeft;
+		g_VSMatrixCB.projEye[0] = g_FullProjMatrixLeft;
 		resources->InitVSConstantBuffer3D(resources->_VSConstantBuffer.GetAddressOf(), &g_VSCBuffer);
 		//resources->InitPSConstantBuffer3D(resources->_PSConstantBuffer.GetAddressOf(), &g_PSCBuffer);
 		resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
@@ -4967,7 +4971,7 @@ void PrimarySurface::RenderHyperspaceEffect(D3D11_VIEWPORT *lastViewport,
 			viewport.MaxDepth = D3D11_MAX_DEPTH;
 			resources->InitViewport(&viewport);
 			// Set the right projection matrix
-			g_VSMatrixCB.projEye = g_FullProjMatrixRight;
+			g_VSMatrixCB.projEye[0] = g_FullProjMatrixRight;
 			resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
 
 			if (g_bUseSteamVR)
@@ -5459,7 +5463,7 @@ void PrimarySurface::RenderStarDebug()
 			g_VSCBuffer.bPreventTransform = 1.0f;
 
 		// Set the left projection matrix (the viewMatrix is set at the beginning of the frame)
-		g_VSMatrixCB.projEye = g_FullProjMatrixLeft;
+		g_VSMatrixCB.projEye[0] = g_FullProjMatrixLeft;
 		resources->InitVSConstantBuffer3D(resources->_VSConstantBuffer.GetAddressOf(), &g_VSCBuffer);
 		resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
 
@@ -5506,7 +5510,7 @@ void PrimarySurface::RenderStarDebug()
 			viewport.MaxDepth = D3D11_MAX_DEPTH;
 			resources->InitViewport(&viewport);
 			// Set the right projection matrix
-			g_VSMatrixCB.projEye = g_FullProjMatrixRight;
+			g_VSMatrixCB.projEye[0] = g_FullProjMatrixRight;
 			resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
 
 			if (g_bUseSteamVR) {
@@ -5799,7 +5803,7 @@ void PrimarySurface::RenderExternalHUD()
 			g_VSCBuffer.bPreventTransform = 1.0f;
 
 		// Set the left projection matrix (the viewMatrix is set at the beginning of the frame)
-		g_VSMatrixCB.projEye = g_FullProjMatrixLeft;
+		g_VSMatrixCB.projEye[0] = g_FullProjMatrixLeft;
 		resources->InitVSConstantBuffer3D(resources->_VSConstantBuffer.GetAddressOf(), &g_VSCBuffer);
 		resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
 
@@ -5847,7 +5851,7 @@ void PrimarySurface::RenderExternalHUD()
 			viewport.MaxDepth = D3D11_MAX_DEPTH;
 			resources->InitViewport(&viewport);
 			// Set the right projection matrix
-			g_VSMatrixCB.projEye = g_FullProjMatrixRight;
+			g_VSMatrixCB.projEye[0] = g_FullProjMatrixRight;
 			resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
 
 			if (g_bUseSteamVR) {
@@ -6321,7 +6325,7 @@ void PrimarySurface::RenderSpeedEffect()
 		}
 
 		// Set the left projection matrix (the viewMatrix is set at the beginning of the frame)
-		g_VSMatrixCB.projEye = g_FullProjMatrixLeft;
+		g_VSMatrixCB.projEye[0] = g_FullProjMatrixLeft;
 		resources->InitVSConstantBuffer3D(resources->_VSConstantBuffer.GetAddressOf(), &g_VSCBuffer);
 		resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
 
@@ -6350,7 +6354,7 @@ void PrimarySurface::RenderSpeedEffect()
 			viewport.MaxDepth = D3D11_MAX_DEPTH;
 			resources->InitViewport(&viewport);
 			// Set the right projection matrix
-			g_VSMatrixCB.projEye = g_FullProjMatrixRight;
+			g_VSMatrixCB.projEye[0] = g_FullProjMatrixRight;
 			resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
 
 			if (g_bUseSteamVR)
@@ -6781,7 +6785,7 @@ void PrimarySurface::RenderAdditionalGeometry()
 		}
 
 		// Set the left projection matrix (the viewMatrix is set at the beginning of the frame)
-		g_VSMatrixCB.projEye = g_FullProjMatrixLeft;
+		g_VSMatrixCB.projEye[0] = g_FullProjMatrixLeft;
 		resources->InitVSConstantBuffer3D(resources->_VSConstantBuffer.GetAddressOf(), &g_VSCBuffer);
 		resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
 
@@ -6811,7 +6815,7 @@ void PrimarySurface::RenderAdditionalGeometry()
 			viewport.MaxDepth = D3D11_MAX_DEPTH;
 			resources->InitViewport(&viewport);
 			// Set the right projection matrix
-			g_VSMatrixCB.projEye = g_FullProjMatrixRight;
+			g_VSMatrixCB.projEye[0] = g_FullProjMatrixRight;
 			resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
 
 			if (g_bUseSteamVR)
@@ -7562,7 +7566,7 @@ void PrimarySurface::RenderSunFlare()
 		g_VSCBuffer.scale_override = 1.0f;
 
 		// Set the left projection matrix (the viewMatrix is set at the beginning of the frame)
-		g_VSMatrixCB.projEye = g_FullProjMatrixLeft;
+		g_VSMatrixCB.projEye[0] = g_FullProjMatrixLeft;
 		resources->InitVSConstantBuffer3D(resources->_VSConstantBuffer.GetAddressOf(), &g_VSCBuffer);
 		resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
 
@@ -7608,7 +7612,7 @@ void PrimarySurface::RenderSunFlare()
 			viewport.MaxDepth = D3D11_MAX_DEPTH;
 			resources->InitViewport(&viewport);
 			// Set the right projection matrix
-			g_VSMatrixCB.projEye = g_FullProjMatrixRight;
+			g_VSMatrixCB.projEye[0] = g_FullProjMatrixRight;
 			resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
 
 			if (g_bUseSteamVR) {
@@ -8547,7 +8551,7 @@ nochange:
 		g_VSCBuffer.scale_override = 1.0f;
 
 		// Set the left projection matrix (the viewMatrix is set at the beginning of the frame)
-		g_VSMatrixCB.projEye = g_FullProjMatrixLeft;
+		g_VSMatrixCB.projEye[0] = g_FullProjMatrixLeft;
 		resources->InitVSConstantBuffer3D(resources->_VSConstantBuffer.GetAddressOf(), &g_VSCBuffer);
 		resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
 
@@ -9034,7 +9038,7 @@ HRESULT PrimarySurface::Flip(
 				for (UINT i = 0; i < interval; i++)
 				{
 					// In the original code the offscreenBuffer is simply resolved into the backBuffer.
-					// this->_deviceResources->_d3dDeviceContext->ResolveSubresource(this->_deviceResources->_backBuffer, 0, this->_deviceResources->_offscreenBuffer, 0, BACKBUFFER_FORMAT);
+					// this->_deviceResources->_d3dDeviceContext->ResolveSubresource(this->_deviceResources->_backBuffer, 0, this->_deviceresources->_offscreenBuffer, 0, BACKBUFFER_FORMAT);
 
 					if (!g_bDisableBarrelEffect && g_bEnableVR && !g_bUseSteamVR) {
 						// Barrel effect enabled for DirectSBS mode.
@@ -9508,7 +9512,7 @@ HRESULT PrimarySurface::Flip(
 					//DirectX::SaveWICTextureToFile(context, resources->_offscreenBuffer, GUID_ContainerFormatJpeg, L"C:\\Temp\\_offscreenBuffer.jpg");
 					DirectX::SaveDDSTextureToFile(context, resources->_offscreenBufferAsInputBloomMask, L"C:\\Temp\\_bloomMask2.dds");
 					//DirectX::SaveDDSTextureToFile(context, resources->_bentBuf, L"C:\\Temp\\_bentBuf.dds");
-					DirectX::SaveWICTextureToFile(context, resources->_bentBuf, GUID_ContainerFormatJpeg, L"C:\\Temp\\_bentBuf.jpg");
+					//DirectX::SaveWICTextureToFile(context, resources->_bentBuf, GUID_ContainerFormatJpeg, L"C:\\Temp\\_bentBuf.jpg");
 					DirectX::SaveDDSTextureToFile(context, resources->_ssaoBuf, L"C:\\Temp\\_ssaoBuf.dds");
 					//DirectX::SaveWICTextureToFile(context, resources->_ssaoBufR, GUID_ContainerFormatJpeg, L"C:\\Temp\\_ssaoBufR.jpg");
 					DirectX::SaveDDSTextureToFile(context, resources->_ssaoBufR, L"C:\\Temp\\_ssaoBufR.dds");
@@ -9886,7 +9890,7 @@ HRESULT PrimarySurface::Flip(
 				g_bDumpLaserPointerDebugInfo = false;
 
 			// In the original code, the offscreenBuffer is resolved to the backBuffer
-			//this->_deviceResources->_d3dDeviceContext->ResolveSubresource(this->_deviceResources->_backBuffer, 0, this->_deviceResources->_offscreenBuffer, 0, BACKBUFFER_FORMAT);
+			//this->_deviceResources->_d3dDeviceContext->ResolveSubresource(this->_deviceResources->_backBuffer, 0, this->_deviceresources->_offscreenBuffer, 0, BACKBUFFER_FORMAT);
 
 			if (g_bDumpSSAOBuffers && !g_bAOEnabled) {
 				log_debug("[DBG] SSAO Disabled. Dumping buffers");

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -2880,7 +2880,7 @@ void PrimarySurface::SSDOPass(float fZoomFactor, float fZoomFactor2) {
 			//Clear the destination buffers: the blur will re-populate them
 			context->ClearRenderTargetView(resources->_renderTargetViewSSAO.Get(), black);
 			//context->ClearRenderTargetView(resources->_renderTargetViewBentBuf.Get(), black);
-			ID3D11ShaderResourceView *srvs[4] = {
+			ID3D11ShaderResourceView *srvs[3] = {
 					//resources->_offscreenAsInputShaderResourceView.Get(), // LDR
 					resources->_bloomOutput1SRV.Get(), // HDR
 					resources->_depthBufSRV.Get(),
@@ -2894,13 +2894,13 @@ void PrimarySurface::SSDOPass(float fZoomFactor, float fZoomFactor2) {
 				// If both are set and MSAA is active, nothing gets rendered -- even with a NULL depth stencil.
 				// The solution here is to avoid setting the renderTargetViewBentBuf if MSAA is active
 				// Alternatively, we could change renderTargetViewBentBuf to be MSAA too, just like I did for ssMaskMSAA, etc; but... eh...
-				ID3D11RenderTargetView *rtvs[2] = {
+				ID3D11RenderTargetView *rtvs[1] = {
 					resources->_renderTargetView.Get(), // resources->_renderTargetViewSSAO.Get(),
 					//resources->_useMultisampling ? NULL : resources->_renderTargetViewBentBuf.Get(),
 					//resources->_useMultisampling ? NULL : resources->_renderTargetViewEmissionMask.Get(),
 				};
-				context->OMSetRenderTargets(2, rtvs, NULL);
-				context->PSSetShaderResources(0, 4, srvs);
+				context->OMSetRenderTargets(1, rtvs, NULL);
+				context->PSSetShaderResources(0, 3, srvs);
 				// DEBUG: Enable the following line to display the bent normals (it will also blur the bent normals buffer
 				//context->PSSetShaderResources(0, 1, resources->_bentBufSRV.GetAddressOf());
 				// DEBUG: Enable the following line to display the normals
@@ -2910,13 +2910,13 @@ void PrimarySurface::SSDOPass(float fZoomFactor, float fZoomFactor2) {
 				goto out1;
 			}
 			else {
-				ID3D11RenderTargetView *rtvs[2] = {
+				ID3D11RenderTargetView *rtvs[1] = {
 					resources->_renderTargetViewSSAO.Get(),
 					//resources->_renderTargetViewBentBuf.Get(),
 					//resources->_renderTargetViewEmissionMask.Get(),
 				};
-				context->OMSetRenderTargets(2, rtvs, NULL);
-				context->PSSetShaderResources(0, 4, srvs);
+				context->OMSetRenderTargets(1, rtvs, NULL);
+				context->PSSetShaderResources(0, 3, srvs);
 				context->Draw(6, 0);
 			}
 		}
@@ -3060,18 +3060,18 @@ void PrimarySurface::SSDOPass(float fZoomFactor, float fZoomFactor2) {
 		resources->InitViewport(&viewport);
 		// ssaoBuf was bound as an RTV, so let's bind the RTV first to unbind ssaoBuf
 		// so that it can be used as an SRV
-		ID3D11RenderTargetView *rtvs[5] = {
+		ID3D11RenderTargetView *rtvs[2] = {
 			resources->_renderTargetView.Get(),			 // MSAA
 			resources->_renderTargetViewBloomMask.Get(), // MSAA
-			NULL, //resources->_renderTargetViewBentBuf.Get(), // DEBUG REMOVE THIS LATER! Non-MSAA
-			NULL, NULL,
+			//NULL, //resources->_renderTargetViewBentBuf.Get(), // DEBUG REMOVE THIS LATER! Non-MSAA
+			//NULL, NULL,
 		};
-		context->OMSetRenderTargets(5, rtvs, NULL);
+		context->OMSetRenderTargets(2, rtvs, NULL);
 		// Resolve offscreenBuf
 		context->ResolveSubresource(resources->_offscreenBufferAsInput, 0, resources->_offscreenBuffer,
 			0, BACKBUFFER_FORMAT);
 
-		ID3D11ShaderResourceView *srvs_pass2[9] = {
+		ID3D11ShaderResourceView *srvs_pass2[8] = {
 			resources->_offscreenAsInputShaderResourceView.Get(),	// Color buffer
 			resources->_ssaoBufSRV.Get(),							// SSDO Direct Component
 			resources->_ssaoBufSRV_R.Get(),							// SSDO Indirect
@@ -3085,7 +3085,7 @@ void PrimarySurface::SSDOPass(float fZoomFactor, float fZoomFactor2) {
 			g_ShadowMapping.bEnabled ? 
 				resources->_shadowMapArraySRV.Get() : NULL,			// The shadow map
 		};
-		context->PSSetShaderResources(0, 9, srvs_pass2);
+		context->PSSetShaderResources(0, 8, srvs_pass2);
 		context->Draw(6, 0);
 	}
 
@@ -3121,25 +3121,25 @@ out1:
 			
 			resources->InitPixelShader(resources->_ssdoDirectPS);
 			if (g_bShowSSAODebug && !g_bBlurSSAO && !g_bEnableIndirectSSDO) {
-				ID3D11RenderTargetView *rtvs[2] = {
+				ID3D11RenderTargetView *rtvs[1] = {
 					resources->_renderTargetViewR.Get(),
 					//resources->_renderTargetViewBentBufR.Get(),
 				};
 				context->ClearRenderTargetView(resources->_renderTargetViewR, black);
 				context->ClearRenderTargetView(resources->_renderTargetViewBentBufR, black);
-				context->OMSetRenderTargets(2, rtvs, NULL);
+				context->OMSetRenderTargets(1, rtvs, NULL);
 				context->PSSetShaderResources(0, 5, srvs_pass1);
 				context->Draw(6, 0);
 				goto out2;
 			}
 			else {
-				ID3D11RenderTargetView *rtvs[2] = {
+				ID3D11RenderTargetView *rtvs[1] = {
 					resources->_renderTargetViewSSAO_R.Get(),
 					//resources->_renderTargetViewBentBufR.Get()
 				};
 				context->ClearRenderTargetView(resources->_renderTargetViewSSAO_R, black);
 				//context->ClearRenderTargetView(resources->_renderTargetViewBentBufR, black);
-				context->OMSetRenderTargets(2, rtvs, NULL);
+				context->OMSetRenderTargets(1, rtvs, NULL);
 				context->PSSetShaderResources(0, 5, srvs_pass1);
 				context->Draw(6, 0);
 			}

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -9597,7 +9597,9 @@ HRESULT PrimarySurface::Flip(
 
 			// Render the enhanced bracket after all the shading has been applied.
 			if (g_config.Radar2DRendererEnabled && !g_bEnableVR)
-				this->RenderBracket();
+			{
+			}
+				//this->RenderBracket();				
 
 			// Draw the reticle on top of everything else
 			if (g_bExternalHUDEnabled || g_bEnableVR)

--- a/impl11/ddraw/SteamVRRenderer.cpp
+++ b/impl11/ddraw/SteamVRRenderer.cpp
@@ -140,38 +140,40 @@ void SteamVRRenderer::RenderScene()
 		};
 		context->OMSetRenderTargets(6, rtvs, resources->_depthStencilViewL.Get());
 
-		// Set the left projection matrix
-		g_VSMatrixCB.projEye = g_FullProjMatrixLeft;
+		// Set the left projection matrix		
+		g_VSMatrixCB.projEye[0] = g_FullProjMatrixLeft;
+		g_VSMatrixCB.projEye[1] = g_FullProjMatrixRight;
 		// The viewMatrix is set at the beginning of the frame
 		resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
 
-		context->DrawIndexed(_trianglesCount * 3, 0, 0);
+		//context->DrawIndexed(_trianglesCount * 3, 0, 0);
+		context->DrawIndexedInstanced(_trianglesCount * 3, 2, 0, 0, 1);
 	}
 
 	// ****************************************************************************
 	// Render the right image
 	// ****************************************************************************
-	{
-		ID3D11RenderTargetView *rtvs[6] = {
-			SelectOffscreenBuffer(_bIsCockpit || _bIsGunner /* || bIsReticle */, true),
-			resources->_renderTargetViewBloomMaskR.Get(),
-			resources->_renderTargetViewDepthBufR.Get(),
-			// The normals hook should not be allowed to write normals for light textures. This is now implemented
-			// in XwaD3dPixelShader
-			_deviceResources->_renderTargetViewNormBufR.Get(),
-			// Blast Marks are confused with glass because they are not shadeless; but they have transparency
-			_bIsBlastMark ? NULL : resources->_renderTargetViewSSAOMaskR.Get(),
-			_bIsBlastMark ? NULL : resources->_renderTargetViewSSMaskR.Get(),
-		};
-		context->OMSetRenderTargets(6, rtvs, resources->_depthStencilViewR.Get());
+	//{
+	//	ID3D11RenderTargetView *rtvs[6] = {
+	//		SelectOffscreenBuffer(_bIsCockpit || _bIsGunner /* || bIsReticle */, true),
+	//		resources->_renderTargetViewBloomMaskR.Get(),
+	//		resources->_renderTargetViewDepthBufR.Get(),
+	//		// The normals hook should not be allowed to write normals for light textures. This is now implemented
+	//		// in XwaD3dPixelShader
+	//		_deviceResources->_renderTargetViewNormBufR.Get(),
+	//		// Blast Marks are confused with glass because they are not shadeless; but they have transparency
+	//		_bIsBlastMark ? NULL : resources->_renderTargetViewSSAOMaskR.Get(),
+	//		_bIsBlastMark ? NULL : resources->_renderTargetViewSSMaskR.Get(),
+	//	};
+	//	context->OMSetRenderTargets(6, rtvs, resources->_depthStencilViewR.Get());
 
-		// Set the right projection matrix
-		g_VSMatrixCB.projEye = g_FullProjMatrixRight;
-		// The viewMatrix is set at the beginning of the frame
-		resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
+	//	// Set the right projection matrix
+	//	g_VSMatrixCB.projEye[0] = g_FullProjMatrixRight;
+	//	// The viewMatrix is set at the beginning of the frame
+	//	resources->InitVSConstantBufferMatrix(resources->_VSMatrixBuffer.GetAddressOf(), &g_VSMatrixCB);
 
-		context->DrawIndexed(_trianglesCount * 3, 0, 0);
-	}
+	//	context->DrawIndexed(_trianglesCount * 3, 0, 0);
+	//}
 
 //out:
 	g_iD3DExecuteCounter++;

--- a/impl11/ddraw/SteamVRRenderer.cpp
+++ b/impl11/ddraw/SteamVRRenderer.cpp
@@ -65,8 +65,6 @@ void SteamVRRenderer::RenderScene()
 		// resources->InitVertexShader(_shadowVertexShaderVR);
 		return;
 
-	_deviceResources->_d3dAnnotation->BeginEvent(L"RenderScene");
-
 	auto &resources = _deviceResources;
 	auto &context = resources->_d3dDeviceContext;
 
@@ -178,6 +176,4 @@ void SteamVRRenderer::RenderScene()
 //out:
 	g_iD3DExecuteCounter++;
 	g_iDrawCounter++; // We need this counter to enable proper Tech Room detection
-
-	_deviceResources->_d3dAnnotation->EndEvent();
 }

--- a/impl11/ddraw/SteamVRRenderer.cpp
+++ b/impl11/ddraw/SteamVRRenderer.cpp
@@ -93,10 +93,6 @@ void SteamVRRenderer::RenderScene()
 	*/
 
 	//_deviceResources->InitScissorRect(&scissor);
-
-	// TODO: Implement instanced rendering so that we issue only one draw call to
-	// render both eyes.
-	// https://github.com/Prof-Butts/xwa_ddraw_d3d11/issues/48
 	
 	// Regular VR path
 	resources->InitVertexShader(_vertexShaderVR);

--- a/impl11/ddraw/XwaD3dRendererHook.cpp
+++ b/impl11/ddraw/XwaD3dRendererHook.cpp
@@ -1714,6 +1714,8 @@ void D3dRenderHyperspaceLinesHook(int A4)
 	g_isInRenderHyperspaceLines = false;
 }
 
+
+// This is hooking 2 calls to the function that processes OptNodes with NodeType==FaceData
 void D3dRendererMainHook(SceneCompData* scene)
 {
 	if (*(int*)0x06628E0 != 0)

--- a/impl11/ddraw/XwaD3dRendererHook.cpp
+++ b/impl11/ddraw/XwaD3dRendererHook.cpp
@@ -273,7 +273,7 @@ void D3dRenderer::SceneBegin(DeviceResources* deviceResources)
 {
 	_deviceResources = deviceResources;
 
-	_deviceResources->_d3dAnnotation->BeginEvent(L"D3dRendererScene");
+	_deviceResources->BeginAnnotatedEvent(L"D3dRendererScene");
 
 	if (!_isInitialized)
 	{
@@ -305,7 +305,7 @@ void D3dRenderer::SceneBegin(DeviceResources* deviceResources)
 
 void D3dRenderer::SceneEnd()
 {
-	_deviceResources->_d3dAnnotation->EndEvent();
+	_deviceResources->EndAnnotatedEvent();
 }
 
 void D3dRenderer::FlightStart()

--- a/impl11/ddraw/dllmain.cpp
+++ b/impl11/ddraw/dllmain.cpp
@@ -1702,7 +1702,8 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
 			// ZIPReader: Load and erase any dangling temporary directories
 			{
 				if (InitZIPReader())
-					DeleteAllTempZIPDirectories();
+					//DeleteAllTempZIPDirectories();
+					break;
 			}
 		}
 		break;

--- a/impl11/shaders/AddGeometryComposePixelShader.hlsl
+++ b/impl11/shaders/AddGeometryComposePixelShader.hlsl
@@ -7,11 +7,11 @@
 #include "ShadertoyCBuffer.h"
 
 // The offscreenBuffer up to this point
-Texture2D    colorTex     : register(t0);
+Texture2DArray    colorTex     : register(t0);
 SamplerState colorSampler : register(s0);
 
 // The effects (trails, additional geometry, etc) buffer up to this point
-Texture2D    effectTex     : register(t1);
+Texture2DArray    effectTex     : register(t1);
 SamplerState effectSampler : register(s1);
 
 /*
@@ -24,6 +24,7 @@ struct PixelShaderInput
 {
 	float4 pos : SV_POSITION;
 	float2 uv  : TEXCOORD;
+	uint viewId: SV_RenderTargetArrayIndex;
 };
 
 struct PixelShaderOutput
@@ -35,8 +36,8 @@ PixelShaderOutput main(PixelShaderInput input)
 {
 	PixelShaderOutput output;
 
-	float4 texColor = colorTex.Sample(colorSampler, input.uv);
-	float4 effectColor = effectTex.Sample(effectSampler, input.uv);
+	float4 texColor = colorTex.Sample(colorSampler, float3(input.uv,input.viewId));
+	float4 effectColor = effectTex.Sample(effectSampler, float3(input.uv, input.viewId));
 
 	// Initialize the result:
 	output.color = texColor;

--- a/impl11/shaders/AddGeometryVertexShader.hlsl
+++ b/impl11/shaders/AddGeometryVertexShader.hlsl
@@ -13,6 +13,7 @@ struct VertexShaderInput
 	float4 color		: COLOR0;
 	float4 normal   : COLOR1;
 	float2 tex		: TEXCOORD;
+	uint instId : SV_InstanceID;
 };
 
 struct PixelShaderInput
@@ -21,6 +22,7 @@ struct PixelShaderInput
 	float4 color		: COLOR0;
 	float4 normal	: COLOR1;
 	float2 tex		: TEXCOORD;
+	uint viewId : SV_RenderTargetArrayIndex;
 };
 
 PixelShaderInput main(VertexShaderInput input)
@@ -67,7 +69,7 @@ PixelShaderInput main(VertexShaderInput input)
 
 		// Project:
 		P.z = -P.z;
-		output.pos = mul(projEyeMatrix, float4(P.xyz, 1.0));
+		output.pos = mul(projEyeMatrix[0], float4(P.xyz, 1.0));
 		
 		/*
 		VR PATH
@@ -116,5 +118,7 @@ PixelShaderInput main(VertexShaderInput input)
 	output.color  = input.color.zyxw;
 	output.tex    = input.tex;
 	output.normal = input.normal;
+	// Pass forward the instance ID to choose the right RTV for each eye
+	output.viewId = input.instId;
 	return output;
 }

--- a/impl11/shaders/AddGeometryVertexShader.hlsl
+++ b/impl11/shaders/AddGeometryVertexShader.hlsl
@@ -69,7 +69,7 @@ PixelShaderInput main(VertexShaderInput input)
 
 		// Project:
 		P.z = -P.z;
-		output.pos = mul(projEyeMatrix[0], float4(P.xyz, 1.0));
+		output.pos = mul(projEyeMatrix[input.instId], float4(P.xyz, 1.0));
 		
 		/*
 		VR PATH

--- a/impl11/shaders/BloomBufferAddPS.hlsl
+++ b/impl11/shaders/BloomBufferAddPS.hlsl
@@ -5,11 +5,11 @@
 // https://learnopengl.com/Advanced-Lighting/Bloom
 
 // This texture slot should be the source bloom buffer
-Texture2D bloomTex0 : register(t0);
+Texture2DArray bloomTex0 : register(t0);
 SamplerState sampler0 : register(s0);
 
 // This texture slot should be a copy of the accummulator
-Texture2D bloomSumTex : register(t1);
+Texture2DArray bloomSumTex : register(t1);
 SamplerState bloomSumSampler : register(s1);
 
 cbuffer ConstantBuffer : register(b2)
@@ -24,13 +24,14 @@ struct PixelShaderInput
 {
 	float4 pos : SV_POSITION;
 	float2 uv : TEXCOORD;
+	uint viewId: SV_RenderTargetArrayIndex;
 };
 
 float4 main(PixelShaderInput input) : SV_TARGET
 {
 	float2 input_uv_sub = input.uv * amplifyFactor;
-	float3 bloom = bloomTex0.Sample(sampler0, input_uv_sub).rgb;
-	float3 bloomSum = bloomSumTex.Sample(bloomSumSampler, input.uv).rgb;
+	float3 bloom = bloomTex0.Sample(sampler0, float3(input_uv_sub, input.viewId)).rgb;
+	float3 bloomSum = bloomSumTex.Sample(bloomSumSampler, float3(input.uv, input.viewId)).rgb;
 
 	// Truncate negative values coming from the bloom texture:
 	return float4(bloomSum.rgb + max(0, bloomStrength * bloom.rgb), 1);

--- a/impl11/shaders/DATVertexShaderVR.hlsl
+++ b/impl11/shaders/DATVertexShaderVR.hlsl
@@ -18,6 +18,7 @@ struct VertexShaderInput
 	float4 color	: COLOR0;
 	float4 specular : COLOR1;
 	float2 tex		: TEXCOORD;
+	uint instId : SV_InstanceID;
 };
 
 struct PixelShaderInput
@@ -27,6 +28,7 @@ struct PixelShaderInput
 	float2 tex      : TEXCOORD0;
 	float4 pos3D    : COLOR1;
 	float4 normal   : NORMAL;
+	uint viewId : SV_RenderTargetArrayIndex;
 };
 
 float3 InverseTransformProjectionScreen(float4 input)
@@ -78,7 +80,7 @@ PixelShaderInput main(VertexShaderInput input)
 		output.pos = mul(viewMatrix, float4(P, 1));
 	else
 		output.pos = mul(fullViewMatrix, float4(P, 1));
-	output.pos = mul(projEyeMatrix, output.pos);
+	output.pos = mul(projEyeMatrix[input.instId], output.pos);
 
 	// At this point, we should be doing:
 	//
@@ -101,5 +103,7 @@ PixelShaderInput main(VertexShaderInput input)
 	output.color  = input.color.zyxw;
 	output.normal = input.specular;
 	output.tex = input.tex;
+	// Pass forward the instance ID to choose the right RTV for each eye
+	output.viewId = input.instId;
 	return output;
 }

--- a/impl11/shaders/ExternalHUDShader.hlsl
+++ b/impl11/shaders/ExternalHUDShader.hlsl
@@ -13,7 +13,7 @@
 #include "metric_common.h"
 
 // The background texture
-Texture2D    bgTex     : register(t0);
+Texture2DArray    bgTex     : register(t0);
 SamplerState bgSampler : register(s0);
 
 // The reticle texture
@@ -32,6 +32,8 @@ struct PixelShaderInput
 	float4 color  : COLOR0;
 	float2 uv     : TEXCOORD0;
 	float4 pos3D  : COLOR1;
+	float4 normal   : NORMAL; // hook_normals.dll populates this field
+	uint viewId   : SV_RenderTargetArrayIndex;
 };
 
 struct PixelShaderOutput
@@ -147,7 +149,7 @@ PixelShaderOutput main(PixelShaderInput input) {
 	// In SBS VR mode, each half-screen receives a full 0..1 uv range. So if we sample the
 	// texture using input.uv, we'll get one SBS image on the left, and one SBS image on the
 	// right. That's 4 images in one screen!
-	if (VRmode == 0) output.color = bgTex.Sample(bgSampler, input.uv);
+	if (VRmode == 0) output.color = bgTex.Sample(bgSampler, float3(input.uv, input.viewId));
 	
 	vec2 p = (2.0 * fragCoord.xy - iResolution.xy) / min(iResolution.x, iResolution.y);
 	p *= preserveAspectRatioComp;

--- a/impl11/shaders/HeadLightsPS.hlsl
+++ b/impl11/shaders/HeadLightsPS.hlsl
@@ -75,7 +75,7 @@ struct PixelShaderOutput
 {
 	float4 color : SV_TARGET0;
 	float4 bloom : SV_TARGET1;
-	float4 bent  : SV_TARGET2;
+	//float4 bent  : SV_TARGET2;
 };
 
 inline float3 getPosition(in float2 uv, in uint viewId, in float level) {
@@ -90,7 +90,7 @@ PixelShaderOutput main(PixelShaderInput input)
 	PixelShaderOutput output;
 	output.color = 0;
 	output.bloom = 0;
-	output.bent = 0;
+	//output.bent = 0;
 
 	float2 input_uv_sub	  = input.uv * amplifyFactor;
 	//float2 input_uv_sub2 = input.uv * amplifyFactor2;

--- a/impl11/shaders/HeadLightsPS.hlsl
+++ b/impl11/shaders/HeadLightsPS.hlsl
@@ -41,8 +41,8 @@ SamplerState samplerNormal : register(s5);
 //SamplerState samplerBent : register(s6);
 
 // The Shading System Mask buffer
-Texture2DArray texSSMask : register(t7);
-SamplerState samplerSSMask : register(s7);
+Texture2DArray texSSMask : register(t6);
+SamplerState samplerSSMask : register(s6);
 
 // The Emission Mask buffer
 //Texture2D texEmissionMask : register(t8);

--- a/impl11/shaders/MainVertexShader.hlsl
+++ b/impl11/shaders/MainVertexShader.hlsl
@@ -18,12 +18,14 @@ struct VertexShaderInput
 {
 	float2 pos : POSITION;
 	float2 tex : TEXCOORD;
+	uint instId : SV_InstanceID;
 };
 
 struct PixelShaderInput
 {
 	float4 pos : SV_POSITION;
 	float2 tex : TEXCOORD;
+	uint viewId : SV_RenderTargetArrayIndex;
 };
 
 /* This shader is used to render the concourse, menu and other 2D elements. */
@@ -42,12 +44,13 @@ PixelShaderInput main(VertexShaderInput input)
 		// Apply the current view matrix
 		P = mul(fullViewMatrix, P);
 		// Project to 2D
-		output.pos = mul(projEyeMatrix, P);
+		output.pos = mul(projEyeMatrix[input.instId], P);
 	} else { // Use this for the original 2D version of the game:
 		output.pos = float4((input.pos.x) * scale * aspect_ratio, input.pos.y * scale, parallax, 1.0f);
 	}
 	output.tex = input.tex;
-
+	// Pass forward the instance ID to choose the right RTV for each eye
+	output.viewId = input.instId;
 	return output;
 }
 

--- a/impl11/shaders/RT/RTShadowMaskPS.hlsl
+++ b/impl11/shaders/RT/RTShadowMaskPS.hlsl
@@ -3,17 +3,18 @@
 #include "../shadow_mapping_common.h"
 
 // The (Smooth) Normals buffer
-Texture2D texNormal : register(t0);
+Texture2DArray texNormal : register(t0);
 SamplerState samplerNormal : register(s0);
 
 // The position/depth buffer
-Texture2D texPos : register(t1);
+Texture2DArray texPos : register(t1);
 SamplerState sampPos : register(s1);
 
 struct PixelShaderInput
 {
 	float4 pos : SV_POSITION;
 	float2 uv  : TEXCOORD;
+    uint viewId : SV_RenderTargetArrayIndex;
 };
 
 struct PixelShaderOutput
@@ -30,8 +31,8 @@ PixelShaderOutput main(PixelShaderInput input)
 	//return output;
 	// DEBUG
 
-	const float3 P      = texPos.Sample(sampPos, input.uv).xyz;
-	const float4 Normal = texNormal.Sample(samplerNormal, input.uv);
+    const float3 P      = texPos.Sample(sampPos, float3(input.uv, input.viewId)).xyz;
+    const float4 Normal = texNormal.Sample(samplerNormal, float3(input.uv, input.viewId));
 	const float3 N      = Normal.xyz;
 
 	float rt_shadow_factor = 1.0f;

--- a/impl11/shaders/SBSVertexShader.hlsl
+++ b/impl11/shaders/SBSVertexShader.hlsl
@@ -13,6 +13,7 @@ struct VertexShaderInput
 	float4 color	: COLOR0;
 	float4 specular : COLOR1;
 	float2 tex		: TEXCOORD;
+	uint instId : SV_InstanceID;
 };
 
 struct PixelShaderInput
@@ -22,6 +23,7 @@ struct PixelShaderInput
 	float2 tex      : TEXCOORD0;
 	float4 pos3D    : COLOR1;
 	float4 normal   : NORMAL; // hook_normals.dll populates this field
+	uint viewId : SV_RenderTargetArrayIndex;
 };
 
 PixelShaderInput main(VertexShaderInput input)
@@ -85,7 +87,7 @@ PixelShaderInput main(VertexShaderInput input)
 		compViewMatrix._m03_m13_m23 = 0;
 		output.pos = mul(compViewMatrix, float4(P, 1));
 	}
-	output.pos = mul(projEyeMatrix, output.pos);
+	output.pos = mul(projEyeMatrix[input.instId], output.pos);
 
 	// Use the original sz; but compensate with the new w so that it stays perspective-correct:
 	output.pos.z = sz * output.pos.w;
@@ -97,5 +99,7 @@ PixelShaderInput main(VertexShaderInput input)
 	output.color  = input.color.zyxw;
 	output.normal = input.specular;
 	output.tex    = input.tex;
+	// Pass forward the instance ID to choose the right RTV for each eye
+	output.viewId = input.instId;
 	return output;
 }

--- a/impl11/shaders/SSDO/SSDOAdd.hlsl
+++ b/impl11/shaders/SSDO/SSDOAdd.hlsl
@@ -519,7 +519,7 @@ PixelShaderOutput main(PixelShaderInput input)
 					[unroll]
 					for (j = -range; j <= range; j++)
 					{
-						const float z = texPos.Sample(sampPos, uv).z;
+						const float z = texPos.Sample(sampPos, float3(input.uv, input.viewId)).z;
 						const float delta_z = abs(P.z - z);
 						const float delta_ij = -RTGaussFactor * (i*i + j*j);
 						//const float G = RTUseGaussFilter ? exp(delta_ij) : 1.0;

--- a/impl11/shaders/SSDO/SSDOAdd.hlsl
+++ b/impl11/shaders/SSDO/SSDOAdd.hlsl
@@ -57,7 +57,7 @@ Texture2DArray<float> texShadowMap : register(t7);
 SamplerComparisonState cmpSampler : register(s7);
 
 // The RT Shadow Mask
-Texture2D rtShadowMask : register(t17);
+Texture2DArray rtShadowMask : register(t17);
 
 // We're reusing the same constant buffer used to blur bloom; but here
 // we really only use the amplifyFactor to upscale the SSAO buffer (if
@@ -481,7 +481,7 @@ PixelShaderOutput main(PixelShaderInput input)
 				float2 uv;
 				float rtVal = 0;
 				const int range = 2;
-				const float rtCenter = rtShadowMask.Sample(sampColor, input.uv).x;
+                const float rtCenter = rtShadowMask.Sample(sampColor, float3(input.uv, input.viewId)).x;
 				//const float wsize = (2 * range + 1) * (2 * range + 1);
 				const float2 uv_delta = float2(RTShadowMaskPixelSizeX * RTShadowMaskSizeFactor,
 											   RTShadowMaskPixelSizeY * RTShadowMaskSizeFactor);
@@ -501,7 +501,7 @@ PixelShaderOutput main(PixelShaderInput input)
 						[unroll]
 						for (j = -1; j <= 1; j++)
 						{
-							rtMin = min(rtMin, rtShadowMask.Sample(sampColor, uv).x);
+                            rtMin = min(rtMin, rtShadowMask.Sample(sampColor, float3(uv, input.viewId)).x);
 							uv.x += uv_delta_d.x;
 						}
 						uv.y += uv_delta_d.y;
@@ -526,7 +526,7 @@ PixelShaderOutput main(PixelShaderInput input)
 						const float G = exp(delta_ij);
 						// Objects far away should have bigger thresholds too
 						if (delta_z < RTSoftShadowThresholdMult * P.z)
-							rtVal += G * rtShadowMask.Sample(sampColor, uv).x;
+                            rtVal += G * rtShadowMask.Sample(sampColor, float3(uv, input.viewId)).x;
 						else
 							rtVal += G * rtMin;
 						Gsum += G;

--- a/impl11/shaders/SSDO/SSDOAdd.hlsl
+++ b/impl11/shaders/SSDO/SSDOAdd.hlsl
@@ -49,12 +49,12 @@ SamplerState samplerNormal : register(s5);
 //SamplerState samplerBent : register(s6);
 
 // The Shading System Mask buffer
-Texture2DArray texSSMask : register(t7);
-SamplerState samplerSSMask : register(s7);
+Texture2DArray texSSMask : register(t6);
+SamplerState samplerSSMask : register(s6);
 
 // The Shadow Map buffer
-Texture2DArray<float> texShadowMap : register(t8);
-SamplerComparisonState cmpSampler : register(s8);
+Texture2DArray<float> texShadowMap : register(t7);
+SamplerComparisonState cmpSampler : register(s7);
 
 // The RT Shadow Mask
 Texture2D rtShadowMask : register(t17);
@@ -86,7 +86,7 @@ struct PixelShaderOutput
 {
 	float4 color : SV_TARGET0;
 	float4 bloom : SV_TARGET1;
-	float4 bent  : SV_TARGET2;
+	//float4 bent  : SV_TARGET2;
 };
 
 // From: https://www.shadertoy.com/view/MdfXWr
@@ -384,7 +384,7 @@ PixelShaderOutput main(PixelShaderInput input)
 	PixelShaderOutput output;
 	output.color = 0;
 	output.bloom = 0;
-	output.bent  = 0;
+	//output.bent  = 0;
 
 	float2 input_uv_sub   = input.uv * amplifyFactor;
 	//float2 input_uv_sub2 = input.uv * amplifyFactor2;
@@ -870,14 +870,14 @@ PixelShaderOutput main(PixelShaderInput input)
 	output.color = float4(sqrt(tmp_color), 1); // Invert gamma correction (approx pow 1/2.2)
 
 #ifdef DISABLED
-	if (ssao_debug == 8)
-		output.color.xyz = bentN.xyz * 0.5 + 0.5;
+	//if (ssao_debug == 8)
+		//output.color.xyz = bentN.xyz * 0.5 + 0.5;
 	if (ssao_debug == 9 || ssao_debug >= 14)
 		output.color.xyz = contactShadow;
-	if (ssao_debug == 10)
-		output.color.xyz = bentDiff;
-	if (ssao_debug == 12)
-		output.color.xyz = color * (diff_int * bentDiff + ambient);
+	//if (ssao_debug == 10)
+		//output.color.xyz = bentDiff;
+	//if (ssao_debug == 12)
+		//output.color.xyz = color * (diff_int * bentDiff + ambient);
 	if (ssao_debug == 13)
 		output.color.xyz = N.xyz * 0.5 + 0.5;
 	if (ssao_debug == 18)

--- a/impl11/shaders/SSDO/SSDOAdd.hlsl
+++ b/impl11/shaders/SSDO/SSDOAdd.hlsl
@@ -20,36 +20,36 @@
 
 //#define PBR_DYN_LIGHTS
 
-// The color buffer
-Texture2D texColor : register(t0);
+ // The color buffer
+Texture2DArray texColor : register(t0);
 SamplerState sampColor : register(s0);
 
 // The SSDO Direct buffer
-Texture2D texSSDO : register(t1);
+Texture2DArray texSSDO : register(t1);
 SamplerState samplerSSDO : register(s1);
 
 // The SSDO Indirect buffer
-Texture2D texSSDOInd : register(t2);
+Texture2DArray texSSDOInd : register(t2);
 SamplerState samplerSSDOInd : register(s2);
 
 // The SSAO mask
-Texture2D texSSAOMask : register(t3);
+Texture2DArray texSSAOMask : register(t3);
 SamplerState samplerSSAOMask : register(s3);
 
 // The position/depth buffer
-Texture2D texPos : register(t4);
+Texture2DArray texPos : register(t4);
 SamplerState sampPos : register(s4);
 
 // The (Smooth) Normals buffer
-Texture2D texNormal : register(t5);
+Texture2DArray texNormal : register(t5);
 SamplerState samplerNormal : register(s5);
 
 // The Bent Normals buffer
-Texture2D texBent : register(t6);
-SamplerState samplerBent : register(s6);
+//Texture2DArray texBent : register(t6);
+//SamplerState samplerBent : register(s6);
 
 // The Shading System Mask buffer
-Texture2D texSSMask : register(t7);
+Texture2DArray texSSMask : register(t7);
 SamplerState samplerSSMask : register(s7);
 
 // The Shadow Map buffer
@@ -79,6 +79,7 @@ struct PixelShaderInput
 {
 	float4 pos : SV_POSITION;
 	float2 uv  : TEXCOORD;
+	uint viewId: SV_RenderTargetArrayIndex;
 };
 
 struct PixelShaderOutput
@@ -146,11 +147,11 @@ inline float3 reinhard_extended(float3 v, float max_white)
 	return numerator / (1.0f + v);
 }
 
-inline float3 getPosition(in float2 uv, in float level) {
+inline float3 getPosition(in float2 uv, in uint viewId, in float level) {
 	// The use of SampleLevel fixes the following error:
 	// warning X3595: gradient instruction used in a loop with varying iteration
 	// This happens because the texture is sampled within an if statement (if FGFlag then...)
-	return texPos.SampleLevel(sampPos, uv, level).xyz;
+	return texPos.SampleLevel(sampPos, float3(uv,viewId), level).xyz;
 }
 
 #ifdef DISABLED
@@ -388,16 +389,16 @@ PixelShaderOutput main(PixelShaderInput input)
 	float2 input_uv_sub   = input.uv * amplifyFactor;
 	//float2 input_uv_sub2 = input.uv * amplifyFactor2;
 	float2 input_uv_sub2  = input.uv * amplifyFactor;
-	float3 color          = texColor.Sample(sampColor, input.uv).xyz;
-	float4 Normal         = texNormal.Sample(samplerNormal, input.uv);
-	float3 pos3D	      = texPos.Sample(sampPos, input.uv).xyz;
-	float3 ssdo           = texSSDO.Sample(samplerSSDO, input_uv_sub).rgb;
-	float3 ssdoInd        = texSSDOInd.Sample(samplerSSDOInd, input_uv_sub2).rgb;
+	float3 color          = texColor.Sample(sampColor, float3(input.uv,input.viewId)).xyz;
+	float4 Normal         = texNormal.Sample(samplerNormal, float3(input.uv, input.viewId));
+	float3 pos3D	      = texPos.Sample(sampPos, float3(input.uv, input.viewId)).xyz;
+	float3 ssdo           = texSSDO.Sample(samplerSSDO, float3(input_uv_sub, input.viewId)).rgb;
+	float3 ssdoInd        = texSSDOInd.Sample(samplerSSDOInd, float3(input_uv_sub2, input.viewId)).rgb;
 	// Bent normals are supposed to encode the obscurance in their length, so
 	// let's enforce that condition by multiplying by the AO component: (I think it's already weighed; but this kind of enhances the effect)
 	//float3 bentN         = /* ssdo.y * */ texBent.Sample(samplerBent, input_uv_sub).xyz; // TBV
-	float3 ssaoMask       = texSSAOMask.Sample(samplerSSAOMask, input.uv).xyz;
-	float3 ssMask         = texSSMask.Sample(samplerSSMask, input.uv).xyz;
+	float3 ssaoMask       = texSSAOMask.Sample(samplerSSAOMask, float3(input.uv, input.viewId)).xyz;
+	float3 ssMask         = texSSMask.Sample(samplerSSMask, float3(input.uv, input.viewId)).xyz;
 	//float3 emissionMask  = texEmissionMask.Sample(samplerEmissionMask, input_uv_sub).xyz;
 	float  mask           = ssaoMask.x;
 	float  gloss_mask     = ssaoMask.y;

--- a/impl11/shaders/SpeedEffectCompose.hlsl
+++ b/impl11/shaders/SpeedEffectCompose.hlsl
@@ -7,21 +7,22 @@
 #include "ShadertoyCBuffer.h"
 
 // The offscreenBuffer up to this point
-Texture2D    colorTex     : register(t0);
+Texture2DArray    colorTex     : register(t0);
 SamplerState colorSampler : register(s0);
 
 // The effects (trails) buffer up to this point
-Texture2D    effectTex     : register(t1);
+Texture2DArray    effectTex     : register(t1);
 SamplerState effectSampler : register(s1);
 
 // The pos3D buffer
-Texture2D    posTex     : register(t2);
+Texture2DArray    posTex     : register(t2);
 SamplerState posSampler : register(s2);
 
 struct PixelShaderInput
 {
 	float4 pos : SV_POSITION;
 	float2 uv  : TEXCOORD;
+    uint viewId : SV_RenderTargetArrayIndex;
 };
 
 struct PixelShaderOutput
@@ -33,9 +34,9 @@ PixelShaderOutput main(PixelShaderInput input)
 {
 	PixelShaderOutput output;
 
-	float4 texColor = colorTex.Sample(colorSampler, input.uv);
-	float4 effectColor = effectTex.Sample(effectSampler, input.uv);
-	float3 pos3D = posTex.Sample(posSampler, input.uv).xyz;
+    float4 texColor = colorTex.Sample(colorSampler, float3(input.uv, input.viewId));
+    float4 effectColor = effectTex.Sample(effectSampler, float3(input.uv, input.viewId));
+    float3 pos3D = posTex.Sample(posSampler, float3(input.uv, input.viewId)).xyz;
 
 	// Initialize the result:
 	output.color = texColor;

--- a/impl11/shaders/SpeedEffectPixelShader.hlsl
+++ b/impl11/shaders/SpeedEffectPixelShader.hlsl
@@ -32,6 +32,8 @@ struct PixelShaderInput
 	float4 color  : COLOR0;
 	float2 uv     : TEXCOORD0;
 	//float4 pos3D  : COLOR1; //not used anymore and causing a DEVICE_SHADER_LINKAGE_SEMANTICNAME_NOT_FOUND
+    uint viewId : SV_RenderTargetArrayIndex;
+	
 };
 
 struct PixelShaderOutput

--- a/impl11/shaders/SpeedEffectVertexShader.hlsl
+++ b/impl11/shaders/SpeedEffectVertexShader.hlsl
@@ -12,6 +12,7 @@ struct VertexShaderInput
 	float4 color	: COLOR0;
 	float4 specular : COLOR1;
 	float2 tex		: TEXCOORD;
+	uint instId : SV_InstanceID;
 };
 
 struct PixelShaderInput
@@ -19,6 +20,7 @@ struct PixelShaderInput
 	float4 pos		: SV_POSITION;
 	float4 color	: COLOR0;
 	float2 tex		: TEXCOORD;
+	uint viewId : SV_RenderTargetArrayIndex;
 };
 
 PixelShaderInput main(VertexShaderInput input)
@@ -80,7 +82,7 @@ PixelShaderInput main(VertexShaderInput input)
 
 		// Project again
 		P.z = -P.z;
-		output.pos = mul(projEyeMatrix, float4(P, 1.0));
+		output.pos = mul(projEyeMatrix[input.instId], float4(P, 1.0));
 		// DirectX will divide output.pos by output.pos.w, so we don't need to do it here,
 		// plus we probably can't do it here in the case of SteamVR anyway...
 		// Old code follows, just for reference (this code actually worked):
@@ -95,5 +97,7 @@ PixelShaderInput main(VertexShaderInput input)
 
 	output.color = fadeout * input.color.zyxw;
 	output.tex   = input.tex;
+	// Pass forward the instance ID to choose the right RTV for each eye
+	output.viewId = input.instId;
 	return output;
 }

--- a/impl11/shaders/SteamVRMirrorPixelShader.hlsl
+++ b/impl11/shaders/SteamVRMirrorPixelShader.hlsl
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE.txt
 // Extended for VR by Leo Reyes (c) 2019
 
-Texture2D texture0 : register(t0);
+Texture2DArray texture0 : register(t0);
 SamplerState sampler0 : register(s0);
 
 // MainShadersCBuffer
@@ -23,8 +23,11 @@ float4 main(PixelShaderInput input) : SV_TARGET
 	// Resize the mirror window about the center of the image so that we can 
 	// hide some of the ugly distortion we see near  the edges due to the wide
 	// FOV used in VR:
-	float2 uv = (input.tex - 0.5) * inv_scale + 0.5;
-	float4 texelColor = texture0.Sample(sampler0, uv);
+	float3 uv;
+	uv.xy = (input.tex - 0.5) * inv_scale + 0.5;
+	// The third component is the array index. We choose the left eye.
+	uv.z = 0;
+	float4 texelColor = texture0.Sample(sampler0, uv, 0);
 	//float2 D = abs(input.tex - 0.5);
 	//if (any(D > crop_amount))
 	//	texelColor.b += 0.7;

--- a/impl11/shaders/SunFlareCompose.hlsl
+++ b/impl11/shaders/SunFlareCompose.hlsl
@@ -7,11 +7,11 @@
 #include "ShadertoyCBuffer.h"
 
 // The color texture
-Texture2D    colorTex     : register(t0);
+Texture2DArray    colorTex	: register(t0);
 SamplerState colorSampler : register(s0);
 
 // The flare texture
-Texture2D    flareTex     : register(t1);
+Texture2DArray    flareTex     : register(t1);
 SamplerState flareSampler : register(s1);
 
 // The depth texture (shadertoyAuxBuf)
@@ -24,6 +24,7 @@ struct PixelShaderInput
 {
 	float4 pos : SV_POSITION;
 	float2 uv  : TEXCOORD;
+    uint viewId : SV_RenderTargetArrayIndex;
 };
 
 struct PixelShaderOutput
@@ -42,8 +43,8 @@ PixelShaderOutput main(PixelShaderInput input)
 {
 	PixelShaderOutput output;
 
-	float4 color = colorTex.Sample(colorSampler, input.uv);
-	float4 flare = flareTex.Sample(flareSampler, input.uv);
+    float4 color = colorTex.Sample(colorSampler, float3(input.uv, input.viewId));
+    float4 flare = flareTex.Sample(flareSampler, float3(input.uv, input.viewId));
 	float2 sunPos;
 	float3 sunPos3D;
 	//float2 debug_uv;

--- a/impl11/shaders/SunFlareShader.hlsl
+++ b/impl11/shaders/SunFlareShader.hlsl
@@ -18,7 +18,7 @@
 #include "metric_common.h"
 
  // The background texture
-Texture2D    bgTex     : register(t0);
+Texture2DArray    bgTex     : register(t0);
 
 #ifdef GENMIPMAPS_DEBUG
 // DEBUG section. This will enable mip maps in this shader
@@ -61,7 +61,9 @@ struct PixelShaderInput
 	float4 pos    : SV_POSITION;
 	float4 color  : COLOR0;
 	float2 uv     : TEXCOORD0;
-	float4 pos3D  : COLOR1;
+    float4 pos3D  : COLOR1;
+    uint viewId   : SV_RenderTargetArrayIndex;
+
 };
 
 struct PixelShaderOutput
@@ -312,7 +314,7 @@ PixelShaderOutput main(PixelShaderInput input) {
 		// DEBUG section. This will enable mip maps in this shader
 		output.color = bgTex.SampleLevel(bgSampler, input.uv, 5.0);
 #else
-		output.color = bgTex.Sample(bgSampler, input.uv);
+        output.color = bgTex.Sample(bgSampler, float3(input.uv, input.viewId));
 #endif
 
 	// Early exit: avoid rendering outside the original viewport edges

--- a/impl11/shaders/VertexShaderMatrixCB.h
+++ b/impl11/shaders/VertexShaderMatrixCB.h
@@ -1,7 +1,7 @@
 // VertexShaderMatrixCB
 cbuffer ConstantBuffer : register(b2)
 {
-	matrix projEyeMatrix;
+	matrix projEyeMatrix[2];
 	matrix viewMatrix;
 	matrix fullViewMatrix;
 	// Used for metric reconstruction

--- a/impl11/shaders/XwaD3dShadowVertexShaderVR.hlsl
+++ b/impl11/shaders/XwaD3dShadowVertexShaderVR.hlsl
@@ -19,6 +19,7 @@ Buffer<float2> g_textureCoords : register(t2);
 struct VertexShaderInput
 {
 	int4 index : POSITION;
+	uint instId : SV_InstanceID;
 };
 
 struct PixelShaderInput
@@ -28,6 +29,7 @@ struct PixelShaderInput
 	//float4 normal : COLOR1;
 	//float2 tex : TEXCOORD;
 	//float4 color : COLOR0;
+	uint viewId : SV_RenderTargetArrayIndex;
 };
 
 PixelShaderInput main(VertexShaderInput input)
@@ -82,9 +84,10 @@ PixelShaderInput main(VertexShaderInput input)
 		output.pos = mul(viewMatrix, output.pos);
 	else
 		output.pos = mul(fullViewMatrix, output.pos);
-	output.pos = mul(projEyeMatrix, output.pos);
+	output.pos = mul(projEyeMatrix[input.instId], output.pos);
 	// Fix the depth
 	output.pos.z = (Q.z / Q.w) * output.pos.w;
-
+	// Pass forward the instance ID to choose the right RTV for each eye
+	output.viewId = input.instId;
 	return output;
 }

--- a/impl11/shaders/XwaD3dVertexShader.hlsl
+++ b/impl11/shaders/XwaD3dVertexShader.hlsl
@@ -13,7 +13,7 @@ cbuffer ConstantBuffer : register(b8) {
 
 struct VertexShaderInput
 {
-	int4 index : POSITION;
+	uint4 index : POSITION;
 };
 
 

--- a/impl11/shaders/bloom/BloomCombinePS.hlsl
+++ b/impl11/shaders/bloom/BloomCombinePS.hlsl
@@ -5,11 +5,11 @@
 // https://learnopengl.com/Advanced-Lighting/Bloom
 
 // This texture slot should be the original backbuffer SRV
-Texture2D texture0 : register(t0);
+Texture2DArray texture0 : register(t0);
 SamplerState sampler0 : register(s0);
 
 // This texture slot should be the bloom texture
-Texture2D bloomTex: register(t1);
+Texture2DArray bloomTex: register(t1);
 SamplerState bloomSampler : register(s1);
 
 cbuffer ConstantBuffer : register(b2)
@@ -24,6 +24,7 @@ struct PixelShaderInput
 {
 	float4 pos : SV_POSITION;
 	float2 uv : TEXCOORD;
+	uint viewId: SV_RenderTargetArrayIndex;
 };
 
 // From http://www.chilliant.com/rgb2hsv.html
@@ -121,8 +122,8 @@ struct PixelShaderOutput
 
 float4 main(PixelShaderInput input) : SV_TARGET
 {
-	float4 color = texture0.Sample(sampler0, input.uv);
-	float3 bloom = bloomTex.Sample(bloomSampler, input.uv).rgb;
+	float4 color = texture0.Sample(sampler0, float3(input.uv, input.viewId));
+	float3 bloom = bloomTex.Sample(bloomSampler, float3(input.uv, input.viewId)).rgb;
 	color.w = 1.0f;
 
 	//float3 HSV = RGBtoHSV(output.bloom.xyz);

--- a/impl11/shaders/bloom/BloomHGaussPS.hlsl
+++ b/impl11/shaders/bloom/BloomHGaussPS.hlsl
@@ -28,7 +28,7 @@ struct PixelShaderInput
 float4 main(PixelShaderInput input) : SV_TARGET
 {
 	float2 input_uv = input.uv * amplifyFactor;
-	float3 color = texture0.Sample(sampler0, float3(input.uv, input.viewId)).xyz * weight[0];
+	float3 color = texture0.Sample(sampler0, float3(input_uv, input.viewId)).xyz * weight[0];
 	float3 s1, s2;
 	float2 dx = uvStepSize * float2(pixelSizeX, 0);
 	float2 uv1 = input_uv + dx;

--- a/impl11/shaders/bloom/BloomHGaussPS.hlsl
+++ b/impl11/shaders/bloom/BloomHGaussPS.hlsl
@@ -7,7 +7,7 @@
 // Kernel calculator:
 // http://dev.theomader.com/gaussian-kernel-calculator/
 
-Texture2D texture0 : register(t0);
+Texture2DArray texture0 : register(t0);
 SamplerState sampler0 : register(s0);
 
 cbuffer ConstantBuffer : register(b2)
@@ -22,12 +22,13 @@ struct PixelShaderInput
 {
 	float4 pos : SV_POSITION;
 	float2 uv : TEXCOORD;
+	uint viewId: SV_RenderTargetArrayIndex;
 };
 
 float4 main(PixelShaderInput input) : SV_TARGET
 {
 	float2 input_uv = input.uv * amplifyFactor;
-	float3 color = texture0.Sample(sampler0, input_uv).xyz * weight[0];
+	float3 color = texture0.Sample(sampler0, float3(input.uv, input.viewId)).xyz * weight[0];
 	float3 s1, s2;
 	float2 dx = uvStepSize * float2(pixelSizeX, 0);
 	float2 uv1 = input_uv + dx;
@@ -35,8 +36,8 @@ float4 main(PixelShaderInput input) : SV_TARGET
 
 	[unroll]
 	for (int i = 1; i < 3; i++) {
-		s1 = texture0.Sample(sampler0, uv1).xyz * weight[i];
-		s2 = texture0.Sample(sampler0, uv2).xyz * weight[i];
+		s1 = texture0.Sample(sampler0, float3(uv1,input.viewId)).xyz * weight[i];
+		s2 = texture0.Sample(sampler0, float3(uv2,input.viewId)).xyz * weight[i];
 		color += s1 + s2;
 		uv1 += dx;
 		uv2 -= dx;

--- a/impl11/shaders/bloom/BloomVGaussPS.hlsl
+++ b/impl11/shaders/bloom/BloomVGaussPS.hlsl
@@ -28,7 +28,7 @@ struct PixelShaderInput
 float4 main(PixelShaderInput input) : SV_TARGET
 {
 	float2 input_uv = input.uv * amplifyFactor;
-	float3 color = texture0.Sample(sampler0, float3(input.uv, input.viewId)).xyz * weight[0];
+	float3 color = texture0.Sample(sampler0, float3(input_uv, input.viewId)).xyz * weight[0];
 	float3 s1, s2;
 	float2 dy = uvStepSize * float2(0, pixelSizeY);
 	float2 uv1 = input_uv + dy;

--- a/impl11/shaders/bloom/BloomVGaussPS.hlsl
+++ b/impl11/shaders/bloom/BloomVGaussPS.hlsl
@@ -7,7 +7,7 @@
 // Kernel calculator:
 // http://dev.theomader.com/gaussian-kernel-calculator/
 
-Texture2D texture0 : register(t0);
+Texture2DArray texture0 : register(t0);
 SamplerState sampler0 : register(s0);
 
 cbuffer ConstantBuffer : register(b2)
@@ -22,12 +22,13 @@ struct PixelShaderInput
 {
 	float4 pos : SV_POSITION;
 	float2 uv : TEXCOORD;
+	uint viewId: SV_RenderTargetArrayIndex;
 };
 
 float4 main(PixelShaderInput input) : SV_TARGET
 {
 	float2 input_uv = input.uv * amplifyFactor;
-	float3 color = texture0.Sample(sampler0, input_uv).xyz * weight[0];
+	float3 color = texture0.Sample(sampler0, float3(input.uv, input.viewId)).xyz * weight[0];
 	float3 s1, s2;
 	float2 dy = uvStepSize * float2(0, pixelSizeY);
 	float2 uv1 = input_uv + dy;
@@ -35,8 +36,8 @@ float4 main(PixelShaderInput input) : SV_TARGET
 
 	[unroll]
 	for (int i = 1; i < 3; i++) {
-		s1 = texture0.Sample(sampler0, uv1).xyz * weight[i];
-		s2 = texture0.Sample(sampler0, uv2).xyz * weight[i];
+		s1 = texture0.Sample(sampler0, float3(uv1, input.viewId)).xyz * weight[i];
+		s2 = texture0.Sample(sampler0, float3(uv2, input.viewId)).xyz * weight[i];
 		color += s1 + s2;
 		uv1 += dy;
 		uv2 -= dy;


### PR DESCRIPTION
This rendering mode should almost halve the draw calls when rendering in SteamVR mode.

In performance critical situations where the draw call count is the bottleneck (many objects on screen), this should improve the performance of stereoscopic rendering and bring it closer to the monoscopic mode.

~~**There are some pending issues like documented in #48**, but~~ it is already in a useable state, useful for testing
