### PR TITLE
Fix D3D11 error and remove unnecessary draw calls from Bloom in VR

### DIFF
--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -1936,15 +1936,15 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 			this->_offscreenBufferAsInputBloomMaskR.Release();
 			this->_offscreenAsInputBloomMaskSRV_R.Release();
 			this->_renderTargetViewBloomMaskR.Release();*/
-			this->_bloomOutput1R.Release();
-			this->_bloomOutput2R.Release();
-			this->_bloomOutputSumR.Release();
-			this->_renderTargetViewBloom1R.Release();
-			this->_renderTargetViewBloom2R.Release();
-			this->_renderTargetViewBloomSumR.Release();
-			this->_bloomOutput1SRV_R.Release();
-			this->_bloomOutput2SRV_R.Release();
-			this->_bloomOutputSumSRV_R.Release();
+			//this->_bloomOutput1R.Release();
+			//this->_bloomOutput2R.Release();
+			//this->_bloomOutputSumR.Release();
+			//this->_renderTargetViewBloom1R.Release();
+			//this->_renderTargetViewBloom2R.Release();
+			//this->_renderTargetViewBloomSumR.Release();
+			//this->_bloomOutput1SRV_R.Release();
+			//this->_bloomOutput2SRV_R.Release();
+			//this->_bloomOutputSumSRV_R.Release();
 		}
 	}
 
@@ -2735,46 +2735,46 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 					log_err("Successfully created _bloomOutputSum with combined flags\n");
 				}
 
-				if (g_bUseSteamVR) {
-					step = "_bloomOutput1R";
-					hr = this->_d3dDevice->CreateTexture2D(&desc, nullptr, &this->_bloomOutput1R);
-					if (FAILED(hr)) {
-						log_err("Failed to create _bloomOutput1R\n");
-						log_err("GetDeviceRemovedReason: 0x%x\n", this->_d3dDevice->GetDeviceRemovedReason());
-						log_err("dwWidth, Height: %u, %u\n", dwWidth, dwHeight);
-						log_err_desc(step, hWnd, hr, desc);
-						goto out;
-					}
-					else {
-						log_err("Successfully created _bloomOutput1R with combined flags\n");
-					}
+				//if (g_bUseSteamVR) {
+				//	step = "_bloomOutput1R";
+				//	hr = this->_d3dDevice->CreateTexture2D(&desc, nullptr, &this->_bloomOutput1R);
+				//	if (FAILED(hr)) {
+				//		log_err("Failed to create _bloomOutput1R\n");
+				//		log_err("GetDeviceRemovedReason: 0x%x\n", this->_d3dDevice->GetDeviceRemovedReason());
+				//		log_err("dwWidth, Height: %u, %u\n", dwWidth, dwHeight);
+				//		log_err_desc(step, hWnd, hr, desc);
+				//		goto out;
+				//	}
+				//	else {
+				//		log_err("Successfully created _bloomOutput1R with combined flags\n");
+				//	}
 
-					step = "_bloomOutput2R";
-					hr = this->_d3dDevice->CreateTexture2D(&desc, nullptr, &this->_bloomOutput2R);
-					if (FAILED(hr)) {
-						log_err("Failed to create _bloomOutput2R\n");
-						log_err("GetDeviceRemovedReason: 0x%x\n", this->_d3dDevice->GetDeviceRemovedReason());
-						log_err("dwWidth, Height: %u, %u\n", dwWidth, dwHeight);
-						log_err_desc(step, hWnd, hr, desc);
-						goto out;
-					}
-					else {
-						log_err("Successfully created _bloomOutput2R with combined flags\n");
-					}
+				//	step = "_bloomOutput2R";
+				//	hr = this->_d3dDevice->CreateTexture2D(&desc, nullptr, &this->_bloomOutput2R);
+				//	if (FAILED(hr)) {
+				//		log_err("Failed to create _bloomOutput2R\n");
+				//		log_err("GetDeviceRemovedReason: 0x%x\n", this->_d3dDevice->GetDeviceRemovedReason());
+				//		log_err("dwWidth, Height: %u, %u\n", dwWidth, dwHeight);
+				//		log_err_desc(step, hWnd, hr, desc);
+				//		goto out;
+				//	}
+				//	else {
+				//		log_err("Successfully created _bloomOutput2R with combined flags\n");
+				//	}
 
-					step = "_bloomOutputSumR";
-					hr = this->_d3dDevice->CreateTexture2D(&desc, nullptr, &this->_bloomOutputSumR);
-					if (FAILED(hr)) {
-						log_err("Failed to create _bloomOutputSumR\n");
-						log_err("GetDeviceRemovedReason: 0x%x\n", this->_d3dDevice->GetDeviceRemovedReason());
-						log_err("dwWidth, Height: %u, %u\n", dwWidth, dwHeight);
-						log_err_desc(step, hWnd, hr, desc);
-						goto out;
-					}
-					else {
-						log_err("Successfully created _bloomOutputSumR with combined flags\n");
-					}
-				}
+				//	step = "_bloomOutputSumR";
+				//	hr = this->_d3dDevice->CreateTexture2D(&desc, nullptr, &this->_bloomOutputSumR);
+				//	if (FAILED(hr)) {
+				//		log_err("Failed to create _bloomOutputSumR\n");
+				//		log_err("GetDeviceRemovedReason: 0x%x\n", this->_d3dDevice->GetDeviceRemovedReason());
+				//		log_err("dwWidth, Height: %u, %u\n", dwWidth, dwHeight);
+				//		log_err_desc(step, hWnd, hr, desc);
+				//		goto out;
+				//	}
+				//	else {
+				//		log_err("Successfully created _bloomOutputSumR with combined flags\n");
+				//	}
+				//}
 
 				// Restore the previous bind flags, just in case there is a dependency on these later on
 				desc.BindFlags = curFlags;
