### PR TITLE
Fix Default Starfield

### DIFF
--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -3074,12 +3074,6 @@ HRESULT Direct3DDevice::Execute(
 		// This avoids blocking the CPU while the compositor waits for the pixel shader effects to run in the GPU
 		// (that's what happens if we sync after Submit+Present)
 		UpdateViewMatrix(); // g_ExecuteCount == 1 && !g_bInTechRoom
-
-		if (!g_bMapMode)
-		{
-			//RenderSkyBox();
-			resources->_primarySurface->RenderDefaultBackground();
-		}
 	}
 
 	// Render images
@@ -6344,6 +6338,18 @@ HRESULT Direct3DDevice::BeginScene()
 		for (int i = 0; i < length; i++)
 		{
 			buffer[i] = 0x200000;
+		}
+	}
+
+	// Capture the state of the external camera. We'll use this information to render the default
+	// starfield at the end of the frame.
+	{
+		g_externalCameraState.craftIndex = PlayerDataTable[*g_playerIndex].Camera.CraftIndex;
+		g_externalCameraState.externalCamera = PlayerDataTable[*g_playerIndex].Camera.ExternalCamera;
+		if (g_externalCameraState.externalCamera)
+		{
+			g_externalCameraState.yaw   = -(float)PlayerDataTable[*g_playerIndex].Camera.Yaw   / 65536.0f * 360.0f;
+			g_externalCameraState.pitch =  (float)PlayerDataTable[*g_playerIndex].Camera.Pitch / 65536.0f * 360.0f;
 		}
 	}
 

--- a/impl11/ddraw/Effects.h
+++ b/impl11/ddraw/Effects.h
@@ -25,6 +25,7 @@ struct ExternalCameraState
 	int craftIndex;
 	float yaw, pitch;
 	bool defaultBackgroundRendered;
+	bool externalCamera;
 };
 extern ExternalCameraState g_externalCameraState;
 

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -6267,15 +6267,6 @@ void EffectsRenderer::RenderScene(bool bBindTranspLyr1)
 	auto& resources = _deviceResources;
 	auto& context = _deviceResources->_d3dDeviceContext;
 
-	if (g_iD3DExecuteCounter == 0 && !g_bInTechRoom)
-	{
-		g_externalCameraState.craftIndex = PlayerDataTable[*g_playerIndex].Camera.CraftIndex;
-		if (PlayerDataTable[*g_playerIndex].Camera.ExternalCamera) {
-			g_externalCameraState.yaw   = -(float)PlayerDataTable[*g_playerIndex].Camera.Yaw   / 65536.0f * 360.0f;
-			g_externalCameraState.pitch =  (float)PlayerDataTable[*g_playerIndex].Camera.Pitch / 65536.0f * 360.0f;
-		}
-	}
-
 #ifdef DISABLED
 	if (g_iD3DExecuteCounter == 0 && !g_bInTechRoom)
 	{

--- a/impl11/ddraw/SteamVR.h
+++ b/impl11/ddraw/SteamVR.h
@@ -27,6 +27,7 @@ extern bool g_bRenderDefaultStarfield;
 extern bool g_bDebugDefaultStarfield;
 extern bool g_bReplaceBackdrops;
 extern bool g_bDefaultStarfieldRendered;
+extern bool g_bUseExternalCameraState;
 extern bool g_bSteamVRMirrorWindowLeftEye;
 extern const bool DEFAULT_INTERLEAVED_REPROJECTION;
 extern const bool DEFAULT_STEAMVR_POS_FROM_FREEPIE;

--- a/impl11/ddraw/SteamVRRenderer.cpp
+++ b/impl11/ddraw/SteamVRRenderer.cpp
@@ -71,15 +71,6 @@ void SteamVRRenderer::RenderScene(bool bBindTranspLyr1)
 	auto &resources = _deviceResources;
 	auto &context = resources->_d3dDeviceContext;
 
-	if (g_iD3DExecuteCounter == 0 && !g_bInTechRoom)
-	{
-		g_externalCameraState.craftIndex = PlayerDataTable[*g_playerIndex].Camera.CraftIndex;
-		if (PlayerDataTable[*g_playerIndex].Camera.ExternalCamera) {
-			g_externalCameraState.yaw   = -(float)PlayerDataTable[*g_playerIndex].Camera.Yaw   / 65536.0f * 360.0f;
-			g_externalCameraState.pitch =  (float)PlayerDataTable[*g_playerIndex].Camera.Pitch / 65536.0f * 360.0f;
-		}
-	}
-
 #ifdef DISABLED
 	if (g_iD3DExecuteCounter == 0 && !g_bInTechRoom)
 	{


### PR DESCRIPTION
There's some situations where the default starfield is
not displayed properly (when Direct3DDevice::Execute()
is not called). This fixes those situations.