### PR TITLE
Enhanced HUD, various improvements

### DIFF
--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -4121,7 +4121,10 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 				if (g_EnhancedHUDData.Enabled)
 				{
 					this->_d2d1EnhancedHUDRenderTarget->SetAntialiasMode(g_config.Geometry2DAntiAlias ? D2D1_ANTIALIAS_MODE_PER_PRIMITIVE : D2D1_ANTIALIAS_MODE_ALIASED);
-					this->_d2d1EnhancedHUDRenderTarget->SetTextAntialiasMode(g_config.Text2DAntiAlias ? D2D1_TEXT_ANTIALIAS_MODE_CLEARTYPE : D2D1_TEXT_ANTIALIAS_MODE_ALIASED);
+					// The Cleartype mode destroys the alpha component (the alpha is _always_ 0 after rendering the text).
+					// For the Enhanced HUD, we might want to add transparency or even render a dark rect below the text
+					// to make it easier to read. So, let's use a different antialias mode that writes the alpha channel:
+					this->_d2d1EnhancedHUDRenderTarget->SetTextAntialiasMode(D2D1_TEXT_ANTIALIAS_MODE_GRAYSCALE);
 				}
 
 				this->_d2d1DCRenderTarget->SetAntialiasMode(g_config.Geometry2DAntiAlias ? D2D1_ANTIALIAS_MODE_PER_PRIMITIVE : D2D1_ANTIALIAS_MODE_ALIASED);

--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -1737,8 +1737,6 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 	this->_depthStencilR.Release();
 	this->_d2d1RenderTarget.Release();
 	this->_d2d1OffscreenRenderTarget.Release();
-	if (g_bUseSteamVR && g_EnhancedHUDData.Enabled)
-		_d2d1EnhancedHUDRenderTarget.Release();
 	this->_d2d1DCRenderTarget.Release();
 	this->_renderTargetView.Release();
 	if (g_bUseSteamVR)
@@ -4077,7 +4075,6 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 		ComPtr<IDXGISurface> surface;
 		ComPtr<IDXGISurface> offscreenSurface;
 		ComPtr<IDXGISurface> DCSurface;
-		ComPtr<IDXGISurface> enhancedHUDSurface;
 		// The logic for the Dynamic Cockpit expects the text to be in its own
 		// buffer so that the alpha can be fixed and the text can be blended
 		// properly. So, instead of using _offscreenBuffer, we always write to
@@ -4092,9 +4089,6 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 		else
 			hr = this->_offscreenBuffer.As(&offscreenSurface);
 
-		if (g_bUseSteamVR && g_EnhancedHUDData.Enabled)
-			this->_enhancedHUDBuffer.As(&enhancedHUDSurface);
-
 		// This surface can be used to render directly to the DC foreground buffer
 		//if (g_bDynCockpitEnabled)
 			hr = this->_offscreenBufferDynCockpit.As(&DCSurface);
@@ -4108,8 +4102,6 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 			hr = this->_d2d1Factory->CreateDxgiSurfaceRenderTarget(surface, properties, &this->_d2d1RenderTarget);
 			hr = this->_d2d1Factory->CreateDxgiSurfaceRenderTarget(DCSurface, properties, &this->_d2d1DCRenderTarget);
 			hr = this->_d2d1Factory->CreateDxgiSurfaceRenderTarget(offscreenSurface, properties, &this->_d2d1OffscreenRenderTarget);
-			if (g_bUseSteamVR && g_EnhancedHUDData.Enabled)
-				hr = this->_d2d1Factory->CreateDxgiSurfaceRenderTarget(enhancedHUDSurface, properties, &this->_d2d1EnhancedHUDRenderTarget);
 
 			if (SUCCEEDED(hr))
 			{
@@ -4118,11 +4110,6 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 
 				this->_d2d1OffscreenRenderTarget->SetAntialiasMode(g_config.Geometry2DAntiAlias ? D2D1_ANTIALIAS_MODE_PER_PRIMITIVE : D2D1_ANTIALIAS_MODE_ALIASED);
 				this->_d2d1OffscreenRenderTarget->SetTextAntialiasMode(g_config.Text2DAntiAlias ? D2D1_TEXT_ANTIALIAS_MODE_CLEARTYPE : D2D1_TEXT_ANTIALIAS_MODE_ALIASED);
-				if (g_bUseSteamVR && g_EnhancedHUDData.Enabled)
-				{
-					this->_d2d1EnhancedHUDRenderTarget->SetAntialiasMode(g_config.Geometry2DAntiAlias ? D2D1_ANTIALIAS_MODE_PER_PRIMITIVE : D2D1_ANTIALIAS_MODE_ALIASED);
-					this->_d2d1EnhancedHUDRenderTarget->SetTextAntialiasMode(g_config.Text2DAntiAlias ? D2D1_TEXT_ANTIALIAS_MODE_CLEARTYPE : D2D1_TEXT_ANTIALIAS_MODE_ALIASED);
-				}
 
 				this->_d2d1DCRenderTarget->SetAntialiasMode(g_config.Geometry2DAntiAlias ? D2D1_ANTIALIAS_MODE_PER_PRIMITIVE : D2D1_ANTIALIAS_MODE_ALIASED);
 				this->_d2d1DCRenderTarget->SetTextAntialiasMode(g_config.Text2DAntiAlias ? D2D1_TEXT_ANTIALIAS_MODE_CLEARTYPE : D2D1_TEXT_ANTIALIAS_MODE_ALIASED);

--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -33,6 +33,7 @@
 #include "../Debug/PixelShaderDCHolo.h"
 #include "../Debug/PixelShaderEmptyDC.h"
 #include "../Debug/PixelShaderHUD.h"
+#include "../Debug/EnhancedHudPS.h"
 #include "../Debug/PixelShaderSolid.h"
 #include "../Debug/PixelShaderClearBox.h"
 #include "../Debug/BloomHGaussPS.h"
@@ -122,6 +123,7 @@
 #include "../Release/PixelShaderDCHolo.h"
 #include "../Release/PixelShaderEmptyDC.h"
 #include "../Release/PixelShaderHUD.h"
+#include "../Release/EnhancedHudPS.h"
 #include "../Release/PixelShaderSolid.h"
 #include "../Release/PixelShaderClearBox.h"
 #include "../Release/BloomHGaussPS.h"
@@ -4602,6 +4604,9 @@ HRESULT DeviceResources::LoadResources()
 	}
 
 	if (FAILED(hr = this->_d3dDevice->CreatePixelShader(g_PixelShaderHUD, sizeof(g_PixelShaderHUD), nullptr, &_pixelShaderHUD)))
+		return hr;
+
+	if (FAILED(hr = this->_d3dDevice->CreatePixelShader(g_EnhancedHudPS, sizeof(g_EnhancedHudPS), nullptr, &_enhancedHudPS)))
 		return hr;
 
 	if (FAILED(hr = this->_d3dDevice->CreatePixelShader(g_PixelShaderSolid, sizeof(g_PixelShaderSolid), nullptr, &_pixelShaderSolid)))

--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -1815,11 +1815,6 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 		this->_shadertoyBufR.Release();
 		this->_shadertoyRTV_R.Release();
 		this->_shadertoySRV_R.Release();
-		if (g_EnhancedHUDData.Enabled)
-		{
-			this->_enhancedHUDBuffer.Release();
-			this->_enhancedHUDSRV.Release();
-		}
 	}
 	if (g_b3DVisionEnabled) {
 		log_debug("[DBG] [3DV] Releasing 3D vision buffers");
@@ -2815,25 +2810,6 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 					log_err("Successfully created _DCTextAsInput with combined flags\n");
 				}
 
-				if (g_bUseSteamVR && g_EnhancedHUDData.Enabled)
-				{
-					CD3D11_TEXTURE2D_DESC tmp = desc;
-					desc.Width  = VR_ENHANCED_HUD_BUFFER_SIZE;
-					desc.Height = VR_ENHANCED_HUD_BUFFER_SIZE;
-					hr = this->_d3dDevice->CreateTexture2D(&desc, nullptr, &this->_enhancedHUDBuffer);
-					if (FAILED(hr)) {
-						log_err("Failed to create _enhancedHUDBuffer, error: 0x%x\n", hr);
-						log_err("GetDeviceRemovedReason: 0x%x\n", this->_d3dDevice->GetDeviceRemovedReason());
-						log_err("dwWidth, Height: %u, %u\n", dwWidth, dwHeight);
-						log_err_desc(step, hWnd, hr, desc);
-						goto out;
-					}
-					else {
-						log_err("Successfully created _enhancedHUDBuffer\n");
-					}
-					desc = tmp;
-				}
-
 				// Restore the previous bind flags, just in case there is a dependency on these later on
 				desc.BindFlags = curFlags;
 			}
@@ -3513,17 +3489,6 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 					log_err("dwWidth, Height: %u, %u\n", dwWidth, dwHeight);
 					log_shaderres_view(step, hWnd, hr, shaderResourceViewDesc);
 					goto out;
-				}
-
-				if (g_bUseSteamVR && g_EnhancedHUDData.Enabled)
-				{
-					step = "_enhancedHUDBuffer";
-					hr = this->_d3dDevice->CreateShaderResourceView(this->_enhancedHUDBuffer,
-						&shaderResourceViewDesc, &this->_enhancedHUDSRV);
-					if (FAILED(hr)) {
-						log_shaderres_view(step, hWnd, hr, shaderResourceViewDesc);
-						goto out;
-					}
 				}
 			}
 

--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -1728,7 +1728,6 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 	ResetGameEvent();
 	ResetObjectIndexMap();
 	ReloadInterdictionMap();
-	ClearSpeciesCompMap();
 	//ResetRawMouseInput();
 	if (IsZIPReaderLoaded() && g_bCleanupZIPDirs)
 		DeleteAllTempZIPDirectories();

--- a/impl11/ddraw/DeviceResources.h
+++ b/impl11/ddraw/DeviceResources.h
@@ -237,6 +237,7 @@ public:
 	ComPtr<ID3D11Texture2D> _transpBufferAsInput1;    // Non-MSAA, associated with an SRV
 	ComPtr<ID3D11Texture2D> _transpBuffer2;           // MSAA, keeps the second transparency layer
 	ComPtr<ID3D11Texture2D> _transpBufferAsInput2;    // Non-MSAA, associated with an SRV
+	ComPtr<ID3D11Texture2D> _enhancedHUDBuffer;       // Non-MSAA
 	//ComPtr<ID3D11Texture2D> _textureCube;             // Non-MSAA
 	ID3D11Texture2D* _textureCube;
 
@@ -379,6 +380,7 @@ public:
 	ComPtr<ID3D11ShaderResourceView> _offscreenAsInputDynCockpitBG_SRV; // SRV for HUD element backgrounds
 	ComPtr<ID3D11ShaderResourceView> _DCTextSRV;						// SRV for the HUD text
 	ComPtr<ID3D11ShaderResourceView> _ReticleSRV;						// SRV for the reticle
+	ComPtr<ID3D11ShaderResourceView> _enhancedHUDSRV;
 	// Shadertoy
 	ComPtr<ID3D11ShaderResourceView> _shadertoySRV;
 	ComPtr<ID3D11ShaderResourceView> _shadertoySRV_R;