@@ -3230,17 +3230,17 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 					goto out;
 				}
 
-				if (g_bUseSteamVR)
-				{
-					step = "_offscreenAsInputBloomSRV_R";
-					hr = this->_d3dDevice->CreateShaderResourceView(this->_offscreenBufferAsInputBloomMaskR,
-						&shaderResourceViewDesc, &this->_offscreenAsInputBloomMaskSRV_R);
-					if (FAILED(hr)) {
-						log_err("dwWidth, Height: %u, %u\n", dwWidth, dwHeight);
-						log_shaderres_view(step, hWnd, hr, shaderResourceViewDesc);
-						goto out;
-					}
-				}
+				//if (g_bUseSteamVR)
+				//{
+				//	step = "_offscreenAsInputBloomSRV_R";
+				//	hr = this->_d3dDevice->CreateShaderResourceView(this->_offscreenBufferAsInputBloomMaskR,
+				//		&shaderResourceViewDesc, &this->_offscreenAsInputBloomMaskSRV_R);
+				//	if (FAILED(hr)) {
+				//		log_err("dwWidth, Height: %u, %u\n", dwWidth, dwHeight);
+				//		log_shaderres_view(step, hWnd, hr, shaderResourceViewDesc);
+				//		goto out;
+				//	}
+				//}
 
 				step = "_bloomOutput1SRV";
 				hr = this->_d3dDevice->CreateShaderResourceView(this->_bloomOutput1,
@@ -3274,36 +3274,36 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 					goto out;
 				}
 
