### PR TITLE
Fix RT Shadows

### DIFF
--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -148,6 +148,7 @@ Intersection ClosestHit(BVHNode* g_BVH, float3 origin, int Offset, float3& P_out
 	ac_uv_coords* coords, int contIdx);
 
 Vector4 SteamVRToOPTCoords(Vector4 P);
+void SetLights(DeviceResources* resources, float fSSDOEnabled);
 
 //#define DUMP_TLAS 1
 #undef DUMP_TLAS
@@ -2160,6 +2161,10 @@ void EffectsRenderer::SceneBegin(DeviceResources* deviceResources)
 		g_ACtlasLeaves.clear();
 		g_TLASMap.clear();
 		RTResetMatrixSlotCounter();
+		/*log_debug("[DBG] EffectsRenderer::SceneBegin: %0.3f, %0.3f, %0.3f",
+			g_pSharedDataCockpitLook->Yaw, g_pSharedDataCockpitLook->Pitch, g_pSharedDataCockpitLook->Roll);*/
+		//ShowMatrix4(g_VSMatrixCB.fullViewMat, "SceneBegin");
+
 		if (g_TLASTree != nullptr)
 		{
 			delete g_TLASTree;
@@ -2849,6 +2854,9 @@ void EffectsRenderer::SceneEnd()
 		_BLASNeedsUpdate = false;
 	}
 
+	if (g_bRTEnabled)
+		SetLights(_deviceResources, 0.0f);
+
 	if ((g_bRTEnabled || g_bActiveCockpitEnabled) && !g_bInTechRoom && !(*g_playerInHangar))
 	{
 		// We may need to reallocate the matrices buffer depending on how many
@@ -2889,6 +2897,9 @@ void EffectsRenderer::SceneEnd()
 			//log_debug("[DBG] [BVH] Matrices Realloc'ed");
 			ReAllocateAndPopulateTLASBvhBuffers();
 			//log_debug("[DBG] [BVH] TLAS Buffers Realloc'ed");
+			/*log_debug("[DBG] EffectsRenderer::SceneEnd: %0.3f, %0.3f, %0.3f",
+				g_pSharedDataCockpitLook->Yaw, g_pSharedDataCockpitLook->Pitch, g_pSharedDataCockpitLook->Roll);*/
+			//ShowMatrix4(g_VSMatrixCB.fullViewMat, "SceneEnd");
 		}
 	}
 

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -2161,8 +2161,6 @@ void EffectsRenderer::SceneBegin(DeviceResources* deviceResources)
 		g_ACtlasLeaves.clear();
 		g_TLASMap.clear();
 		RTResetMatrixSlotCounter();
-		/*log_debug("[DBG] EffectsRenderer::SceneBegin: %0.3f, %0.3f, %0.3f",
-			g_pSharedDataCockpitLook->Yaw, g_pSharedDataCockpitLook->Pitch, g_pSharedDataCockpitLook->Roll);*/
 		//ShowMatrix4(g_VSMatrixCB.fullViewMat, "SceneBegin");
 
 		if (g_TLASTree != nullptr)
@@ -2897,8 +2895,6 @@ void EffectsRenderer::SceneEnd()
 			//log_debug("[DBG] [BVH] Matrices Realloc'ed");
 			ReAllocateAndPopulateTLASBvhBuffers();
 			//log_debug("[DBG] [BVH] TLAS Buffers Realloc'ed");
-			/*log_debug("[DBG] EffectsRenderer::SceneEnd: %0.3f, %0.3f, %0.3f",
-				g_pSharedDataCockpitLook->Yaw, g_pSharedDataCockpitLook->Pitch, g_pSharedDataCockpitLook->Roll);*/
 			//ShowMatrix4(g_VSMatrixCB.fullViewMat, "SceneEnd");
 		}
 	}

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -5928,6 +5928,7 @@ void EffectsRenderer::RenderScene()
 
 		// Wipe out the background:
 		context->ClearRenderTargetView(resources->_renderTargetView, resources->clearColor);
+		g_bBackgroundCaptured = true;
 	}
 
 	unsigned short scissorLeft = *(unsigned short*)0x07D5244;

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -2852,9 +2852,6 @@ void EffectsRenderer::SceneEnd()
 		_BLASNeedsUpdate = false;
 	}
 