@@ -431,6 +433,7 @@ public:
 	ComPtr<IDWriteFactory> _dwriteFactory;
 	ComPtr<ID2D1RenderTarget> _d2d1RenderTarget;
 	ComPtr<ID2D1RenderTarget> _d2d1OffscreenRenderTarget;
+	ComPtr<ID2D1RenderTarget> _d2d1EnhancedHUDRenderTarget;
 	ComPtr<ID2D1RenderTarget> _d2d1DCRenderTarget;
 	ComPtr<ID2D1DrawingStateBlock> _d2d1DrawingStateBlock;
 

--- a/impl11/ddraw/DeviceResources.h
+++ b/impl11/ddraw/DeviceResources.h
@@ -543,6 +543,7 @@ public:
 	ComPtr<ID3D11PixelShader> _pixelShaderDCHolo;
 	ComPtr<ID3D11PixelShader> _pixelShaderEmptyDC;
 	ComPtr<ID3D11PixelShader> _pixelShaderHUD;
+	ComPtr<ID3D11PixelShader> _enhancedHudPS;
 	ComPtr<ID3D11PixelShader> _pixelShaderSolid;
 	ComPtr<ID3D11PixelShader> _pixelShaderClearBox;
 	ComPtr<ID3D11PixelShader> _pixelShaderAnim;

--- a/impl11/ddraw/DeviceResources.h
+++ b/impl11/ddraw/DeviceResources.h
@@ -237,7 +237,6 @@ public:
 	ComPtr<ID3D11Texture2D> _transpBufferAsInput1;    // Non-MSAA, associated with an SRV
 	ComPtr<ID3D11Texture2D> _transpBuffer2;           // MSAA, keeps the second transparency layer
 	ComPtr<ID3D11Texture2D> _transpBufferAsInput2;    // Non-MSAA, associated with an SRV
-	ComPtr<ID3D11Texture2D> _enhancedHUDBuffer;       // Non-MSAA
 	//ComPtr<ID3D11Texture2D> _textureCube;             // Non-MSAA
 	ID3D11Texture2D* _textureCube;
 
@@ -380,7 +379,6 @@ public:
 	ComPtr<ID3D11ShaderResourceView> _offscreenAsInputDynCockpitBG_SRV; // SRV for HUD element backgrounds
 	ComPtr<ID3D11ShaderResourceView> _DCTextSRV;						// SRV for the HUD text
 	ComPtr<ID3D11ShaderResourceView> _ReticleSRV;						// SRV for the reticle
-	ComPtr<ID3D11ShaderResourceView> _enhancedHUDSRV;
 	// Shadertoy
 	ComPtr<ID3D11ShaderResourceView> _shadertoySRV;
 	ComPtr<ID3D11ShaderResourceView> _shadertoySRV_R;

--- a/impl11/ddraw/DeviceResources.h
+++ b/impl11/ddraw/DeviceResources.h
@@ -433,7 +433,6 @@ public:
 	ComPtr<IDWriteFactory> _dwriteFactory;
 	ComPtr<ID2D1RenderTarget> _d2d1RenderTarget;
 	ComPtr<ID2D1RenderTarget> _d2d1OffscreenRenderTarget;
-	ComPtr<ID2D1RenderTarget> _d2d1EnhancedHUDRenderTarget;
 	ComPtr<ID2D1RenderTarget> _d2d1DCRenderTarget;
 	ComPtr<ID2D1DrawingStateBlock> _d2d1DrawingStateBlock;
 

--- a/impl11/ddraw/DynamicCockpit.cpp
+++ b/impl11/ddraw/DynamicCockpit.cpp
@@ -916,7 +916,23 @@ bool LoadDCInternalCoordinates() {
 				}
 				Box box = { 0 };
 				if (LoadDCGlobalUVCoords(buf, &box))
+				{
+					// HACK ALERT: The coords for the following areas don't actually cover the strings
+					//             very well. I could either distribute a new .cfg file to fix this, but
+					//             honestly, who is even using these? (I would've received complaints by now).
+					//             So, I'm just going to override the areas with coords that actually work.
+					if (source_slot == TARGETED_OBJ_NAME_SRC_IDX)
+					{
+						box.x0 =  72.0f / 256.0f; box.y0 = 15.0f / 128.0f;
+						box.x1 = 184.0f / 256.0f; box.y1 = 28.0f / 128.0f;
+					}
+					else if (source_slot == TARGETED_OBJ_CARGO_SRC_IDX)
+					{
+						box.x0 =  14.0f / 256.0f; box.y0 = 110.0f / 128.0f;
+						box.x1 = 100.0f / 256.0f; box.y1 = 128.0f / 128.0f;
+					}
 					g_DCElemSrcBoxes.src_boxes[source_slot].uv_coords = box;
+				}
 				else
 					log_debug("[DBG] [DC] WARNING: '%s' could not be loaded", buf);
 				source_slot++;

--- a/impl11/ddraw/Effects.cpp
+++ b/impl11/ddraw/Effects.cpp
@@ -1215,6 +1215,23 @@ CraftInstance* GetCraftInstanceSafe(int16_t objectIndex, ObjectEntry** object, M
 	return craftInstance;
 }
 