-				if (g_bUseSteamVR) {
-					shaderResourceViewDesc.Format = BLOOM_BUFFER_FORMAT;
+				//if (g_bUseSteamVR) {
+				//	shaderResourceViewDesc.Format = BLOOM_BUFFER_FORMAT;
 
-					step = "_bloomOutput1SRV_R";
-					hr = this->_d3dDevice->CreateShaderResourceView(this->_bloomOutput1R,
-						&shaderResourceViewDesc, &this->_bloomOutput1SRV_R);
-					if (FAILED(hr)) {
-						log_err("dwWidth, Height: %u, %u\n", dwWidth, dwHeight);
-						log_shaderres_view(step, hWnd, hr, shaderResourceViewDesc);
-						goto out;
-					}
+				//	step = "_bloomOutput1SRV_R";
+				//	hr = this->_d3dDevice->CreateShaderResourceView(this->_bloomOutput1R,
+				//		&shaderResourceViewDesc, &this->_bloomOutput1SRV_R);
+				//	if (FAILED(hr)) {
+				//		log_err("dwWidth, Height: %u, %u\n", dwWidth, dwHeight);
+				//		log_shaderres_view(step, hWnd, hr, shaderResourceViewDesc);
+				//		goto out;
+				//	}
 
-					step = "_bloomOutput2SRV_R";
-					hr = this->_d3dDevice->CreateShaderResourceView(this->_bloomOutput2R,
-						&shaderResourceViewDesc, &this->_bloomOutput2SRV_R);
-					if (FAILED(hr)) {
-						log_err("dwWidth, Height: %u, %u\n", dwWidth, dwHeight);
-						log_shaderres_view(step, hWnd, hr, shaderResourceViewDesc);
-						goto out;
-					}
+				//	step = "_bloomOutput2SRV_R";
+				//	hr = this->_d3dDevice->CreateShaderResourceView(this->_bloomOutput2R,
+				//		&shaderResourceViewDesc, &this->_bloomOutput2SRV_R);
+				//	if (FAILED(hr)) {
+				//		log_err("dwWidth, Height: %u, %u\n", dwWidth, dwHeight);
+				//		log_shaderres_view(step, hWnd, hr, shaderResourceViewDesc);
+				//		goto out;
+				//	}
 
-					step = "_bloomOutputSumSRV_R";
-					hr = this->_d3dDevice->CreateShaderResourceView(this->_bloomOutputSumR,
-						&shaderResourceViewDesc, &this->_bloomOutputSumSRV_R);
-					if (FAILED(hr)) {
-						log_err("dwWidth, Height: %u, %u\n", dwWidth, dwHeight);
-						log_shaderres_view(step, hWnd, hr, shaderResourceViewDesc);
-						goto out;
-					}
-				}
+				//	step = "_bloomOutputSumSRV_R";
+				//	hr = this->_d3dDevice->CreateShaderResourceView(this->_bloomOutputSumR,
+				//		&shaderResourceViewDesc, &this->_bloomOutputSumSRV_R);
+				//	if (FAILED(hr)) {
+				//		log_err("dwWidth, Height: %u, %u\n", dwWidth, dwHeight);
+				//		log_shaderres_view(step, hWnd, hr, shaderResourceViewDesc);
+				//		goto out;
+				//	}
+				//}
 				shaderResourceViewDesc.Format = oldFormat;
 			}
 
