### PR TITLE
Resolve some errors raised by the DirectX Debug Layer

### DIFF
--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -4094,11 +4094,20 @@ HRESULT DeviceResources::LoadResources()
 	if (FAILED(hr = this->_d3dDevice->CreateInputLayout(vertexLayoutDesc, ARRAYSIZE(vertexLayoutDesc), g_VertexShader, sizeof(g_VertexShader), &_inputLayout)))
 		return hr;
 
-	if (FAILED(hr = this->_d3dDevice->CreateInputLayout(vertexLayoutDesc, ARRAYSIZE(vertexLayoutDesc), g_SBSVertexShader, sizeof(g_SBSVertexShader), &_inputLayout)))
+	// Input layout specific for shadowmap, as the input (shadow OBJ) only contains position information
+	const D3D11_INPUT_ELEMENT_DESC shadowVertexLayoutDesc[] =
+	{
+		{ "POSITION", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+	};
+
+	if (FAILED(hr = this->_d3dDevice->CreateInputLayout(shadowVertexLayoutDesc, ARRAYSIZE(shadowVertexLayoutDesc), g_ShadowMapVS, sizeof(g_ShadowMapVS), &_shadowMapInputLayout)))
 		return hr;
 
-	if (FAILED(hr = this->_d3dDevice->CreateInputLayout(vertexLayoutDesc, ARRAYSIZE(vertexLayoutDesc), g_DATVertexShaderVR, sizeof(g_DATVertexShaderVR), &_inputLayout)))
-		return hr;
+//	if (FAILED(hr = this->_d3dDevice->CreateInputLayout(vertexLayoutDesc, ARRAYSIZE(vertexLayoutDesc), g_SBSVertexShader, sizeof(g_SBSVertexShader), &_inputLayout)))
+//		return hr;
+
+//	if (FAILED(hr = this->_d3dDevice->CreateInputLayout(vertexLayoutDesc, ARRAYSIZE(vertexLayoutDesc), g_DATVertexShaderVR, sizeof(g_DATVertexShaderVR), &_inputLayout)))
+//		return hr;
 
 	if (FAILED(hr = this->_d3dDevice->CreatePixelShader(g_PixelShaderTexture, sizeof(g_PixelShaderTexture), nullptr, &_pixelShaderTexture)))
 		return hr;

--- a/impl11/ddraw/DeviceResources.h
+++ b/impl11/ddraw/DeviceResources.h
@@ -489,6 +489,7 @@ public:
 	ComPtr<ID3D11VertexShader> _hangarShadowMapVS;
 	ComPtr<ID3D11VertexShader> _csmVS;
 	ComPtr<ID3D11InputLayout> _inputLayout;
+	ComPtr<ID3D11InputLayout> _shadowMapInputLayout;
 	ComPtr<ID3D11PixelShader> _pixelShaderTexture;
 	ComPtr<ID3D11PixelShader> _pixelShaderDC;
 	ComPtr<ID3D11PixelShader> _pixelShaderDCHolo;

--- a/impl11/shaders/ShadowMapVS.hlsl
+++ b/impl11/shaders/ShadowMapVS.hlsl
@@ -10,9 +10,9 @@
 struct VertexShaderInput
 {
 	float4 pos      : POSITION; // The D3DRendererHook version has OPT-scale metric coords here
-	float4 color    : COLOR0;
-	float4 specular : COLOR1;
-	float2 tex      : TEXCOORD;
+	//float4 color    : COLOR0;
+	//float4 specular : COLOR1;
+	//float2 tex      : TEXCOORD;
 };
 
 struct SHADOW_PS_INPUT

--- a/impl11/shaders/SpeedEffectPixelShader.hlsl
+++ b/impl11/shaders/SpeedEffectPixelShader.hlsl
@@ -31,7 +31,7 @@ struct PixelShaderInput
 	float4 pos    : SV_POSITION;
 	float4 color  : COLOR0;
 	float2 uv     : TEXCOORD0;
-	float4 pos3D  : COLOR1;
+	//float4 pos3D  : COLOR1; //not used anymore and causing a DEVICE_SHADER_LINKAGE_SEMANTICNAME_NOT_FOUND
 };
 
 struct PixelShaderOutput


### PR DESCRIPTION
All the ERRORs related to input/output linking mismatch in PS and VS are solved.
There are still D3D11: DeviceChild reference counter underflow errors.