-	if (g_bRTEnabled)
-		SetLights(_deviceResources, 0.0f);
-
 	if ((g_bRTEnabled || g_bActiveCockpitEnabled) && !g_bInTechRoom && !(*g_playerInHangar))
 	{
 		// We may need to reallocate the matrices buffer depending on how many

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -3193,8 +3193,7 @@ void PrimarySurface::DeferredPass()
 	resources->InitViewport(&viewport);
 
 	// Set the lights and the Shading System Constant Buffer
-	if (!g_bRTEnabled) // When RT is on, we set the lights when the BVH is built. See EffectsRenderer::SceneEnd()
-		SetLights(_deviceResources, 0.0f);
+	SetLights(_deviceResources, 0.0f);
 
 	// Set the Vertex Shader Constant buffers
 	resources->InitVSConstantBuffer2D(resources->_mainShadersConstantBuffer.GetAddressOf(),
@@ -8978,7 +8977,7 @@ void PrimarySurface::RenderRTShadowMask()
 	SetScissoRectFullScreen();
 
 	// Don't forget to set the lights!
-	//SetLights(0.0f);
+	SetLights(resources, 0.0f);
 
 	// Reset the vertex shader to regular 2D post-process
 	// Set the Vertex Shader Constant buffers

--- a/impl11/ddraw/PrimarySurface.h
+++ b/impl11/ddraw/PrimarySurface.h
@@ -95,7 +95,7 @@ public:
 
 	void DrawHUDVertices();
 
-	void SetLights(float fSSDOEnabled);
+	//void SetLights(float fSSDOEnabled);
 	
 	void SSAOPass(float fZoomFactor);
 
@@ -113,7 +113,7 @@ public:
 
 	void GetHyperspaceEffectMatrix(Matrix4 *result);
 
-	void GetCockpitViewMatrixSpeedEffect(Matrix4 * result, bool invert);
+	//void GetCockpitViewMatrixSpeedEffect(Matrix4 * result, bool invert);
 
 	//void GetGunnerTurretViewMatrix(Matrix4 * result);
 
@@ -234,3 +234,6 @@ public:
 
 	UINT _flipFrames;
 };
+
+void GetCockpitViewMatrixSpeedEffect(Matrix4* result, bool invert);
+void SetLights(DeviceResources *resources, float fSSDOEnabled);

--- a/impl11/ddraw/SteamVRRenderer.cpp
+++ b/impl11/ddraw/SteamVRRenderer.cpp
@@ -79,6 +79,7 @@ void SteamVRRenderer::RenderScene()
 
 		// Wipe out the background:
 		context->ClearRenderTargetView(resources->_renderTargetView, resources->clearColor);
+		g_bBackgroundCaptured = true;
 	}
 
 	/*

--- a/impl11/ddraw/VRConfig.cpp
+++ b/impl11/ddraw/VRConfig.cpp
@@ -247,7 +247,7 @@ float g_fInterdictionShakeInVR = 0.0f;
 float g_fInterdictionAngleScale = 0.25f;
 
 int g_iDelayedDumpDebugBuffers = 0;
-//float g_fFlareAspectMult = 1.0f; // DEBUG: Fudge factor to place the flares on the right spot...
+bool g_bBackgroundCaptured = false; // Reset on every frame
 
 // white_point = 1 --> OK
 // white_point = 0.5 --> Makes everything bright

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -222,6 +222,8 @@ extern int g_iForceAltExplosion;
 extern float4 g_SunColors[MAX_SUN_FLARES];
 extern int g_iSunFlareCount;
 
+extern bool g_bBackgroundCaptured;
+
 // D3DRendererHook draw call counter;
 extern int g_iD3DExecuteCounter;
 constexpr float OPT_TO_METERS = 1.0f / 40.96f;


### PR DESCRIPTION
The orientation of the player's ship is now read directly from its mobileObject entry and I had to disable the roll inertia (in the CockpitLook hook) to fix the shadows. I think it was worth it.

Also, here's a fix for the background not getting captured properly.