@@ -3737,11 +3737,11 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 			if (FAILED(hr)) goto out;
 
 			if (g_bUseSteamVR) {
-				step = "_renderTargetViewBloomMaskR";
-				hr = this->_d3dDevice->CreateRenderTargetView(this->_offscreenBufferBloomMaskR,
-					&GetRtvDesc(this->_useMultisampling, g_bUseSteamVR, BLOOM_BUFFER_FORMAT),
-					&this->_renderTargetViewBloomMaskR);
-				if (FAILED(hr)) goto out;
+				//step = "_renderTargetViewBloomMaskR";
+				//hr = this->_d3dDevice->CreateRenderTargetView(this->_offscreenBufferBloomMaskR,
+				//	&GetRtvDesc(this->_useMultisampling, g_bUseSteamVR, BLOOM_BUFFER_FORMAT),
+				//	&this->_renderTargetViewBloomMaskR);
+				//if (FAILED(hr)) goto out;
 
 				//step = "_renderTargetViewEmissionMaskR";
 				//hr = this->_d3dDevice->CreateRenderTargetView(this->_ssEmissionMaskR, &renderTargetViewDescNoMSAA, &this->_renderTargetViewEmissionMaskR);
@@ -3771,19 +3771,19 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 			hr = this->_d3dDevice->CreateRenderTargetView(this->_bloomOutputSum, &GetRtvDesc(false, g_bUseSteamVR, BLOOM_BUFFER_FORMAT), &this->_renderTargetViewBloomSum);
 			if (FAILED(hr)) goto out;
 
-			if (g_bUseSteamVR) {
-				step = "_renderTargetViewBloom1R";
-				hr = this->_d3dDevice->CreateRenderTargetView(this->_bloomOutput1R, &GetRtvDesc(false, g_bUseSteamVR, BLOOM_BUFFER_FORMAT), &this->_renderTargetViewBloom1R);
-				if (FAILED(hr)) goto out;
+			//if (g_bUseSteamVR) {
+			//	step = "_renderTargetViewBloom1R";
+			//	hr = this->_d3dDevice->CreateRenderTargetView(this->_bloomOutput1R, &GetRtvDesc(false, g_bUseSteamVR, BLOOM_BUFFER_FORMAT), &this->_renderTargetViewBloom1R);
+			//	if (FAILED(hr)) goto out;
 
-				step = "_renderTargetViewBloom2R";
-				hr = this->_d3dDevice->CreateRenderTargetView(this->_bloomOutput2R, &GetRtvDesc(false, g_bUseSteamVR, BLOOM_BUFFER_FORMAT), &this->_renderTargetViewBloom2R);
-				if (FAILED(hr)) goto out;
+			//	step = "_renderTargetViewBloom2R";
+			//	hr = this->_d3dDevice->CreateRenderTargetView(this->_bloomOutput2R, &GetRtvDesc(false, g_bUseSteamVR, BLOOM_BUFFER_FORMAT), &this->_renderTargetViewBloom2R);
+			//	if (FAILED(hr)) goto out;
 
-				step = "_renderTargetViewBloomSumR";
-				hr = this->_d3dDevice->CreateRenderTargetView(this->_bloomOutputSumR, &GetRtvDesc(false, g_bUseSteamVR, BLOOM_BUFFER_FORMAT), &this->_renderTargetViewBloomSumR);
-				if (FAILED(hr)) goto out;
-			}
+			//	step = "_renderTargetViewBloomSumR";
+			//	hr = this->_d3dDevice->CreateRenderTargetView(this->_bloomOutputSumR, &GetRtvDesc(false, g_bUseSteamVR, BLOOM_BUFFER_FORMAT), &this->_renderTargetViewBloomSumR);
+			//	if (FAILED(hr)) goto out;
+			//}
 		}
 
 		// SSAO RTVs

--- a/impl11/ddraw/DeviceResources.h
+++ b/impl11/ddraw/DeviceResources.h
@@ -268,10 +268,10 @@ public:
 	ComPtr<ID3D11Texture2D> _bloomOutput1; // Output from bloom pass 1
 	ComPtr<ID3D11Texture2D> _bloomOutput2; // Output from bloom pass 2
 	ComPtr<ID3D11Texture2D> _bloomOutputSum; // Bloom accummulator