+CraftInstance* GetCraftInstanceForCurrentTargetSafe()
+{
+	if (g_iPresentCounter <= PLAYERDATATABLE_MIN_SAFE_FRAME) return nullptr;
+
+	short currentTargetIndex = *g_playerInHangar ?
+		PlayerDataTable[*g_playerIndex].objectIndex : PlayerDataTable[*g_playerIndex].currentTargetIndex;
+	if (currentTargetIndex < 0)
+		return nullptr;
+
+	ObjectEntry *object = &((*objects)[currentTargetIndex]);
+	if (object == NULL) return nullptr;
+	MobileObjectEntry *mobileObject = object->MobileObjectPtr;
+	if (mobileObject == NULL) return nullptr;
+	CraftInstance *craftInstance = mobileObject->craftInstancePtr;
+	return craftInstance;
+}
+
 // This code is courtesy of Jeremy.
 bool InTechGlobe()
 {

--- a/impl11/ddraw/Effects.cpp
+++ b/impl11/ddraw/Effects.cpp
@@ -408,12 +408,23 @@ void InGameToScreenCoords(UINT left, UINT top, UINT width, UINT height, float x,
 	*y_out = top + y / g_fCurInGameHeight * height;
 }
 
+void InGameToScreenCoords(float x, float y, float* x_out, float* y_out)
+{
+	InGameToScreenCoords((UINT)g_nonVRViewport.TopLeftX, (UINT)g_nonVRViewport.TopLeftY,
+		(UINT)g_nonVRViewport.Width, (UINT)g_nonVRViewport.Height, x, y, x_out, y_out);
+}
+
 void ScreenCoordsToInGame(float left, float top, float width, float height, float x, float y, float* x_out, float* y_out)
 {
 	*x_out = g_fCurInGameWidth * (x - left) / width;
 	*y_out = g_fCurInGameHeight * (y - top) / height;
 }
 
+void ScreenCoordsToInGame(float x, float y, float* x_out, float* y_out)
+{
+	ScreenCoordsToInGame(g_nonVRViewport.TopLeftX, g_nonVRViewport.TopLeftY,
+		g_nonVRViewport.Width, g_nonVRViewport.Height, x, y, x_out, y_out);
+}
 
 void CycleFOVSetting()
 {

--- a/impl11/ddraw/Effects.h
+++ b/impl11/ddraw/Effects.h
@@ -292,6 +292,7 @@ CraftInstance *GetPlayerCraftInstanceSafe();
 CraftInstance *GetPlayerCraftInstanceSafe(ObjectEntry** object);
 CraftInstance* GetPlayerCraftInstanceSafe(ObjectEntry** object, MobileObjectEntry** mobileObject);
 CraftInstance* GetCraftInstanceSafe(int16_t objectIndex, ObjectEntry** object, MobileObjectEntry** mobileObject);
+CraftInstance* GetCraftInstanceForCurrentTargetSafe();
 // Also updates g_bInTechGlobe when called.
 bool InTechGlobe();
 bool InBriefingRoom();

--- a/impl11/ddraw/Effects.h
+++ b/impl11/ddraw/Effects.h
@@ -132,7 +132,9 @@ bool isInVector(char* name, std::vector<char*>& vector);
 bool isInVector(char* OPTname, std::vector<OPTNameType>& vector);
 void DisplayCoords(LPD3DINSTRUCTION instruction, UINT curIndex);
 void InGameToScreenCoords(UINT left, UINT top, UINT width, UINT height, float x, float y, float* x_out, float* y_out);
+void InGameToScreenCoords(float x, float y, float* x_out, float* y_out);
 void ScreenCoordsToInGame(float left, float top, float width, float height, float x, float y, float* x_out, float* y_out);
+void ScreenCoordsToInGame(float x, float y, float* x_out, float* y_out);
 void GetScreenLimitsInUVCoords(float* x0, float* y0, float* x1, float* y1, bool UseNonVR = false);
 
 bool UpdateXWAHackerFOV();

--- a/impl11/ddraw/EffectsCommon.h
+++ b/impl11/ddraw/EffectsCommon.h
@@ -396,7 +396,7 @@ typedef struct RTConstantsBufferStruct {
 struct VRGeometryCBuffer {
 	uint32_t numStickyRegions;
 	uint32_t clicked[2];
-	bool     bRenderBracket;
+	uint32_t renderBracket;
 	// 16 bytes
 	float4   stickyRegions[MAX_VRKEYB_REGIONS];
 	// 80 bytes
@@ -405,10 +405,9 @@ struct VRGeometryCBuffer {
 	float    strokeWidth;
 	float3   bracketColor;
 	// 128 bytes
-	//float4   U;
-	uint32_t renderText;
-	uint32_t isSubComponent;
-	uint32_t vrg_unused0[2];
+	//float4   U;;
+	float    u0, v0;
+	float    u1, v1;
 	// 144 bytes
 	Matrix4  viewMat;
 	// 208 bytes

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -7521,7 +7521,7 @@ void EffectsRenderer::RenderVRHUD()
  */
 void EffectsRenderer::RenderVREnhancedHUD()
 {
-	if (!g_bUseSteamVR || !g_bRendering3D || _bEnhancedBracketsRendered || !_bCockpitConstantsCaptured ||
+	if (!g_bUseSteamVR || !g_bRendering3D || _bEnhancedBracketsRendered ||
 		*g_playerInHangar || !g_curTargetBracketVRCaptured)
 		return;
 

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -1,5 +1,6 @@
 #include "common.h"
 #include "EffectsRenderer.h"
+#include "XwaDrawBracketHook.h"
 #include <algorithm>
 
 void ProcessKeyboard();
@@ -113,6 +114,8 @@ VRGlovesMesh g_vrGlovesMeshes[2];
 EffectsRenderer *g_effects_renderer = nullptr;
 
 std::vector<BracketVR> g_bracketsVR;
+BracketVR g_curTargetBracketVR;
+bool g_curTargetBracketVRCaptured = false;
 
 // Current turn rate. This will make the ship turn faster at 1/3 throttle.
 // This variable makes a smooth transition when the throttle changes.
@@ -7488,6 +7491,221 @@ void EffectsRenderer::RenderVRHUD()
 		DotTransform = V;
 		// This is the same as doing DotTransform = T * V:
 		DotTransform.translate(X);
+	}
+	//else
+	//{
+	//	Matrix4 swapScale({ 1,0,0,0,  0,0,-1,0,  0,-1,0,0,  0,0,0,1 });
+	//	Matrix4 S = Matrix4().scale(OPT_TO_METERS);
+	//	Matrix4 Sinv = Matrix4().scale(METERS_TO_OPT);
+	//	Matrix4 T = Matrix4().translate(g_LaserPointerIntersSteamVR[contIdx]);
+	//	Matrix4 toOPT = Sinv * swap;
+	//	Matrix4 toSteamVR = swap * S;
+	//	// This transform chain is the same as the one used in RenderVRGloves minus gloveDisp and
+	//	// pose is replaced with T. Also, V is used to convert the mesh into a billboard first
+	//	DotTransform = swapScale * toOPT * Vinv * T * toSteamVR * V;
+	//}
+	// The Vertex Shader does post-multiplication, so we need to transpose the matrix:
+	DotTransform.transpose();
+	g_OPTMeshTransformCB.MeshTransform = DotTransform;
+
+	// Apply the VS and PS constants
+	resources->InitVSConstantOPTMeshTransform(resources->_OPTMeshTransformCB.GetAddressOf(), &g_OPTMeshTransformCB);
+	RenderScene(false);
+
+	_bHUDRendered = true;
+	RestoreContext();
+	_deviceResources->EndAnnotatedEvent();
+}
+
+/*
+ * Renders quads around the current target bracket where information can be displayed.
+ * Based on RenderVRHUD(). The fake HUD quad that is normally rendered right on top of the
+ * reticle is rotated around the origin so that it keeps its apparent size. Additional rotations
+ * are applied to keep the up direction and to apply a displacement so that the quad appears around
+ * the current target bracket.
+ */
+void EffectsRenderer::RenderVREnhancedHUD()
+{
+	if (!g_bUseSteamVR || !g_bRendering3D || _bHUDRendered || !_bCockpitConstantsCaptured ||
+		!g_curTargetBracketVRCaptured)
+		return;
+
+	_deviceResources->BeginAnnotatedEvent(L"RenderVREnhancedHUD");
+
+	auto& resources = _deviceResources;
+	auto& context = resources->_d3dDeviceContext;
+	const bool bGunnerTurret = (g_iPresentCounter > PLAYERDATATABLE_MIN_SAFE_FRAME) ?
+		PlayerDataTable[*g_playerIndex].gunnerTurretActive : false;
+	const bool bInHangar = *g_playerInHangar;
+
+	SaveContext();
+
+	context->VSSetConstantBuffers(0, 1, _constantBuffer.GetAddressOf());
+	context->PSSetConstantBuffers(0, 1, _constantBuffer.GetAddressOf());
+	// Set the proper rasterizer and depth stencil states for transparency
+	_deviceResources->InitBlendState(_transparentBlendState, nullptr);
+	//_deviceResources->InitDepthStencilState(_transparentDepthState, nullptr);
+	// _mainDepthState is D3D11_COMPARISON_ALWAYS, so the VR dots are always displayed
+	_deviceResources->InitDepthStencilState(_deviceResources->_mainDepthState, nullptr);
+
+	_deviceResources->InitViewport(&_viewport);
+	_deviceResources->InitTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	_deviceResources->InitInputLayout(_inputLayout);
+	_deviceResources->InitVertexShader(_vertexShader);
+
+	// Other stuff that is common in the loop below
+	UINT vertexBufferStride = sizeof(D3dVertex);
+	UINT vertexBufferOffset = 0;
+
+	ZeroMemory(&g_PSCBuffer, sizeof(g_PSCBuffer));
+	g_PSCBuffer.bIsShadeless = 1;
+	g_PSCBuffer.fPosNormalAlpha = 0.0f;
+
+	g_VRGeometryCBuffer.numStickyRegions = 0;
+	// Disable region highlighting
+	g_VRGeometryCBuffer.clicked[0] = false;
+	g_VRGeometryCBuffer.clicked[1] = false;
+	g_VRGeometryCBuffer.bRenderBracket = false;
+
+	// Flags used in RenderScene():
+	_bIsCockpit = !bGunnerTurret;
+	_bIsGunner = bGunnerTurret;
+	_bIsBlastMark = false;
+
+	// Set the textures
+	_deviceResources->InitPSShaderResourceView(_vrGreenCirclesSRV.Get(), nullptr);
+
+	// Set the mesh buffers
+	ID3D11ShaderResourceView* vsSSRV[4] = { _vrDotMeshVerticesSRV.Get(), nullptr, _vrDotMeshTexCoordsSRV.Get(), nullptr };
+	context->VSSetShaderResources(0, 4, vsSSRV);
+
+	// Set the index and vertex buffers
+	_deviceResources->InitVertexBuffer(nullptr, nullptr, nullptr);
+	_deviceResources->InitVertexBuffer(_vrDotVertexBuffer.GetAddressOf(), &vertexBufferStride, &vertexBufferOffset);
+	_deviceResources->InitIndexBuffer(nullptr, true);
+	_deviceResources->InitIndexBuffer(_vrDotIndexBuffer.Get(), true);
+
+	// Apply the VS and PS constants
+	resources->InitPSConstantBuffer3D(resources->_PSConstantBuffer.GetAddressOf(), &g_PSCBuffer);
+	resources->InitVRGeometryCBuffer(resources->_VRGeometryCBuffer.GetAddressOf(), &g_VRGeometryCBuffer);
+	_deviceResources->InitPixelShader(resources->_pixelShaderVRGeom);
+
+	// Set the constants buffer
+	Matrix4 Vinv;
+	if (bGunnerTurret || bInHangar)
+	{
+		// For the Gunner Turret, we're going to remove the world-view transform and replace it
+		// with an identity matrix. That way, the gloves, which are already in viewspace coords,
+		// will follow the headset no matter how the turret is oriented.
+		Matrix4 Id;
+		const float* m = Id.get();
+		for (int i = 0; i < 16; i++) _CockpitConstants.transformWorldView[i] = m[i];
+
+		Vinv = g_VSMatrixCB.fullViewMat;
+		Vinv.invert();
+	}
+	context->UpdateSubresource(_constantBuffer, 0, nullptr, &_CockpitConstants, 0, 0);
+	_trianglesCount = g_vrDotNumTriangles;
+
+	Matrix4 V, swap({ 1,0,0,0,  0,0,1,0,  0,1,0,0,  0,0,0,1 });
+	Matrix4 S = Matrix4().scale(OPT_TO_METERS);
+	Matrix4 toSteamVR = swap * S;
+
+	// X is 200m in front of us. This is the location of the reticle and the place where lasers
+	// converge. Turns out it wasn't that hard to figure out after all...
+	Vector3 X(0, -8192, 0);
+	Vector3 Xt = g_curTargetBracketVR.posOPT;
+	log_debug_vr("X: %0.3f, %0.3f, %0.3f", Xt.x, Xt.y, Xt.z);
+
+	// Compute a new matrix for the dot by using the origin -> intersection point view vector.
+	// First we'll align this vector with Z+ and then we'll use the inverse of this matrix to
+	// rotate the dot so that it always faces the origin.
+	Matrix4 Rxt, Rzt;
+	{
+		Vector4 P;
+		if (!bGunnerTurret && !bInHangar)
+		{
+			// g_LaserPointerIntersSteamVR is not populated in this case, so we need to transform
+			// g_LaserPointer3DIntersection, which is in OPT scale, into the SteamVR coord sys.
+			const float cockpitOriginX = *g_POV_X;
+			const float cockpitOriginY = *g_POV_Y;
+			const float cockpitOriginZ = *g_POV_Z;
+			Matrix4 T;
+
+			T.translate(
+				-cockpitOriginX - (g_pSharedDataCockpitLook->POVOffsetX * g_pSharedDataCockpitLook->povFactor),
+				-cockpitOriginY + (g_pSharedDataCockpitLook->POVOffsetZ * g_pSharedDataCockpitLook->povFactor),
+				-cockpitOriginZ - (g_pSharedDataCockpitLook->POVOffsetY * g_pSharedDataCockpitLook->povFactor));
+
+			P = toSteamVR * T * Vector3ToVector4(X, 1.0f);
+		}
+		//else
+		//	// Gunner turret... TODO
+		//	P = Vector3ToVector4(g_LaserPointerIntersSteamVR[contIdx], 1);
+
+		// O is the headset's center, in SteamVR coords:
+		Vector4 O = g_VSMatrixCB.fullViewMat * Vector4(0, 0, 0, 1);
+		// N goes from the headset's origin to the intersection point (P): it's the view vector now
+		Vector4 N = P - O;
+		//log_debug_vr(50 + contIdx * 25, FONT_WHITE_COLOR, "P[%d]: %0.3f, %0.3f, %0.3f", contIdx, P.x, P.y, P.z);
+
+		N.normalize();
+		// Rotate N into the Y-Z plane --> make x == 0
+		const float Yang = atan2(N.x, N.z) * RAD_TO_DEG;
+		Matrix4 Ry = Matrix4().rotateY(-Yang);
+		N = Ry * N;
+
+		const float Zangt = atan2(Xt.x, -Xt.y) * RAD_TO_DEG;
+		Rzt = Matrix4().rotateZ(Zangt);
+
+		const float Xangt = atan2(Xt.z, -Xt.y) * RAD_TO_DEG;
+		Rxt = Matrix4().rotateX(-Xangt);
+
+		// Rotate N into the X-Z plane --> make y == 0. N should now be equal to Z+
+		const float Xang = atan2(N.y, N.z) * RAD_TO_DEG;
+		Matrix4 Rx = Matrix4().rotateX(Xang);
+		//N = Rx * N;
+		//log_debug_vr(50 + contIdx * 25, FONT_WHITE_COLOR, "[%d]: %0.3f, %0.3f, %0.3f", contIdx, N.x, N.y, N.z);
+		// The transform chain is now Rx * Ry: this will align the view vector going from the
+		// origin to the intersection with Z+
+		// Adding Rz to the chain makes the dot keep the up direction aligned with the camera.
+		// This is what the brackets do right now.
+		// Removing Rz keeps the up direction aligned with the reticle: this is probably
+		// what we want to do if we want to replace the brackets/reticle/pips
+		//Matrix4 Rz = Matrix4().rotateZ(-g_pSharedDataCockpitLook->Roll);
+		//V = Rz * Rx * Ry; // <-- Up direction is always view-aligned
+		V = Rx * Ry; // <-- Up direction is reticle-aligned
+		// The transpose is the inverse, so it will align Z+ with the view vector:
+		V.transpose();
+		V = Matrix4().scale(812.0f) * swap * V * swap;
+	}
+
+	Matrix4 DotTransform;
+	if (!bGunnerTurret && !bInHangar)
+	{
+		// Small angular displacement so that we can display quads
+		// a little off-center from the bracket
+		// +Z --> displace right
+		// +X --> displace down
+		Matrix4 DispZ = Matrix4().rotateZ(3.5f);
+		Matrix4 DispX = Matrix4().rotateX(3.5f);
+		Matrix4 Disp = DispX * DispZ;
+
+		// The FrontCenter matrix is enough to put the square on top of the reticle.
+		// We just scale the quad and push it 200m away:
+		Matrix4 FrontCenter = Matrix4().translate(0, -8192, 0) * Matrix4().scale(812);
+		// Once the quad is ahead of us, we rotate it about the origin so that it follows
+		// the current bracket. Ryt is only used to invert the headset rotation and keep
+		// the quad aligned with the cockpit:
+		Matrix4 Ryt = Matrix4().rotateY(g_pSharedDataCockpitLook->Roll);
+		DotTransform = Rxt * Rzt * Ryt * Disp * FrontCenter;
+
+		// The following inverts the view matrix. We need to do this because the bracket is
+		// in camera coords and these coords change if the headset rotates.
+		Matrix4 inv = g_VSMatrixCB.fullViewMat;
+		// We do swap * V * swap here because DotTransform is in OPT coords, but V is
+		// in SteamVR coords
+		DotTransform = swap * inv * swap * DotTransform;
 	}
 	//else
 	//{

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -2494,6 +2494,7 @@ void EffectsRenderer::SceneBegin(DeviceResources* deviceResources)
 	_bDotsbRendered = false;
 	_bHUDRendered = false;
 	_bBracketsRendered = false;
+	_bEnhancedBracketsRendered = false;
 
 	// Initialize the OBJ dump file for the current frame
 	if ((bD3DDumpOBJEnabled || bHangarDumpOBJEnabled) && g_bDumpSSAOBuffers) {
@@ -7425,7 +7426,8 @@ void EffectsRenderer::RenderVRHUD()
 
 	// X is 200m in front of us. This is the location of the reticle and the place where lasers
 	// converge. Turns out it wasn't that hard to figure out after all...
-	Vector3 X(0, -8192, 0);
+	constexpr float RETICLE_DEPTH_OPT = 65536.0f * METERS_TO_OPT;
+	Vector3 X(0, -RETICLE_DEPTH_OPT, 0);
 
 	// Compute a new matrix for the dot by using the origin -> intersection point view vector.
 	// First we'll align this vector with Z+ and then we'll use the inverse of this matrix to
@@ -7482,7 +7484,7 @@ void EffectsRenderer::RenderVRHUD()
 		V = Rx * Ry; // <-- Up direction is reticle-aligned
 		// The transpose is the inverse, so it will align Z+ with the view vector:
 		V.transpose();
-		V = Matrix4().scale(812.0f) * swap * V * swap;
+		V = Matrix4().scale(RETICLE_DEPTH_OPT * 0.1f) * swap * V * swap;
 	}
 
 	Matrix4 DotTransform;
@@ -7526,7 +7528,7 @@ void EffectsRenderer::RenderVRHUD()
  */
 void EffectsRenderer::RenderVREnhancedHUD()
 {
-	if (!g_bUseSteamVR || !g_bRendering3D || _bHUDRendered || !_bCockpitConstantsCaptured ||
+	if (!g_bUseSteamVR || !g_bRendering3D || _bEnhancedBracketsRendered || !_bCockpitConstantsCaptured ||
 		*g_playerInHangar || !g_curTargetBracketVRCaptured)
 		return;
 
@@ -7743,7 +7745,7 @@ void EffectsRenderer::RenderVREnhancedHUD()
 	resources->InitVSConstantOPTMeshTransform(resources->_OPTMeshTransformCB.GetAddressOf(), &g_OPTMeshTransformCB);
 	RenderScene(false);
 
-	_bHUDRendered = true;
+	_bEnhancedBracketsRendered = true;
 	RestoreContext();
 	_deviceResources->EndAnnotatedEvent();
 }

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -7627,7 +7627,7 @@ void EffectsRenderer::RenderVREnhancedHUD()
 	Matrix4 S = Matrix4().scale(OPT_TO_METERS);
 	Matrix4 toSteamVR = swap * S;
 
-	const float BRACKET_DEPTH_METERS = 200.0f;
+	const float BRACKET_DEPTH_METERS = 65536.0f;
 	const float BRACKET_DEPTH_OPT    = METERS_TO_OPT * BRACKET_DEPTH_METERS;
 	Vector3 X = g_curTargetBracketVR.posOPT;
 	Matrix4 TOpt = Matrix4().translate(X.x, X.y, X.z);
@@ -7684,8 +7684,9 @@ void EffectsRenderer::RenderVREnhancedHUD()
 	Matrix4 DotTransform;
 	//if (!bGunnerTurret)
 	{
-		// This is the *fixed* scale of the text bracket:
-		const float scale = 2.25f * 819.2f;
+		// This is the *fixed* scale of the text bracket. Here we're using a scale that is
+		// proportional to the fixed depth we'll be using.
+		const float scale = 2.25f * (BRACKET_DEPTH_METERS / 10.0f) * METERS_TO_OPT;
 		// This is the variable scale of the target bracket (this is the same scale we use
 		// in RenderVRBrackets).
 		const float meshScale = (g_curTargetBracketVR.halfWidthOPT * 2.0f) / meshWidth;

--- a/impl11/ddraw/EffectsRenderer.h
+++ b/impl11/ddraw/EffectsRenderer.h
@@ -282,6 +282,7 @@ public:
 	void RenderVRDots();
 	void RenderVRBrackets();
 	void RenderVRHUD();
+	void RenderVREnhancedHUD();
 	void RenderSkyBox(bool debug);
 	void RenderVRKeyboard();
 	void RenderVRGloves();

--- a/impl11/ddraw/EffectsRenderer.h
+++ b/impl11/ddraw/EffectsRenderer.h
@@ -140,6 +140,7 @@ protected:
 	bool _bDotsbRendered;
 	bool _bHUDRendered;
 	bool _bBracketsRendered;
+	bool _bEnhancedBracketsRendered;
 
 	D3D11_PRIMITIVE_TOPOLOGY _oldTopology;
 	UINT _oldStencilRef, _oldSampleMask;

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -13453,12 +13453,20 @@ void PrimarySurface::RenderBracket()
 				const float shd     = g_EnhancedHUDData.shields / 100.0f;
 				const float hull    = g_EnhancedHUDData.hull / 100.0f;
 				const float sys     = g_EnhancedHUDData.sys / 100.0f;
-
 				float barW = max(minBarW, min(maxBarW, posW * 0.7f));
-				const float centerX = posX + posW * 0.5f;
-				const float startX  = centerX - barW * 0.5f;
 
+				// Let's make the hull change color depending on its value
+				float3 hullCol;
+				if (hull > 0.5f)
+					hullCol = lerp(g_EnhancedHUDData.hullCol2, g_EnhancedHUDData.hullCol1, (hull - 0.5f) / 0.5f);
+				else
+					hullCol = lerp(g_EnhancedHUDData.hullCol3, g_EnhancedHUDData.hullCol2, hull / 0.5f);
+				s_hullBrush->SetColor(D2D1::ColorF(hullCol.x, hullCol.y, hullCol.z));
+
+				if (!g_EnhancedHUDData.verticalBarLayout)
 				{
+					const float centerX = posX + posW * 0.5f;
+					const float startX  = centerX - barW * 0.5f;
 					float y = posY + posH + gapH;
 
 					if (g_EnhancedHUDData.shields >= 0)
@@ -13475,14 +13483,6 @@ void PrimarySurface::RenderBracket()
 					}
 					y += barH + gapH;
 
-					// Let's make the hull change color depending on its value
-					float3 hullCol;
-					if (hull > 0.5f)
-						hullCol = lerp(g_EnhancedHUDData.hullCol2, g_EnhancedHUDData.hullCol1, (hull - 0.5f) / 0.5f);
-					else
-						hullCol = lerp(g_EnhancedHUDData.hullCol3, g_EnhancedHUDData.hullCol2, hull / 0.5f);
-					s_hullBrush->SetColor(D2D1::ColorF(hullCol.x, hullCol.y, hullCol.z));
-
 					if (g_EnhancedHUDData.hull >= 0)
 					{
 						rtv->DrawRectangle(D2D1::RectF(startX, y, startX + barW, y + barH), s_hullBrush, strokeSize);
@@ -13493,6 +13493,42 @@ void PrimarySurface::RenderBracket()
 					// Only display the sys bar when there's damage
 					if (g_EnhancedHUDData.sys >= 0 && g_EnhancedHUDData.sys < 100)
 					{
+						rtv->DrawRectangle(D2D1::RectF(startX, y, startX + barW, y + barH), s_sysBrush, strokeSize);
+						rtv->FillRectangle(D2D1::RectF(startX, y, startX + sys * barW, y + barH), s_sysBrush);
+					}
+				}
+				else
+				{
+					const float centerY = posY + posH * 0.5f;
+					const float startY  = centerY + barW * 0.5f;
+					if (g_EnhancedHUDData.shields >= 0)
+					{
+						const float x = posX - gapH - barH;
+						s_shieldsBrush->SetColor(D2D1::ColorF(g_EnhancedHUDData.shieldsCol));
+						rtv->DrawRectangle(D2D1::RectF(x, startY, posX - gapH, startY - barW), s_shieldsBrush, strokeSize);
+						rtv->FillRectangle(D2D1::RectF(x, startY, posX - gapH, startY - min(1.0f, shd) * barW), s_shieldsBrush);
+						// Shields can go up to 200%, in that case, we draw another bar on top of the first one:
+						if (shd > 1.0f)
+						{
+							s_shieldsBrush->SetColor(D2D1::ColorF(g_EnhancedHUDData.overShdCol));
+							rtv->FillRectangle(D2D1::RectF(posX - gapH - barH, startY, posX - gapH, startY - (shd - 1.0f) * barW), s_shieldsBrush);
+						}
+					}
+
+					if (g_EnhancedHUDData.hull >= 0)
+					{
+						const float x = posX + posW + gapH;
+						rtv->DrawRectangle(D2D1::RectF(x, startY, x + barH, startY - barW), s_hullBrush, strokeSize);
+						rtv->FillRectangle(D2D1::RectF(x, startY, x + barH, startY - hull * barW), s_hullBrush);
+					}
+
+					// Only display the sys bar when there's damage
+					if (g_EnhancedHUDData.sys >= 0 && g_EnhancedHUDData.sys < 100)
+					{
+						const float centerX = posX + posW * 0.5f;
+						const float startX  = centerX - barW * 0.5f;
+						float y = posY + posH + gapH;
+
 						rtv->DrawRectangle(D2D1::RectF(startX, y, startX + barW, y + barH), s_sysBrush, strokeSize);
 						rtv->FillRectangle(D2D1::RectF(startX, y, startX + sys * barW, y + barH), s_sysBrush);
 					}

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -13440,7 +13440,9 @@ void PrimarySurface::RenderBracket()
 			rtv->DrawLine(D2D1::Point2F(posX + posW, posY + posH - posH * posSide), D2D1::Point2F(posX + posW, posY + posH), s_brush, strokeWidth);
 
 			// Render bars for shields, hull and sys:
-			if (g_EnhancedHUDData.Enabled && xwaBracket.isCurrentTarget)
+			if (g_EnhancedHUDData.Enabled &&
+				g_EnhancedHUDData.displayBars &&
+				xwaBracket.isCurrentTarget)
 			{
 				const float strokeSize = g_EnhancedHUDData.barStrokeSize;
 

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -13379,9 +13379,7 @@ void PrimarySurface::CacheBracketsVR()
 		W.z = -W.z;
 
 		BracketVR bracketVR;
-		bracketVR.posOPT.x = V.x;
-		bracketVR.posOPT.y = V.z;
-		bracketVR.posOPT.z = V.y;
+		bracketVR.posOPT       = { V.x, V.z, V.y };
 		bracketVR.halfWidthOPT = fabs(W.x - C.x);
 		bracketVR.widthPix     = xwaBracket.width;
 		bracketVR.strokeWidth  = strokeWidthOPT / (2.0f * bracketVR.halfWidthOPT);
@@ -13396,27 +13394,7 @@ void PrimarySurface::CacheBracketsVR()
 		{
 			// For the enhanced HUD, we'll add a special bracket just to render
 			// the text.
-			const float Z200 = Zfar / (200.0f * METERS_TO_OPT + Zfar);
-
-			X = (float)(xwaBracket.positionX + xwaBracket.width  / 2.0f);
-			Y = (float)(xwaBracket.positionY + xwaBracket.height / 2.0f);
-			float3 V = InverseTransformProjectionScreen({ X, Y, Z200, Z200 }); // CacheBracketsVR
-			V.y = -V.y;
-			V.z = -V.z;
-
-			C = InverseTransformProjectionScreen({ screenCenter.x, screenCenter.y, Z200, Z200 }); // CacheBracketsVR
-			C.y = -C.y;
-			C.z = -C.z;
-
-			X = screenCenter.x + xwaBracket.width  / 2.0f;
-			Y = screenCenter.y + xwaBracket.height / 2.0f;
-			float3 W = InverseTransformProjectionScreen({ X, Y, Z200, Z200 }); // CacheBracketsVR
-			W.y = -W.y;
-			W.z = -W.z;
-
-			bracketVR.posOPT       = { V.x, V.z, V.y };
-			bracketVR.halfWidthOPT = fabs(W.x - C.x);
-			g_curTargetBracketVR   = bracketVR;
+			g_curTargetBracketVR = bracketVR;
 			g_curTargetBracketVRCaptured = true;
 			//g_bracketsVR.push_back(bracketVR);
 		}

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -12661,20 +12661,9 @@ void PrimarySurface::RenderText(bool earlyExit)
 	// If we render directly to _d2d1OffscreenRenderTarget, that avoids the delay and the
 	// text displays properly everywhere but it only works for non-VR.
 	ID2D1RenderTarget* rtv = earlyExit ? this->_deviceResources->_d2d1OffscreenRenderTarget : this->_deviceResources->_d2d1RenderTarget;
-	// When VR is enabled, we'll render the enhanced text to its own buffer to be displayed
-	// later as a "transparent" overlay in the cockpit:
-	if (earlyExit && g_bUseSteamVR && g_EnhancedHUDData.Enabled)
-		rtv = this->_deviceResources->_d2d1EnhancedHUDRenderTarget;
 
 	rtv->SaveDrawingState(this->_deviceResources->_d2d1DrawingStateBlock);
 	rtv->BeginDraw();
-
-	if (earlyExit && g_bUseSteamVR && g_EnhancedHUDData.Enabled)
-	{
-		this->_deviceResources->_d2d1EnhancedHUDRenderTarget->Clear(NULL);
-		//rtv->DrawLine({ 512, 0 }, { 512, 1024 }, s_brush);
-		//rtv->DrawLine({ 0, 512 }, { 1024, 512 }, s_brush);
-	}
 
 	unsigned int brushColor = 0;
 	s_brush->SetColor(D2D1::ColorF(brushColor));
@@ -12771,14 +12760,6 @@ void PrimarySurface::RenderText(bool earlyExit)
 
 		float x = (float)s_left + (float)xwaText.positionX * s_scaleX;
 		float y = (float)s_top + (float)xwaText.positionY * s_scaleY;
-		// The enhanced HUD VR text is already placed at buffer coordinates. That is, the
-		// buffer is a square of VR_ENHANCED_HUD_BUFFER_SIZE pixels and the text is placed
-		// inside this square.
-		if (g_bUseSteamVR && g_EnhancedHUDData.Enabled && earlyExit)
-		{
-			x = (float)xwaText.positionX;
-			y = (float)xwaText.positionY;
-		}
 
 		//textLayout->SetFontStretch(DWRITE_FONT_STRETCH_ULTRA_EXPANDED, { 0, 256 });
 		//this->_deviceResources->_d2d1RenderTarget->DrawTextLayout(
@@ -13396,7 +13377,6 @@ void PrimarySurface::CacheBracketsVR()
 			// the text.
 			g_curTargetBracketVR = bracketVR;
 			g_curTargetBracketVRCaptured = true;
-			//g_bracketsVR.push_back(bracketVR);
 		}
 	}
 	g_xwa_bracket.clear();

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -382,7 +382,7 @@ void DisplayCenteredLines(
 
 void PrimarySurface::RenderEnhancedHUDText()
 {
-	if (g_bMapMode)
+	if (g_bMapMode || *g_playerInHangar)
 		return;
 
 	auto &resources = this->_deviceResources;
@@ -11134,9 +11134,14 @@ HRESULT PrimarySurface::Flip(
 				{
 					if (g_EnhancedHUDData.Enabled && !g_bMapMode && !g_bUseSteamVR)
 					{
+						CraftInstance *craftInstance = GetCraftInstanceForCurrentTargetSafe();
+						const bool bDestroyed = (craftInstance == nullptr) ||
+							(craftInstance->CraftState == Craftstate_Dying) ||
+							(craftInstance->CraftState == Craftstate_DiedInstantly);
 						this->RenderEnhancedHUDText();
 						this->RenderText(true);
-						this->RenderEnhancedHUDBars();
+						if (!bDestroyed)
+							this->RenderEnhancedHUDBars();
 
 						if (g_bDumpSSAOBuffers && g_EnhancedHUDData.Enabled)
 						{

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -13396,8 +13396,6 @@ void PrimarySurface::CacheBracketsVR()
 		{
 			// For the enhanced HUD, we'll add a special bracket just to render
 			// the text.
-			//float HALF_BRACKET_SIZE_PX = (float)xwaBracket.width / 2.0f;
-			const float HALF_BRACKET_SIZE_PX = (float)xwaBracket.width;
 			const float Z200 = Zfar / (200.0f * METERS_TO_OPT + Zfar);
 
 			X = (float)(xwaBracket.positionX + xwaBracket.width  / 2.0f);
@@ -13406,16 +13404,9 @@ void PrimarySurface::CacheBracketsVR()
 			V.y = -V.y;
 			V.z = -V.z;
 
-			X = screenCenter.x + HALF_BRACKET_SIZE_PX;
-			Y = screenCenter.y + HALF_BRACKET_SIZE_PX;
-			float3 W = InverseTransformProjectionScreen({ X, Y, Z200, Z200 }); // CacheBracketsVR
-			W.y = -W.y;
-			W.z = -W.z;
-
 			bracketVR.posOPT.x = V.x;
 			bracketVR.posOPT.y = V.z;
 			bracketVR.posOPT.z = V.y;
-			bracketVR.halfWidthOPT = fabs(W.x - C.x);
 			bracketVR.renderText  = true;
 			bracketVR.color.x = 1.0f;
 			bracketVR.color.y = 0.1f;

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -11039,6 +11039,11 @@ HRESULT PrimarySurface::Flip(
 					{
 						this->RenderEnhancedHUDText();
 						this->RenderText(true);
+
+						if (g_bDumpSSAOBuffers && g_EnhancedHUDData.Enabled)
+						{
+							DirectX::SaveDDSTextureToFile(context, resources->_enhancedHUDBuffer, L"C:\\Temp\\_enhancedHUDBuffer.dds");
+						}
 					}
 					this->RenderBracket();
 				}
@@ -12841,9 +12846,16 @@ void PrimarySurface::RenderText(bool earlyExit)
 	// If we render directly to _d2d1OffscreenRenderTarget, that avoids the delay and the
 	// text displays properly everywhere but it only works for non-VR.
 	ID2D1RenderTarget* rtv = earlyExit ? this->_deviceResources->_d2d1OffscreenRenderTarget : this->_deviceResources->_d2d1RenderTarget;
+	// When the Enhanced HUD is enabled, we'll render the information to its own buffer to be displayed
+	// later as a "transparent" overlay in the cockpit:
+	if (earlyExit && g_EnhancedHUDData.Enabled)
+		rtv = this->_deviceResources->_d2d1EnhancedHUDRenderTarget;
 
 	rtv->SaveDrawingState(this->_deviceResources->_d2d1DrawingStateBlock);
 	rtv->BeginDraw();
+
+	if (earlyExit && g_EnhancedHUDData.Enabled)
+		this->_deviceResources->_d2d1EnhancedHUDRenderTarget->Clear(NULL);
 
 	unsigned int brushColor = 0;
 	s_brush->SetColor(D2D1::ColorF(brushColor));

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -12630,6 +12630,7 @@ void PrimarySurface::ExtractDCText()
 {
 	unsigned char* fontWidths[] = { (unsigned char*)0x007D4C80, (unsigned char*)0x007D4D80, (unsigned char*)0x007D4E80 };
 	static   short s_rowSize    = (short)(0.0185f * g_fCurInGameHeight);
+	static   float s_lastInGameWidth = 0, s_lastInGameHeight = 0;
 	//static   int   s_fontSizes[3] = { 12, 16, 10 };
 
 	g_EnhancedHUDData.sName    = "";
@@ -12671,6 +12672,17 @@ void PrimarySurface::ExtractDCText()
 		&g_EnhancedHUDData.sSys, &g_EnhancedHUDData.sDist, &g_EnhancedHUDData.sCargo,
 		&g_EnhancedHUDData.sSubCmp };
 	int rows[7] = { -1, -1, -1, -1, -1, -1, -1 };
+
+	// Detect when the in-game screen resolution has changed so that we can recompute the
+	// DC boxes.
+	if (s_lastInGameWidth != g_fCurInGameWidth || s_lastInGameHeight != g_fCurInGameHeight)
+	{
+		s_numComputedBoxes = 0;
+		for (int i = 0; i < 7; i++) s_boxesComputed[i] = false;
+
+		s_lastInGameWidth  = g_fCurInGameWidth;
+		s_lastInGameHeight = g_fCurInGameHeight;
+	}
 
 	// Precompute the box sizes
 	if (s_numComputedBoxes < 7)

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -11066,21 +11066,8 @@ HRESULT PrimarySurface::Flip(
 				}
 				else
 				{
-					if (g_EnhancedHUDData.Enabled && !g_bMapMode)
-					{
-						// Temporarily disable the enhanced HUD in VR (needs more work)
-						/*
-						this->RenderEnhancedHUDText();
-						this->RenderText(true);
-						if (g_bDumpSSAOBuffers)
-						{
-							DirectX::SaveDDSTextureToFile(context, resources->_enhancedHUDBuffer, L"C:\\Temp\\_enhancedHUDBuffer.dds");
-						}
-						*/
-					}
-
 					this->CacheBracketsVR();
-					// The VR bracket needs to be rendered right here or there will be a one-frame delay
+					// The enhanced VR HUD needs to be rendered right here or there will be a one-frame delay
 					// that is noticeable as a shaky bracket
 					if (g_EnhancedHUDData.Enabled)
 						((EffectsRenderer*)g_current_renderer)->RenderVREnhancedHUD();
@@ -13370,11 +13357,9 @@ void PrimarySurface::CacheBracketsVR()
 		bracketVR.isSubComponent = xwaBracket.isSubComponent;
 		g_bracketsVR.push_back(bracketVR);
 
-		// Temporarily disable the enhanced HUD in VR
 		if (g_EnhancedHUDData.Enabled && xwaBracket.isCurrentTarget)
 		{
-			// For the enhanced HUD, we'll add a special bracket just to render
-			// the text.
+			// For the enhanced HUD, we'll add a special bracket just to render the text.
 			g_curTargetBracketVR = bracketVR;
 			g_curTargetBracketVRCaptured = true;
 		}

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -13383,12 +13383,12 @@ void PrimarySurface::CacheBracketsVR()
 		bracketVR.posOPT.y = V.z;
 		bracketVR.posOPT.z = V.y;
 		bracketVR.halfWidthOPT = fabs(W.x - C.x);
+		bracketVR.widthPix     = xwaBracket.width;
 		bracketVR.strokeWidth  = strokeWidthOPT / (2.0f * bracketVR.halfWidthOPT);
 		bracketVR.color.x = (float)((brushColor >> 16) & 0xFF) / 255.0f;
 		bracketVR.color.y = (float)((brushColor >>  8) & 0xFF) / 255.0f;
 		bracketVR.color.z = (float)((brushColor >>  0) & 0xFF) / 255.0f;
 		bracketVR.isSubComponent = xwaBracket.isSubComponent;
-		bracketVR.renderText     = false;
 		g_bracketsVR.push_back(bracketVR);
 
 		// Temporarily disable the enhanced HUD in VR
@@ -13404,14 +13404,19 @@ void PrimarySurface::CacheBracketsVR()
 			V.y = -V.y;
 			V.z = -V.z;
 
-			bracketVR.posOPT.x = V.x;
-			bracketVR.posOPT.y = V.z;
-			bracketVR.posOPT.z = V.y;
-			bracketVR.renderText  = true;
-			bracketVR.color.x = 1.0f;
-			bracketVR.color.y = 0.1f;
-			bracketVR.color.z = 0.1f;
-			g_curTargetBracketVR = bracketVR;
+			C = InverseTransformProjectionScreen({ screenCenter.x, screenCenter.y, Z200, Z200 }); // CacheBracketsVR
+			C.y = -C.y;
+			C.z = -C.z;
+
+			X = screenCenter.x + xwaBracket.width  / 2.0f;
+			Y = screenCenter.y + xwaBracket.height / 2.0f;
+			float3 W = InverseTransformProjectionScreen({ X, Y, Z200, Z200 }); // CacheBracketsVR
+			W.y = -W.y;
+			W.z = -W.z;
+
+			bracketVR.posOPT       = { V.x, V.z, V.y };
+			bracketVR.halfWidthOPT = fabs(W.x - C.x);
+			g_curTargetBracketVR   = bracketVR;
 			g_curTargetBracketVRCaptured = true;
 			//g_bracketsVR.push_back(bracketVR);
 		}

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -13401,6 +13401,7 @@ void PrimarySurface::RenderBracket()
 			extraScale += variableScale;
 			posSide += 0.03f * variableScale;
 		}
+		// This version makes the stroke change its width
 		//float strokeWidth = extraScale * min(s_scaleX, s_scaleY);
 
 		// Update variableScale:
@@ -13439,12 +13440,19 @@ void PrimarySurface::RenderBracket()
 			rtv->DrawLine(D2D1::Point2F(posX + posW, posY + posH - posH * posSide), D2D1::Point2F(posX + posW, posY + posH), s_brush, strokeWidth);
 
 			// Render bars for shields, hull and sys:
-			if (xwaBracket.isCurrentTarget)
+			if (g_EnhancedHUDData.Enabled && xwaBracket.isCurrentTarget)
 			{
-				constexpr float barW = 140.0f, barH = 12.0f, gapH = 7.0f;
-				const float shd  = g_EnhancedHUDData.shields / 100.0f;
-				const float hull = g_EnhancedHUDData.hull / 100.0f;
-				const float sys  = g_EnhancedHUDData.sys / 100.0f;
+				const float strokeSize = g_EnhancedHUDData.barStrokeSize;
+
+				const float minBarW = g_EnhancedHUDData.minBarW;
+				const float maxBarW = g_EnhancedHUDData.maxBarW;
+				const float barH    = g_EnhancedHUDData.barH;
+				const float gapH    = g_EnhancedHUDData.gapH;
+				const float shd     = g_EnhancedHUDData.shields / 100.0f;
+				const float hull    = g_EnhancedHUDData.hull / 100.0f;
+				const float sys     = g_EnhancedHUDData.sys / 100.0f;
+
+				float barW = max(minBarW, min(maxBarW, posW * 0.7f));
 				const float centerX = posX + posW * 0.5f;
 				const float startX  = centerX - barW * 0.5f;
 
@@ -13454,7 +13462,7 @@ void PrimarySurface::RenderBracket()
 					if (g_EnhancedHUDData.shields >= 0)
 					{
 						s_shieldsBrush->SetColor(D2D1::ColorF(g_EnhancedHUDData.shieldsCol));
-						rtv->DrawRectangle(D2D1::RectF(startX, y, startX + barW, y + barH), s_shieldsBrush, 3.0f);
+						rtv->DrawRectangle(D2D1::RectF(startX, y, startX + barW, y + barH), s_shieldsBrush, strokeSize);
 						rtv->FillRectangle(D2D1::RectF(startX, y, startX + min(1.0f, shd) * barW, y + barH), s_shieldsBrush);
 						// Shields can go up to 200%, in that case, we draw another bar on top of the first one:
 						if (shd > 1.0f)
@@ -13475,7 +13483,7 @@ void PrimarySurface::RenderBracket()
 
 					if (g_EnhancedHUDData.hull >= 0)
 					{
-						rtv->DrawRectangle(D2D1::RectF(startX, y, startX + barW, y + barH), s_hullBrush, 3.0f);
+						rtv->DrawRectangle(D2D1::RectF(startX, y, startX + barW, y + barH), s_hullBrush, strokeSize);
 						rtv->FillRectangle(D2D1::RectF(startX, y, startX + hull * barW, y + barH), s_hullBrush);
 					}
 					y += barH + gapH;
@@ -13483,7 +13491,7 @@ void PrimarySurface::RenderBracket()
 					// Only display the sys bar when there's damage
 					if (g_EnhancedHUDData.sys >= 0 && g_EnhancedHUDData.sys < 100)
 					{
-						rtv->DrawRectangle(D2D1::RectF(startX, y, startX + barW, y + barH), s_sysBrush, 3.0f);
+						rtv->DrawRectangle(D2D1::RectF(startX, y, startX + barW, y + barH), s_sysBrush, strokeSize);
 						rtv->FillRectangle(D2D1::RectF(startX, y, startX + sys * barW, y + barH), s_sysBrush);
 					}
 				}

--- a/impl11/ddraw/PrimarySurface.h
+++ b/impl11/ddraw/PrimarySurface.h
@@ -97,6 +97,8 @@ public:
 
 	void DrawHUDVertices();
 
+	void DrawEnhancedHUDVertices();
+
 	//void SetLights(float fSSDOEnabled);
 	
 	void SSAOPass(float fZoomFactor);

--- a/impl11/ddraw/PrimarySurface.h
+++ b/impl11/ddraw/PrimarySurface.h
@@ -221,10 +221,7 @@ public:
 
 	STDMETHOD(UpdateOverlayZOrder)(THIS_ DWORD, LPDIRECTDRAWSURFACE);
 
-	void ExtractDCText(std::string *name,
-		std::string *shields, std::string *hull,
-		std::string *sys, std::string *dist,
-		std::string *cargo, std::string *subCmp);
+	void ExtractDCText();
 
 	void RenderText(bool earlyExit=false);
 

--- a/impl11/ddraw/PrimarySurface.h
+++ b/impl11/ddraw/PrimarySurface.h
@@ -231,6 +231,8 @@ public:
 
 	void RenderBracket();
 
+	void RenderEnhancedHUDBars();
+
 	void CacheBracketsVR();
 
 	bool RenderSkyCylinder();

--- a/impl11/ddraw/PrimarySurface.h
+++ b/impl11/ddraw/PrimarySurface.h
@@ -231,7 +231,7 @@ public:
 
 	void RenderBracket();
 
-	void RenderEnhancedHUDBars();
+	void RenderEnhancedHUDBars(bool bDestroyed);
 
 	void CacheBracketsVR();
 

--- a/impl11/ddraw/PrimarySurface.h
+++ b/impl11/ddraw/PrimarySurface.h
@@ -221,6 +221,11 @@ public:
 
 	STDMETHOD(UpdateOverlayZOrder)(THIS_ DWORD, LPDIRECTDRAWSURFACE);
 
+	void ExtractDCText(std::string *name,
+		std::string *shields, std::string *hull,
+		std::string *sys, std::string *dist,
+		std::string *cargo, std::string *subCmp);
+
 	void RenderText(bool earlyExit=false);
 
 	void RenderRadar();

--- a/impl11/ddraw/VRConfig.cpp
+++ b/impl11/ddraw/VRConfig.cpp
@@ -2395,6 +2395,9 @@ bool LoadSSAOParams() {
 				g_EnhancedHUDData.Enabled = (bool)fValue;
 				g_EnhancedHUDData.fontIdx = FONT_MEDIUM_IDX;
 			}
+			if (_stricmp(param, "enhanced_hud_enhance_name_col") == 0) {
+				g_EnhancedHUDData.enhanceNameColor = (bool)fValue;
+			}
 			else if (_stricmp(param, "enhanced_hud_min_bracket_size") == 0) {
 				g_EnhancedHUDData.MinBracketSize = (int)fValue;
 			}
@@ -2426,6 +2429,14 @@ bool LoadSSAOParams() {
 					((uint32_t)(x * 255.0f) << 16) |
 					((uint32_t)(y * 255.0f) << 8) |
 					 (uint32_t)(z * 255.0f);
+			}
+			else if (_stricmp(param, "enhanced_hud_overshds_col") == 0) {
+				float x, y, z;
+				LoadGeneric3DCoords(buf, &x, &y, &z);
+				g_EnhancedHUDData.overShdCol = 0xFF000000 |
+					((uint32_t)(x * 255.0f) << 16) |
+					((uint32_t)(y * 255.0f) << 8) |
+					(uint32_t)(z * 255.0f);
 			}
 			else if (_stricmp(param, "enhanced_hud_hull_col_full") == 0) {
 				float x, y, z;

--- a/impl11/ddraw/VRConfig.cpp
+++ b/impl11/ddraw/VRConfig.cpp
@@ -2404,6 +2404,21 @@ bool LoadSSAOParams() {
 			else if (_stricmp(param, "enhanced_hud_max_bracket_size") == 0) {
 				g_EnhancedHUDData.MaxBracketSize = (int)fValue;
 			}
+			else if (_stricmp(param, "enhanced_hud_min_bar_width") == 0) {
+				g_EnhancedHUDData.minBarW = fValue;
+			}
+			else if (_stricmp(param, "enhanced_hud_max_bar_width") == 0) {
+				g_EnhancedHUDData.maxBarW = fValue;
+			}
+			else if (_stricmp(param, "enhanced_hud_bar_height") == 0) {
+				g_EnhancedHUDData.barH = fValue;
+			}
+			else if (_stricmp(param, "enhanced_hud_bar_gap") == 0) {
+				g_EnhancedHUDData.gapH = fValue;
+			}
+			else if (_stricmp(param, "enhanced_hud_bar_frame_width") == 0) {
+				g_EnhancedHUDData.barStrokeSize = fValue;
+			}
 			else if (_stricmp(param, "enhanced_hud_font_size") == 0) {
 				const int size = (int)fValue;
 				switch (size)

--- a/impl11/ddraw/VRConfig.cpp
+++ b/impl11/ddraw/VRConfig.cpp
@@ -2419,6 +2419,37 @@ bool LoadSSAOParams() {
 					g_EnhancedHUDData.fontIdx = FONT_MEDIUM_IDX;
 				}
 			}
+			else if (_stricmp(param, "enhanced_hud_shields_col") == 0) {
+				float x, y, z;
+				LoadGeneric3DCoords(buf, &x, &y, &z);
+				g_EnhancedHUDData.shieldsCol = 0xFF000000 |
+					((uint32_t)(x * 255.0f) << 16) |
+					((uint32_t)(y * 255.0f) << 8) |
+					 (uint32_t)(z * 255.0f);
+			}
+			else if (_stricmp(param, "enhanced_hud_hull_col_full") == 0) {
+				float x, y, z;
+				LoadGeneric3DCoords(buf, &x, &y, &z);
+				g_EnhancedHUDData.hullCol1 = { x, y, z };
+			}
+			else if (_stricmp(param, "enhanced_hud_hull_col_mid") == 0) {
+				float x, y, z;
+				LoadGeneric3DCoords(buf, &x, &y, &z);
+				g_EnhancedHUDData.hullCol2 = { x, y, z };
+			}
+			else if (_stricmp(param, "enhanced_hud_hull_col_low") == 0) {
+				float x, y, z;
+				LoadGeneric3DCoords(buf, &x, &y, &z);
+				g_EnhancedHUDData.hullCol3 = { x, y, z };
+			}
+			else if (_stricmp(param, "enhanced_hud_sys_col") == 0) {
+				float x, y, z;
+				LoadGeneric3DCoords(buf, &x, &y, &z);
+				g_EnhancedHUDData.sysCol = 0xFF000000 |
+					((uint32_t)(x * 255.0f) << 16) |
+					((uint32_t)(y * 255.0f) << 8) |
+					(uint32_t)(z * 255.0f);
+			}
 
 			if (_stricmp(param, "bias") == 0) {
 				g_SSAO_PSCBuffer.bias = fValue;

--- a/impl11/ddraw/VRConfig.cpp
+++ b/impl11/ddraw/VRConfig.cpp
@@ -2401,19 +2401,22 @@ bool LoadSSAOParams() {
 			if (_stricmp(param, "enhanced_hud_display_bars") == 0) {
 				g_EnhancedHUDData.displayBars = (bool)fValue;
 			}
+			else if (_stricmp(param, "enhanced_hud_vertical_bars") == 0) {
+				g_EnhancedHUDData.verticalBarLayout = (bool)fValue;
+			}
 			else if (_stricmp(param, "enhanced_hud_min_bracket_size") == 0) {
 				g_EnhancedHUDData.MinBracketSize = (int)fValue;
 			}
 			else if (_stricmp(param, "enhanced_hud_max_bracket_size") == 0) {
 				g_EnhancedHUDData.MaxBracketSize = (int)fValue;
 			}
-			else if (_stricmp(param, "enhanced_hud_min_bar_width") == 0) {
+			else if (_stricmp(param, "enhanced_hud_min_bar_length") == 0) {
 				g_EnhancedHUDData.minBarW = fValue;
 			}
-			else if (_stricmp(param, "enhanced_hud_max_bar_width") == 0) {
+			else if (_stricmp(param, "enhanced_hud_max_bar_length") == 0) {
 				g_EnhancedHUDData.maxBarW = fValue;
 			}
-			else if (_stricmp(param, "enhanced_hud_bar_height") == 0) {
+			else if (_stricmp(param, "enhanced_hud_bar_thickness") == 0) {
 				g_EnhancedHUDData.barH = fValue;
 			}
 			else if (_stricmp(param, "enhanced_hud_bar_gap") == 0) {

--- a/impl11/ddraw/VRConfig.cpp
+++ b/impl11/ddraw/VRConfig.cpp
@@ -2404,6 +2404,9 @@ bool LoadSSAOParams() {
 			else if (_stricmp(param, "enhanced_hud_vertical_bars") == 0) {
 				g_EnhancedHUDData.verticalBarLayout = (bool)fValue;
 			}
+			else if (_stricmp(param, "enhanced_hud_enable_bg_text_box") == 0) {
+				g_EnhancedHUDData.bgTextBoxEnabled = (bool)fValue;
+			}
 			else if (_stricmp(param, "enhanced_hud_min_bracket_size") == 0) {
 				g_EnhancedHUDData.MinBracketSize = (int)fValue;
 			}

--- a/impl11/ddraw/VRConfig.cpp
+++ b/impl11/ddraw/VRConfig.cpp
@@ -2393,12 +2393,31 @@ bool LoadSSAOParams() {
 
 			if (_stricmp(param, "enable_enhanced_hud") == 0) {
 				g_EnhancedHUDData.Enabled = (bool)fValue;
+				g_EnhancedHUDData.fontIdx = FONT_MEDIUM_IDX;
 			}
 			else if (_stricmp(param, "enhanced_hud_min_bracket_size") == 0) {
 				g_EnhancedHUDData.MinBracketSize = (int)fValue;
 			}
 			else if (_stricmp(param, "enhanced_hud_max_bracket_size") == 0) {
 				g_EnhancedHUDData.MaxBracketSize = (int)fValue;
+			}
+			else if (_stricmp(param, "enhanced_hud_font_size") == 0) {
+				const int size = (int)fValue;
+				switch (size)
+				{
+				case 0:
+				case 1:
+					g_EnhancedHUDData.fontIdx = FONT_SMALL_IDX;
+					break;
+				case 2:
+					g_EnhancedHUDData.fontIdx = FONT_MEDIUM_IDX;
+					break;
+				case 3:
+					g_EnhancedHUDData.fontIdx = FONT_LARGE_IDX;
+					break;
+				default:
+					g_EnhancedHUDData.fontIdx = FONT_MEDIUM_IDX;
+				}
 			}
 
 			if (_stricmp(param, "bias") == 0) {

--- a/impl11/ddraw/VRConfig.cpp
+++ b/impl11/ddraw/VRConfig.cpp
@@ -2398,6 +2398,9 @@ bool LoadSSAOParams() {
 			if (_stricmp(param, "enhanced_hud_enhance_name_col") == 0) {
 				g_EnhancedHUDData.enhanceNameColor = (bool)fValue;
 			}
+			if (_stricmp(param, "enhanced_hud_display_bars") == 0) {
+				g_EnhancedHUDData.displayBars = (bool)fValue;
+			}
 			else if (_stricmp(param, "enhanced_hud_min_bracket_size") == 0) {
 				g_EnhancedHUDData.MinBracketSize = (int)fValue;
 			}

--- a/impl11/ddraw/XwaDrawBracketHook.cpp
+++ b/impl11/ddraw/XwaDrawBracketHook.cpp
@@ -110,10 +110,6 @@ void DrawBracketInFlightHook(int A4, int A8, int AC, int A10, unsigned char A14,
 		}
 		g_curSubcomponentBracket = bracket;
 	}
-	else if (g_bracketIsCurrentTarget)
-	{
-		g_curTargetBracket = bracket;
-	}
 
 	if (bracket.depth == 1)
 	{
@@ -152,6 +148,9 @@ void DrawBracketInFlightHook(int A4, int A8, int AC, int A10, unsigned char A14,
 		The only way I can tell which brackets should belong to the DC CMD is by looking
 		at their size; but there's some danger that they will be misclassified.
 	*/
+
+	if (g_bracketIsCurrentTarget)
+		g_curTargetBracket = bracket;
 
 	g_xwa_bracket.push_back(bracket);
 }

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -327,6 +327,8 @@ struct BracketVR
 	bool renderText;
 };
 extern std::vector<BracketVR> g_bracketsVR;
+extern BracketVR g_curTargetBracketVR;
+extern bool g_curTargetBracketVRCaptured;
 
 // Enhanced HUD
 constexpr int VR_ENHANCED_HUD_BUFFER_SIZE = 1024;

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -353,7 +353,7 @@ struct EnhancedHUDData
 	bool   displayBars = true;
 	bool   verticalBarLayout = false;
 	float  minBarW = 16.0f, maxBarW = 140.0f, barStrokeSize = 3.0f;
-	float  barH = 12.0f, gapH = 7.0f;
+	float  barH = 9.0f, gapH = 7.0f;
 };
 extern EnhancedHUDData g_EnhancedHUDData;
 

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -345,13 +345,13 @@ struct EnhancedHUDData
 	float dist;
 	uint32_t shieldsCol = 0xFF2080FF;
 	uint32_t overShdCol = 0xFF7DF9FF; // Electric blue
-	//uint32_t overShdCol = 0xFFFFD700; // Gold color
 	uint32_t sysCol     = 0xFFCCC0FF; // Periwinkle!
 	float3 hullCol1 = { 0.0f, 1.0f, 0.0f };
 	float3 hullCol2 = { 1.0f, 1.0f, 0.0f };
 	float3 hullCol3 = { 1.0f, 0.0f, 0.0f };
 	bool   enhanceNameColor = true;
 	bool   displayBars = true;
+	bool   verticalBarLayout = false;
 	float  minBarW = 16.0f, maxBarW = 140.0f, barStrokeSize = 3.0f;
 	float  barH = 12.0f, gapH = 7.0f;
 };

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -337,6 +337,7 @@ struct EnhancedHUDData
 	bool Enabled;
 	int  MinBracketSize;
 	int  MaxBracketSize;
+	int  fontIdx;
 	std::string sName, sShields, sHull, sSys;
 	std::string sDist, sCargo, sSubCmp, sTmp;
 	uint32_t nameColor, statsColor, subCmpColor;

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -351,6 +351,8 @@ struct EnhancedHUDData
 	float3 hullCol2 = { 1.0f, 1.0f, 0.0f };
 	float3 hullCol3 = { 1.0f, 0.0f, 0.0f };
 	bool   enhanceNameColor = true;
+	float  minBarW = 16.0f, maxBarW = 140.0f, barStrokeSize = 3.0f;
+	float  barH = 12.0f, gapH = 7.0f;
 };
 extern EnhancedHUDData g_EnhancedHUDData;
 

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -322,13 +322,13 @@ struct BracketVR
 	float halfWidthOPT;
 	float strokeWidth;
 	Vector3 color;
-	float rollCompensation;
+	int  widthPix;
 	bool isSubComponent;
-	bool renderText;
 };
 extern std::vector<BracketVR> g_bracketsVR;
 extern BracketVR g_curTargetBracketVR;
 extern bool g_curTargetBracketVRCaptured;
+constexpr float DOT_BUFFER_SIZE_METERS = 0.017f;
 
 // Enhanced HUD
 constexpr int VR_ENHANCED_HUD_BUFFER_SIZE = 1024;

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -328,7 +328,7 @@ struct BracketVR
 extern std::vector<BracketVR> g_bracketsVR;
 extern BracketVR g_curTargetBracketVR;
 extern bool g_curTargetBracketVRCaptured;
-constexpr float DOT_BUFFER_SIZE_METERS = 0.017f;
+constexpr float DOT_MESH_SIZE_M = 0.017f;
 
 // Enhanced HUD
 constexpr int VR_ENHANCED_HUD_BUFFER_SIZE = 1024;

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -343,6 +343,11 @@ struct EnhancedHUDData
 	uint32_t nameColor, statsColor, subCmpColor;
 	int   shields, hull, sys;
 	float dist;
+	uint32_t shieldsCol = 0xFF2080FF;
+	uint32_t sysCol     = 0xFFCCC0FF; // Periwinkle!
+	float3 hullCol1 = { 0.0f, 1.0f, 0.0f };
+	float3 hullCol2 = { 1.0f, 1.0f, 0.0f };
+	float3 hullCol3 = { 1.0f, 0.0f, 0.0f };
 };
 extern EnhancedHUDData g_EnhancedHUDData;
 

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -351,6 +351,7 @@ struct EnhancedHUDData
 	float3 hullCol2 = { 1.0f, 1.0f, 0.0f };
 	float3 hullCol3 = { 1.0f, 0.0f, 0.0f };
 	bool   enhanceNameColor = true;
+	bool   displayBars = true;
 	float  minBarW = 16.0f, maxBarW = 140.0f, barStrokeSize = 3.0f;
 	float  barH = 12.0f, gapH = 7.0f;
 };

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -354,6 +354,8 @@ struct EnhancedHUDData
 	bool   verticalBarLayout = false;
 	float  minBarW = 16.0f, maxBarW = 140.0f, barStrokeSize = 3.0f;
 	float  barH = 9.0f, gapH = 7.0f;
+	bool   bgTextBoxComputed, bgTextBoxEnabled = false;
+	Box    bgTextBox;
 };
 extern EnhancedHUDData g_EnhancedHUDData;
 

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -344,10 +344,13 @@ struct EnhancedHUDData
 	int   shields, hull, sys;
 	float dist;
 	uint32_t shieldsCol = 0xFF2080FF;
+	uint32_t overShdCol = 0xFF7DF9FF; // Electric blue
+	//uint32_t overShdCol = 0xFFFFD700; // Gold color
 	uint32_t sysCol     = 0xFFCCC0FF; // Periwinkle!
 	float3 hullCol1 = { 0.0f, 1.0f, 0.0f };
 	float3 hullCol2 = { 1.0f, 1.0f, 0.0f };
 	float3 hullCol3 = { 1.0f, 0.0f, 0.0f };
+	bool   enhanceNameColor = true;
 };
 extern EnhancedHUDData g_EnhancedHUDData;
 

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -337,6 +337,11 @@ struct EnhancedHUDData
 	bool Enabled;
 	int  MinBracketSize;
 	int  MaxBracketSize;
+	std::string sName, sShields, sHull, sSys;
+	std::string sDist, sCargo, sSubCmp, sTmp;
+	uint32_t nameColor, statsColor, subCmpColor;
+	int   shields, hull, sys;
+	float dist;
 };
 extern EnhancedHUDData g_EnhancedHUDData;
 

--- a/impl11/shaders/EnhancedHudPS.hlsl
+++ b/impl11/shaders/EnhancedHudPS.hlsl
@@ -33,10 +33,6 @@ PixelShaderOutput main(PixelShaderInput input)
 	if (pos3D.z < 25.0f)
 		discard;
 
-	const float4 hudTexel = enhancedHudBuf.Sample(sampler0, input.tex);
-	// Compute the text alpha from approx Luma
-	const float hudAlpha = saturate(10.0 * dot(float3(0.33, 0.5, 0.16), hudTexel.rgb));
-	
-	output.color = float4(hudTexel.rgb, hudAlpha);
+	output.color = enhancedHudBuf.Sample(sampler0, input.tex);
 	return output;
 }

--- a/impl11/shaders/EnhancedHudPS.hlsl
+++ b/impl11/shaders/EnhancedHudPS.hlsl
@@ -1,0 +1,42 @@
+// Copyright (c) 2025 Leo Reyes
+// Licensed under the MIT license. See LICENSE.txt
+// This shader should only be called to render the HUD FG/BG
+#include "shader_common.h"
+#include "PixelShaderTextureCommon.h"
+
+// texture0 == Depth Buffer
+Texture2D    texture0 : register(t0);
+SamplerState sampler0 : register(s0);
+
+// texture1 == Enhanced HUD contents
+Texture2D    texture1 : register(t1);
+
+struct PixelShaderInput
+{
+	float4 pos   : SV_POSITION;
+	float4 color : COLOR0;
+	float2 tex   : TEXCOORD;
+};
+
+struct PixelShaderOutput
+{
+	float4 color : SV_TARGET0;
+};
+
+PixelShaderOutput main(PixelShaderInput input)
+{
+	PixelShaderOutput output;
+
+	const float4 pos3D = texture0.Sample(sampler0, input.tex);
+	// The cockpit tends to be less than 50m in depth in fron to us, so this is probably
+	// a good threshold to reject any display that is closer than that:
+	if (pos3D.z < 50.0f)
+		discard;
+
+	const float4 texelText = texture1.Sample(sampler0, input.tex);
+	// Compute the text alpha from approx Luma
+	const float textAlpha = saturate(10.0 * dot(float3(0.33, 0.5, 0.16), texelText.rgb));
+	
+	output.color = float4(texelText.rgb, textAlpha);
+	return output;
+}

--- a/impl11/shaders/EnhancedHudPS.hlsl
+++ b/impl11/shaders/EnhancedHudPS.hlsl
@@ -5,11 +5,11 @@
 #include "PixelShaderTextureCommon.h"
 
 // texture0 == Depth Buffer
-Texture2D    texture0 : register(t0);
+Texture2D    depthBuf : register(t0);
 SamplerState sampler0 : register(s0);
 
 // texture1 == Enhanced HUD contents
-Texture2D    texture1 : register(t1);
+Texture2D enhancedHudBuf : register(t1);
 
 struct PixelShaderInput
 {
@@ -27,13 +27,13 @@ PixelShaderOutput main(PixelShaderInput input)
 {
 	PixelShaderOutput output;
 
-	const float4 pos3D = texture0.Sample(sampler0, input.tex);
-	// The cockpit tends to be less than 50m in depth in fron to us, so this is probably
+	const float4 pos3D = depthBuf.Sample(sampler0, input.tex);
+	// The cockpit tends to be less than 25m in depth in front of us, so this is probably
 	// a good threshold to reject any display that is closer than that:
-	if (pos3D.z < 50.0f)
+	if (pos3D.z < 25.0f)
 		discard;
 
-	const float4 texelText = texture1.Sample(sampler0, input.tex);
+	const float4 texelText = enhancedHudBuf.Sample(sampler0, input.tex);
 	// Compute the text alpha from approx Luma
 	const float textAlpha = saturate(10.0 * dot(float3(0.33, 0.5, 0.16), texelText.rgb));
 	

--- a/impl11/shaders/EnhancedHudPS.hlsl
+++ b/impl11/shaders/EnhancedHudPS.hlsl
@@ -33,10 +33,10 @@ PixelShaderOutput main(PixelShaderInput input)
 	if (pos3D.z < 25.0f)
 		discard;
 
-	const float4 texelText = enhancedHudBuf.Sample(sampler0, input.tex);
+	const float4 hudTexel = enhancedHudBuf.Sample(sampler0, input.tex);
 	// Compute the text alpha from approx Luma
-	const float textAlpha = saturate(10.0 * dot(float3(0.33, 0.5, 0.16), texelText.rgb));
+	const float hudAlpha = saturate(10.0 * dot(float3(0.33, 0.5, 0.16), hudTexel.rgb));
 	
-	output.color = float4(texelText.rgb, textAlpha);
+	output.color = float4(hudTexel.rgb, hudAlpha);
 	return output;
 }

--- a/impl11/shaders/PixelShaderVRGeom.hlsl
+++ b/impl11/shaders/PixelShaderVRGeom.hlsl
@@ -86,8 +86,18 @@ PixelShaderOutput RenderEnhancedBracket(PixelShaderInput input)
 	const float3 luma  = float3(0.299, 0.587, 0.114);
 	const float2 delta = src1 - src0;
 	const float  ratio = delta.x / delta.y;
+
 	// This code assumes the text to display is larger in the x axis:
-	const float2 uv    = lerp(src0, src1, float2(1, ratio) * input.tex.xy);
+	// If deltaX is always 1.0 (covering the whole quad horizontally),
+	// then deltaY is the inverse of the ratio:
+	const float deltaY = 1.0 / ratio;
+	// To center the text, there's a vertical offset that should be blank:
+	const float yOfs = (1.0 - deltaY) / 2.0;
+	// And now v should go from [0..1] within the deltaY band:
+	const float v = (input.tex.y - yOfs) / deltaY;
+	if (v < 0.0 || v > 1.0)
+		discard;
+	const float2 uv = lerp(src0, src1, float2(input.tex.x, v));
 
 	float4 textCol  = float4(texture0.Sample(sampler0, uv));
 	// We're using approx luma to compute the alpha channel here and then scale

--- a/impl11/shaders/PixelShaderVRGeom.hlsl
+++ b/impl11/shaders/PixelShaderVRGeom.hlsl
@@ -97,7 +97,9 @@ PixelShaderOutput RenderEnhancedBracket(PixelShaderInput input)
 	const float v = (input.tex.y - yOfs) / deltaY;
 	if (v < 0.0 || v > 1.0)
 		discard;
-	const float2 uv = lerp(src0, src1, float2(input.tex.x, v));
+	// v is inverted here because the transform chain for the bracket ends up doing
+	// a vertical mirror image, and it's just easier to flip the texture here:
+	const float2 uv = lerp(src0, src1, float2(input.tex.x, 1.0 - v));
 
 	float4 textCol  = float4(texture0.Sample(sampler0, uv));
 	// We're using approx luma to compute the alpha channel here and then scale

--- a/impl11/shaders/shaders.vcxproj
+++ b/impl11/shaders/shaders.vcxproj
@@ -139,6 +139,11 @@
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Vertex</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4.0</ShaderModel>
     </FxCompile>
+    <FxCompile Include="EnhancedHudPS.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Pixel</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4.0</ShaderModel>
+    </FxCompile>
     <FxCompile Include="ExplosionShader.hlsl">
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Pixel</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4.0</ShaderModel>

--- a/impl11/shaders/shaders.vcxproj.filters
+++ b/impl11/shaders/shaders.vcxproj.filters
@@ -110,6 +110,7 @@
     <FxCompile Include="PixelShaderVRGeom.hlsl" />
     <FxCompile Include="SpeedEffectPixelShader.hlsl" />
     <FxCompile Include="SpeedEffectPixelShaderVR.hlsl" />
+    <FxCompile Include="EnhancedHudPS.hlsl" />
   </ItemGroup>
   <ItemGroup>
     <None Include="bloom\BloomCommon.fxh">


### PR DESCRIPTION
The Enhanced HUD is now visible in VR; but needs more work to make it look just like the pancake version.

The data for the Enhanced HUD is now extracted from the DC areas that overlap with the contents of g_xwa_text. This way, the data is always correct at the cost of doing a little parsing. We also get the colors of the text and the text can be converted to int's which can be used to display bars.