-	ComPtr<ID3D11Texture2D> _bloomOutput1R; // Output from bloom pass 1, right image (SteamVR)
-	ComPtr<ID3D11Texture2D> _bloomOutput2R; // Output from bloom pass 2, right image (SteamVR)
-	ComPtr<ID3D11Texture2D> _bloomOutputSumR; // Bloom accummulator (SteamVR)
-	// Ambient Occlusion
+	//ComPtr<ID3D11Texture2D> _bloomOutput1R; // Output from bloom pass 1, right image (SteamVR)
+	//ComPtr<ID3D11Texture2D> _bloomOutput2R; // Output from bloom pass 2, right image (SteamVR)
+	//ComPtr<ID3D11Texture2D> _bloomOutputSumR; // Bloom accummulator (SteamVR)
+	//// Ambient Occlusion
 	ComPtr<ID3D11Texture2D> _depthBuf;
 	ComPtr<ID3D11Texture2D> _depthBufR;
 	ComPtr<ID3D11Texture2D> _depthBufAsInput;

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -8272,7 +8272,7 @@ void EffectsRenderer::RenderHangarShadowMap()
 	// Init the Viewport. This viewport has the dimensions of the shadowmap texture
 	_deviceResources->InitViewport(&g_ShadowMapping.ViewPort);
 	_deviceResources->InitTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-	_deviceResources->InitInputLayout(_inputLayout);
+	_deviceResources->InitInputLayout(resources->_shadowMapInputLayout);
 
 	_deviceResources->InitVertexShader(resources->_hangarShadowMapVS);
 	_deviceResources->InitPixelShader(resources->_shadowMapPS);

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -1664,8 +1664,8 @@ void PrimarySurface::BloomPyramidLevelPass(int PyramidLevel, int AdditionalPasse
 	// The blur output will *always* be in bloom2, let's copy it to the bloom masks to reuse it for the
 	// next pass:
 	context->CopyResource(resources->_offscreenBufferAsInputBloomMask, resources->_bloomOutput2);
-	if (g_bUseSteamVR)
-		context->CopyResource(resources->_offscreenBufferAsInputBloomMaskR, resources->_bloomOutput2R);
+	//if (g_bUseSteamVR)
+	//	context->CopyResource(resources->_offscreenBufferAsInputBloomMaskR, resources->_bloomOutput2R);
 
 	// DEBUG
 	/*if (g_iPresentCounter == 100 || g_bDumpBloomBuffers) {
@@ -1686,8 +1686,8 @@ void PrimarySurface::BloomPyramidLevelPass(int PyramidLevel, int AdditionalPasse
 
 	// Copy _bloomOutput1 over _bloomOutputSum
 	context->CopyResource(resources->_bloomOutputSum, resources->_bloomOutput1);
-	if (g_bUseSteamVR)
-		context->CopyResource(resources->_bloomOutputSumR, resources->_bloomOutput1R);
+	//if (g_bUseSteamVR)
+	//	context->CopyResource(resources->_bloomOutputSumR, resources->_bloomOutput1R);
 	this->_deviceResources->EndAnnotatedEvent();
 	// DEBUG
 	/*if (g_bDumpSSAOBuffers) {

--- a/impl11/shaders/HangarShadowMapVS.hlsl
+++ b/impl11/shaders/HangarShadowMapVS.hlsl
@@ -6,17 +6,17 @@ Buffer<float3> g_vertices : register(t0);
 
 struct VertexShaderInput
 {
-	int4 index : POSITION;
+	float4 index : POSITION;
 };
 
-struct PixelShaderInput
+struct SHADOW_PS_INPUT
 {
 	float4 pos : SV_POSITION;
 };
 
-PixelShaderInput main(VertexShaderInput input)
+SHADOW_PS_INPUT main(VertexShaderInput input)
 {
-	PixelShaderInput output;
+	SHADOW_PS_INPUT output;
 
 	float3 v = g_vertices[input.index.x];
 	// OPT (object space) to viewspace transform:


### PR DESCRIPTION
DirectX debug layer error when entering into the hangar:

12:05:08:758	D3D11 ERROR: ID3D11DeviceContext::DrawIndexed: Input Assembler - Vertex Shader linkage error: Signatures between stages are incompatible. Semantic 'POSITION' has mismatched data types between the output stage and input stage. [ EXECUTION ERROR #344: DEVICE_SHADER_LINKAGE_COMPONENTTYPE]

The input layout selected was not the correct one, must be specific for shadow maps.

I have also included the removal of expensive `CopyResources()` calls for the right eye buffer (now unused thanks to instanced stereo) from the Bloom calculation.