### PR TITLE
Fix Dynamic Cockpit text using AUTOSIZE boxes

### DIFF
--- a/impl11/ddraw/DeviceResources.cpp
+++ b/impl11/ddraw/DeviceResources.cpp
@@ -1715,6 +1715,7 @@ HRESULT DeviceResources::OnSizeChanged(HWND hWnd, DWORD dwWidth, DWORD dwHeight)
 	g_b3DSkydomePresent = false;
 	g_SSAO_PSCBuffer.enable_dist_fade = 0.0f;
 	g_bDCApplyEraseRegionCommands = !g_bHUDVisibleOnStartup;
+	DCResetSubRegions();
 	log_debug("[DBG] Resetting g_b3DSunPresent, g_b3DSkydomePresent");
 
 	g_meshToFGMap.clear(); // OnSizeChanged(), called when a mission is loaded

--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -4464,9 +4464,18 @@ HRESULT Direct3DDevice::Execute(
 							dcElemSrcBox->bComputed = true;
 
 							{
-								auto& autoBox  = g_DCSubRegions[DC_SUB_SHIP_NAME_IDX];
+								auto& autoBox  = g_DCSubRegions[DC_SUB_NAME_IDX];
 								autoBox.coords = dcElemSrcBox->coords;
 								autoBox.coords.y1 = autoBox.coords.y0 + 0.4f * (autoBox.coords.y1 - autoBox.coords.y0);
+								// Extend the box to the right to capture wide fonts
+								autoBox.coords.x1 += 23.0f / g_fCurInGameWidth;
+								autoBox.bComputed = true;
+							}
+
+							{
+								auto& autoBox  = g_DCSubRegions[DC_SUB_TIME_IDX];
+								autoBox.coords = dcElemSrcBox->coords;
+								autoBox.coords.y0 = autoBox.coords.y0 + 0.6f * (autoBox.coords.y1 - autoBox.coords.y0);
 								// Extend the box to the right to capture wide fonts
 								autoBox.coords.x1 += 23.0f / g_fCurInGameWidth;
 								autoBox.bComputed = true;

--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -4392,6 +4392,12 @@ HRESULT Direct3DDevice::Execute(
 								uv_minmax, box, dcElemSrcBox->uv_coords);
 							dcElemSrcBox->bComputed = true;
 
+							// This is how we transform from UV coords [0..1] to screen coords:
+							//g_DCCurSrcRegion.x0 = g_fCurScreenWidth  * dcElemSrcBox->coords.x0;
+							//g_DCCurSrcRegion.y0 = g_fCurScreenHeight * dcElemSrcBox->coords.y0;
+							//g_DCCurSrcRegion.x1 = g_fCurScreenWidth  * dcElemSrcBox->coords.x1;
+							//g_DCCurSrcRegion.y1 = g_fCurScreenHeight * dcElemSrcBox->coords.y1;
+
 							// Get the limits for the CMD text
 							dcElemSrcBox = &g_DCElemSrcBoxes.src_boxes[KW_TEXT_CMD_DC_ELEM_SRC_IDX];
 							dcElemSrcBox->coords = ComputeCoordsFromUV(left, top, width, height,

--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -4480,6 +4480,16 @@ HRESULT Direct3DDevice::Execute(
 								uv_minmax, box, dcElemSrcBox->uv_coords);
 							dcElemSrcBox->bComputed = true;
 
+							{
+								auto& autoBox  = g_DCSubRegions[DC_SUB_CHAFF_IDX];
+								autoBox.coords = dcElemSrcBox->coords;
+								// Move the left side of the box, so that we don't capture missile digits:
+								autoBox.coords.x0 = autoBox.coords.x0 + 0.5f * (autoBox.coords.x1 - autoBox.coords.x0);
+								// Extend the box to the right to capture wide fonts:
+								autoBox.coords.x1 += 5.0f / g_fCurInGameWidth;
+								autoBox.bComputed = true;
+							}
+
 							// Get the limits for Text Line 3
 							dcElemSrcBox = &g_DCElemSrcBoxes.src_boxes[KW_TEXT_RADIOSYS_DC_ELEM_SRC_IDX];
 							dcElemSrcBox->coords = ComputeCoordsFromUV(left, top, width, height,

--- a/impl11/ddraw/DynamicCockpit.cpp
+++ b/impl11/ddraw/DynamicCockpit.cpp
@@ -10,6 +10,19 @@ DCHUDRegions g_DCHUDRegions;
 DCElemSrcBoxes g_DCElemSrcBoxes;
 dc_element g_DCElements[MAX_DC_SRC_ELEMENTS] = { 0 };
 SubDCSrcBox g_DCSubRegions[MAX_DC_SUB_ELEMENTS];
+Box g_speedBox = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
+Box g_mslsBox[2] = {
+	{ FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX },
+	{ FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX }
+};
+
+void DCResetSubRegions()
+{
+	g_bRecomputeFontHeights = true;
+	g_speedBox = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
+	g_mslsBox[0] = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
+	g_mslsBox[1] = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
+}
 
 float g_fCoverTextureBrightness = 1.0f;
 float g_fDCBrightness = 1.0f;
@@ -115,6 +128,7 @@ std::vector<const char*> g_DCElemSrcNames = {
 	"THROTTLE_BAR_SRC",			// 41
 	"AUTOSIZE_MISSILES_L_SRC",  // 42
 	"AUTOSIZE_MISSILES_R_SRC",  // 43
+	"AUTOSIZE_SPEED_SRC",       // 44
 };
 
 int HUDRegionNameToIndex(char* name) {

--- a/impl11/ddraw/DynamicCockpit.cpp
+++ b/impl11/ddraw/DynamicCockpit.cpp
@@ -18,6 +18,11 @@ Box g_mslsBox[2];
 Box g_tgtNameBox, g_tgtShdBox, g_tgtHullBox, g_tgtSysBox;
 Box g_tgtDistBox, g_tgtSubCmpBox, g_tgtCargoBox;
 
+// DC Debug
+Box  g_DCDebugBox       = { 0 };
+bool g_bEnableDCDebug   = false;
+int  g_iDCDebugSrcIndex = -1;
+
 void DCResetSubRegions()
 {
 	g_bRecomputeFontHeights = true;

--- a/impl11/ddraw/DynamicCockpit.cpp
+++ b/impl11/ddraw/DynamicCockpit.cpp
@@ -10,24 +10,30 @@ DCHUDRegions g_DCHUDRegions;
 DCElemSrcBoxes g_DCElemSrcBoxes;
 dc_element g_DCElements[MAX_DC_SRC_ELEMENTS] = { 0 };
 SubDCSrcBox g_DCSubRegions[MAX_DC_SUB_ELEMENTS];
-Box g_speedBox = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
-Box g_chaffBox = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
-Box g_nameBox = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
-Box g_timeBox = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
-Box g_mslsBox[2] = {
-	{ FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX },
-	{ FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX }
-};
+Box g_speedBox;
+Box g_chaffBox;
+Box g_nameBox;
+Box g_timeBox;
+Box g_mslsBox[2];
+Box g_tgtNameBox, g_tgtShdBox, g_tgtHullBox, g_tgtSysBox;
+Box g_tgtDistBox, g_tgtSubCmpBox, g_tgtCargoBox;
 
 void DCResetSubRegions()
 {
 	g_bRecomputeFontHeights = true;
-	g_speedBox = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
-	g_chaffBox = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
-	g_nameBox = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
-	g_timeBox = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
-	g_mslsBox[0] = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
-	g_mslsBox[1] = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
+	g_speedBox.Invalidate();
+	g_chaffBox.Invalidate();
+	g_nameBox.Invalidate();
+	g_timeBox.Invalidate();
+	g_mslsBox[0].Invalidate();
+	g_mslsBox[1].Invalidate();
+	g_tgtNameBox.Invalidate();
+	g_tgtShdBox.Invalidate();
+	g_tgtHullBox.Invalidate();
+	g_tgtSysBox.Invalidate();
+	g_tgtDistBox.Invalidate();
+	g_tgtSubCmpBox.Invalidate();
+	g_tgtCargoBox.Invalidate();
 }
 
 float g_fCoverTextureBrightness = 1.0f;

--- a/impl11/ddraw/DynamicCockpit.cpp
+++ b/impl11/ddraw/DynamicCockpit.cpp
@@ -113,6 +113,8 @@ std::vector<const char*> g_DCElemSrcNames = {
 	"TARGETED_OBJ_SUBCMP_SRC",	// 39
 	"EIGHT_LASERS_BOTH_SRC",	// 40
 	"THROTTLE_BAR_SRC",			// 41
+	"AUTOSIZE_MISSILES_L_SRC",  // 42
+	"AUTOSIZE_MISSILES_R_SRC",  // 43
 };
 
 int HUDRegionNameToIndex(char* name) {

--- a/impl11/ddraw/DynamicCockpit.cpp
+++ b/impl11/ddraw/DynamicCockpit.cpp
@@ -34,13 +34,20 @@ void DCResetSubRegions()
 	g_timeBox.Invalidate();
 	g_mslsBox[0].Invalidate();
 	g_mslsBox[1].Invalidate();
-	g_tgtNameBox.Invalidate();
+
 	g_tgtShdBox.Invalidate();
 	g_tgtHullBox.Invalidate();
 	g_tgtSysBox.Invalidate();
 	g_tgtDistBox.Invalidate();
-	g_tgtSubCmpBox.Invalidate();
-	g_tgtCargoBox.Invalidate();
+
+	// Do not invalidate these fields. It will cause them to shink and text will look
+	// quite stretched:
+	//g_tgtNameBox.Invalidate();
+	//g_tgtSubCmpBox.Invalidate();
+	//g_tgtCargoBox.Invalidate();
+	g_tgtNameBox   = g_DCElemSrcBoxes.src_boxes[TARGETED_OBJ_NAME_SRC_IDX].coords;
+	g_tgtSubCmpBox = g_DCElemSrcBoxes.src_boxes[TARGETED_OBJ_SUBCMP_SRC_IDX].coords;
+	g_tgtCargoBox  = g_DCElemSrcBoxes.src_boxes[TARGETED_OBJ_CARGO_SRC_IDX].coords;
 }
 
 float g_fCoverTextureBrightness = 1.0f;

--- a/impl11/ddraw/DynamicCockpit.cpp
+++ b/impl11/ddraw/DynamicCockpit.cpp
@@ -11,6 +11,7 @@ DCElemSrcBoxes g_DCElemSrcBoxes;
 dc_element g_DCElements[MAX_DC_SRC_ELEMENTS] = { 0 };
 SubDCSrcBox g_DCSubRegions[MAX_DC_SUB_ELEMENTS];
 Box g_speedBox = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
+Box g_chaffBox = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
 Box g_mslsBox[2] = {
 	{ FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX },
 	{ FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX }
@@ -20,6 +21,7 @@ void DCResetSubRegions()
 {
 	g_bRecomputeFontHeights = true;
 	g_speedBox = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
+	g_chaffBox = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
 	g_mslsBox[0] = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
 	g_mslsBox[1] = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
 }
@@ -129,6 +131,7 @@ std::vector<const char*> g_DCElemSrcNames = {
 	"AUTOSIZE_MISSILES_L_SRC",  // 42
 	"AUTOSIZE_MISSILES_R_SRC",  // 43
 	"AUTOSIZE_SPEED_SRC",       // 44
+	"AUTOSIZE_CHAFF_SRC",       // 45
 };
 
 int HUDRegionNameToIndex(char* name) {

--- a/impl11/ddraw/DynamicCockpit.cpp
+++ b/impl11/ddraw/DynamicCockpit.cpp
@@ -12,6 +12,8 @@ dc_element g_DCElements[MAX_DC_SRC_ELEMENTS] = { 0 };
 SubDCSrcBox g_DCSubRegions[MAX_DC_SUB_ELEMENTS];
 Box g_speedBox = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
 Box g_chaffBox = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
+Box g_nameBox = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
+Box g_timeBox = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
 Box g_mslsBox[2] = {
 	{ FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX },
 	{ FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX }
@@ -22,6 +24,8 @@ void DCResetSubRegions()
 	g_bRecomputeFontHeights = true;
 	g_speedBox = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
 	g_chaffBox = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
+	g_nameBox = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
+	g_timeBox = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
 	g_mslsBox[0] = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
 	g_mslsBox[1] = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
 }
@@ -132,6 +136,8 @@ std::vector<const char*> g_DCElemSrcNames = {
 	"AUTOSIZE_MISSILES_R_SRC",  // 43
 	"AUTOSIZE_SPEED_SRC",       // 44
 	"AUTOSIZE_CHAFF_SRC",       // 45
+	"AUTOSIZE_NAME_SRC",        // 46
+	"AUTOSIZE_TIME_SRC",        // 47
 };
 
 int HUDRegionNameToIndex(char* name) {

--- a/impl11/ddraw/DynamicCockpit.cpp
+++ b/impl11/ddraw/DynamicCockpit.cpp
@@ -982,6 +982,11 @@ bool LoadDCInternalCoordinates() {
 						box.x0 = 34.0f / 128.0f; box.y0 = 13.0f / 128.0f;
 						box.x1 = 63.0f / 128.0f; box.y1 = 25.0f / 128.0f;
 					}
+					else if (source_slot == MISSILES_DC_ELEM_SRC_IDX)
+					{
+						box.x0 = 200.0f / 256.0f; box.y0 =  0.0f / 32.0f;
+						box.x1 = 256.0f / 256.0f; box.y1 = 25.0f / 32.0f;
+					}
 					g_DCElemSrcBoxes.src_boxes[source_slot].uv_coords = box;
 				}
 				else

--- a/impl11/ddraw/DynamicCockpit.cpp
+++ b/impl11/ddraw/DynamicCockpit.cpp
@@ -22,6 +22,8 @@ Box g_tgtDistBox, g_tgtSubCmpBox, g_tgtCargoBox;
 Box  g_DCDebugBox       = { 0 };
 bool g_bEnableDCDebug   = false;
 int  g_iDCDebugSrcIndex = -1;
+bool g_bDCDebugDisplayLabels = false;
+std::string g_DCDebugLabel = "";
 
 void DCResetSubRegions()
 {

--- a/impl11/ddraw/DynamicCockpit.h
+++ b/impl11/ddraw/DynamicCockpit.h
@@ -227,7 +227,8 @@ const int THROTTLE_BAR_DC_SRC_IDX = 41;
 const int AUTO_MSLS_LEFT_DC_SRC_IDX = 42;
 const int AUTO_MSLS_RIGHT_DC_SRC_IDX = 43;
 const int AUTO_SPEED_DC_SRC_IDX = 44;
-const int MAX_DC_SRC_ELEMENTS = 45;
+const int AUTO_CHAFF_DC_SRC_IDX = 45;
+const int MAX_DC_SRC_ELEMENTS = 46;
 extern std::vector<const char*>g_DCElemSrcNames;
 // Convert a string into a *_DC_ELEM_SRC_IDX constant
 int DCSrcElemNameToIndex(char* name);
@@ -272,7 +273,8 @@ struct SubDCSrcBox
 constexpr int DC_SUB_SPEED_IDX     = 0;
 constexpr int DC_SUB_THROTTLE_IDX  = 1;
 constexpr int DC_SUB_SHIP_NAME_IDX = 2;
-constexpr int MAX_DC_SUB_ELEMENTS  = 3;
+constexpr int DC_SUB_CHAFF_IDX     = 3;
+constexpr int MAX_DC_SUB_ELEMENTS  = 4;
 /// <summary>
 /// This array holds UV coords for fractions of HUD elements, like the speed and
 /// throttle, for instance (they are in the same DC src region). These boxes are
@@ -284,6 +286,7 @@ constexpr int MAX_DC_SUB_ELEMENTS  = 3;
 /// </summary>
 extern SubDCSrcBox g_DCSubRegions[MAX_DC_SUB_ELEMENTS];
 extern Box g_speedBox;
+extern Box g_chaffBox;
 extern Box g_mslsBox[2];
 extern bool g_bRecomputeFontHeights;
 void DCResetSubRegions();

--- a/impl11/ddraw/DynamicCockpit.h
+++ b/impl11/ddraw/DynamicCockpit.h
@@ -226,7 +226,8 @@ const int EIGHT_LASERS_BOTH_SRC_IDX = 40;
 const int THROTTLE_BAR_DC_SRC_IDX = 41;
 const int AUTO_MSLS_LEFT_DC_SRC_IDX = 42;
 const int AUTO_MSLS_RIGHT_DC_SRC_IDX = 43;
-const int MAX_DC_SRC_ELEMENTS = 44;
+const int AUTO_SPEED_DC_SRC_IDX = 44;
+const int MAX_DC_SRC_ELEMENTS = 45;
 extern std::vector<const char*>g_DCElemSrcNames;
 // Convert a string into a *_DC_ELEM_SRC_IDX constant
 int DCSrcElemNameToIndex(char* name);
@@ -282,7 +283,10 @@ constexpr int MAX_DC_SUB_ELEMENTS  = 3;
 /// at the same time when the "parent" DC source element UV coords are computed.
 /// </summary>
 extern SubDCSrcBox g_DCSubRegions[MAX_DC_SUB_ELEMENTS];
-
+extern Box g_speedBox;
+extern Box g_mslsBox[2];
+extern bool g_bRecomputeFontHeights;
+void DCResetSubRegions();
 
 extern bool g_bRenderLaserIonEnergyLevels; // If set, the Laser/Ion energy levels will be rendered from XWA's heap data
 extern bool g_bRenderThrottle; // If set, render the throttle as a vertical bar next to the shields

--- a/impl11/ddraw/DynamicCockpit.h
+++ b/impl11/ddraw/DynamicCockpit.h
@@ -224,7 +224,9 @@ const int TARGETED_OBJ_DIST_SRC_IDX = 38;
 const int TARGETED_OBJ_SUBCMP_SRC_IDX = 39;
 const int EIGHT_LASERS_BOTH_SRC_IDX = 40;
 const int THROTTLE_BAR_DC_SRC_IDX = 41;
-const int MAX_DC_SRC_ELEMENTS = 42;
+const int AUTO_MSLS_LEFT_DC_SRC_IDX = 42;
+const int AUTO_MSLS_RIGHT_DC_SRC_IDX = 43;
+const int MAX_DC_SRC_ELEMENTS = 44;
 extern std::vector<const char*>g_DCElemSrcNames;
 // Convert a string into a *_DC_ELEM_SRC_IDX constant
 int DCSrcElemNameToIndex(char* name);

--- a/impl11/ddraw/DynamicCockpit.h
+++ b/impl11/ddraw/DynamicCockpit.h
@@ -61,9 +61,13 @@ HOW TO ADD NEW ERASE REGION COMMANDS:
 */
 
 // DYNAMIC COCKPIT
-typedef struct Box_struct {
+struct Box {
 	float x0, y0, x1, y1;
-} Box;
+	void Invalidate()
+	{
+		*this = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
+	}
+};
 
 // Also found in the Floating_GUI_RESNAME list:
 extern const char* DC_TARGET_COMP_SRC_RESNAME;
@@ -292,6 +296,8 @@ extern Box g_speedBox;
 extern Box g_chaffBox;
 extern Box g_nameBox;
 extern Box g_timeBox;
+extern Box g_tgtNameBox, g_tgtShdBox, g_tgtHullBox, g_tgtSysBox;
+extern Box g_tgtDistBox, g_tgtSubCmpBox, g_tgtCargoBox;
 extern Box g_mslsBox[2];
 extern bool g_bRecomputeFontHeights;
 void DCResetSubRegions();

--- a/impl11/ddraw/DynamicCockpit.h
+++ b/impl11/ddraw/DynamicCockpit.h
@@ -302,6 +302,11 @@ extern Box g_mslsBox[2];
 extern bool g_bRecomputeFontHeights;
 void DCResetSubRegions();
 
+// DC Debug
+extern Box  g_DCDebugBox;
+extern bool g_bEnableDCDebug;
+extern int  g_iDCDebugSrcIndex;
+
 extern bool g_bRenderLaserIonEnergyLevels; // If set, the Laser/Ion energy levels will be rendered from XWA's heap data
 extern bool g_bRenderThrottle; // If set, render the throttle as a vertical bar next to the shields
 extern D2D1::ColorF g_DCLaserColor, g_DCIonColor, g_DCThrottleColor;

--- a/impl11/ddraw/DynamicCockpit.h
+++ b/impl11/ddraw/DynamicCockpit.h
@@ -228,7 +228,9 @@ const int AUTO_MSLS_LEFT_DC_SRC_IDX = 42;
 const int AUTO_MSLS_RIGHT_DC_SRC_IDX = 43;
 const int AUTO_SPEED_DC_SRC_IDX = 44;
 const int AUTO_CHAFF_DC_SRC_IDX = 45;
-const int MAX_DC_SRC_ELEMENTS = 46;
+const int AUTO_NAME_DC_SRC_IDX = 46;
+const int AUTO_TIME_DC_SRC_IDX = 47;
+const int MAX_DC_SRC_ELEMENTS = 48;
 extern std::vector<const char*>g_DCElemSrcNames;
 // Convert a string into a *_DC_ELEM_SRC_IDX constant
 int DCSrcElemNameToIndex(char* name);
@@ -270,11 +272,12 @@ struct SubDCSrcBox
 	bool bComputed = false;
 };
 
-constexpr int DC_SUB_SPEED_IDX     = 0;
-constexpr int DC_SUB_THROTTLE_IDX  = 1;
-constexpr int DC_SUB_SHIP_NAME_IDX = 2;
-constexpr int DC_SUB_CHAFF_IDX     = 3;
-constexpr int MAX_DC_SUB_ELEMENTS  = 4;
+constexpr int DC_SUB_SPEED_IDX    = 0;
+constexpr int DC_SUB_THROTTLE_IDX = 1;
+constexpr int DC_SUB_NAME_IDX     = 2;
+constexpr int DC_SUB_TIME_IDX     = 3;
+constexpr int DC_SUB_CHAFF_IDX    = 4;
+constexpr int MAX_DC_SUB_ELEMENTS = 5;
 /// <summary>
 /// This array holds UV coords for fractions of HUD elements, like the speed and
 /// throttle, for instance (they are in the same DC src region). These boxes are
@@ -287,6 +290,8 @@ constexpr int MAX_DC_SUB_ELEMENTS  = 4;
 extern SubDCSrcBox g_DCSubRegions[MAX_DC_SUB_ELEMENTS];
 extern Box g_speedBox;
 extern Box g_chaffBox;
+extern Box g_nameBox;
+extern Box g_timeBox;
 extern Box g_mslsBox[2];
 extern bool g_bRecomputeFontHeights;
 void DCResetSubRegions();

--- a/impl11/ddraw/DynamicCockpit.h
+++ b/impl11/ddraw/DynamicCockpit.h
@@ -306,6 +306,8 @@ void DCResetSubRegions();
 extern Box  g_DCDebugBox;
 extern bool g_bEnableDCDebug;
 extern int  g_iDCDebugSrcIndex;
+extern bool g_bDCDebugDisplayLabels;
+extern std::string g_DCDebugLabel;
 
 extern bool g_bRenderLaserIonEnergyLevels; // If set, the Laser/Ion energy levels will be rendered from XWA's heap data
 extern bool g_bRenderThrottle; // If set, render the throttle as a vertical bar next to the shields

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -21,6 +21,9 @@ constexpr float BACKGROUND_CUBE_HALFSIZE_METERS = BACKGROUND_CUBE_SIZE_METERS / 
 constexpr float BACKGROUND_CYL_RATIO = 1.09f; // 1.053f ? 1.375f ?
 static constexpr int s_numCylTriangles = 12;
 
+// Dynamic Cockpit
+extern Box g_DCExtractedBox;
+
 // Raytracing
 extern bool g_bEnableQBVHwSAH;
 //BVHBuilderType g_BVHBuilderType = BVHBuilderType_BVH2;
@@ -6089,7 +6092,7 @@ void EffectsRenderer::MainSceneHook(const SceneCompData* scene)
 		goto out;
 
 	// Dynamic Cockpit: Replace textures at run-time. Returns true if we need to skip the current draw call
-	if (DCReplaceTextures())
+	if (DCReplaceTextures(scene))
 		goto out;
 
 	// TODO: Update the Hyperspace FSM -- but only update it exactly once per frame.
@@ -6514,7 +6517,74 @@ void EffectsRenderer::DCCaptureMiniature()
 	}
 }
 
-bool EffectsRenderer::DCReplaceTextures()
+#if 0
+void EffectsRenderer::GetUVsForCurrentTexture(const SceneCompData* scene)
+{
+	// Adapted from ApplyActiveCockpit()
+	XwaVector3* MeshVertices = scene->MeshVertices;
+	int MeshVerticesCount = *(int*)((int)scene->MeshVertices - 8);
+	XwaTextureVertex* MeshTextureVertices = scene->MeshTextureVertices;
+	int MeshTextureVerticesCount = *(int*)((int)scene->MeshTextureVertices - 8);
+	XwaTextureVertex UV0, UV1, UV2;
+
+	Box box = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
+	for (int faceIndex = 0; faceIndex < scene->FacesCount; faceIndex++)
+	{
+		OptFaceDataNode_01_Data_Indices& faceData = scene->FaceIndices[faceIndex];
+		int edgesCount = faceData.Edge[3] == -1 ? 3 : 4;
+
+		// See BuildMultipleBLASFromCurrentBLASMap() too
+		for (int edge = 2; edge < edgesCount; edge++)
+		{
+			D3dTriangle t;
+			t.v1 = 0;
+			t.v2 = edge - 1;
+			t.v3 = edge;
+
+			UV0 = scene->MeshTextureVertices[faceData.TextureVertex[t.v1]];
+			UV1 = scene->MeshTextureVertices[faceData.TextureVertex[t.v2]];
+			UV2 = scene->MeshTextureVertices[faceData.TextureVertex[t.v3]];
+			auto expand = [](Box& box, const XwaTextureVertex& U)
+				{
+					box.x0 = min(box.x0, U.u);
+					box.y0 = min(box.y0, U.v);
+
+					box.x1 = max(box.x1, U.u);
+					box.y1 = max(box.y1, U.v);
+				};
+			expand(box, UV0);
+			expand(box, UV1);
+			expand(box, UV2);
+
+			/*log_debug("[DBG] fi: %d, fc:%d, e:%d, ec:%d, (%0.3f, %0.3f), (%0.3f, %0.3f), (%0.3f, %0.3f)",
+				faceIndex, scene->FacesCount, edge, edgesCount,
+				UV0.u, UV0.v,  UV1.u, UV1.v,  UV2.u, UV2.v);
+			log_debug("[DBG] fi: %d, fc:%d, e:%d, ec:%d, [%d - %d - %d]",
+				faceIndex, scene->FacesCount, edge, edgesCount,
+				faceData.TextureVertex[t.v1],
+				faceData.TextureVertex[t.v2],
+				faceData.TextureVertex[t.v3]);*/
+		}
+	}
+	//log_debug("[DBG] ----------------");
+
+	// Flip the y uv coords (probably because textures are stored upside down in the OPT?)
+	box.y0 = 1.0f - box.y0;
+	box.y1 = 1.0f - box.y1;
+	const float w = (g_DCCurSrcRegion.x1 - g_DCCurSrcRegion.x0) + 1;
+	const float h = (g_DCCurSrcRegion.y1 - g_DCCurSrcRegion.y0) + 1;
+	g_DCSubBoxFromOPT.x0 = g_DCCurSrcRegion.x0 + w * box.x0;
+	g_DCSubBoxFromOPT.y0 = g_DCCurSrcRegion.y0 + h * box.y0;
+
+	g_DCSubBoxFromOPT.x1 = g_DCCurSrcRegion.x0 + w * box.x1;
+	g_DCSubBoxFromOPT.y1 = g_DCCurSrcRegion.y0 + h * box.y1;
+
+	/*log_debug("[DBG] box: (%0.3f, %0.3f)-(%0.3f, %0.3f)",
+		box.x0, box.y0,  box.x1, box.y1);*/
+}
+#endif
+
+bool EffectsRenderer::DCReplaceTextures(const SceneCompData* scene)
 {
 	bool bSkip = false;
 	auto &resources = _deviceResources;
@@ -6564,6 +6634,17 @@ bool EffectsRenderer::DCReplaceTextures()
 				uvfloat4 uv_src;
 				uv_src.x0 = src_box->coords.x0; uv_src.y0 = src_box->coords.y0;
 				uv_src.x1 = src_box->coords.x1; uv_src.y1 = src_box->coords.y1;
+
+				const bool bReplaceUVs = (src_slot == MISSILES_DC_ELEM_SRC_IDX && dc_element->coords.numCoords == 1);
+				if (bReplaceUVs)
+				{
+					// Use this when a single texture is used for missles-L:
+					uv_src.x0 = g_DCExtractedBox.x0 / g_fCurScreenWidth;
+					uv_src.y0 = g_DCExtractedBox.y0 / g_fCurScreenHeight;
+					uv_src.x1 = g_DCExtractedBox.x1 / g_fCurScreenWidth;
+					uv_src.y1 = g_DCExtractedBox.y1 / g_fCurScreenHeight;
+				}
+
 				g_DCPSCBuffer.src[numCoords] = uv_src;
 				g_DCPSCBuffer.dst[numCoords] = dc_element->coords.dst[i];
 				g_DCPSCBuffer.noisy_holo = _bIsNoisyHolo;

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -21,9 +21,6 @@ constexpr float BACKGROUND_CUBE_HALFSIZE_METERS = BACKGROUND_CUBE_SIZE_METERS / 
 constexpr float BACKGROUND_CYL_RATIO = 1.09f; // 1.053f ? 1.375f ?
 static constexpr int s_numCylTriangles = 12;
 
-// Dynamic Cockpit
-extern Box g_DCExtractedBox;
-
 // Raytracing
 extern bool g_bEnableQBVHwSAH;
 //BVHBuilderType g_BVHBuilderType = BVHBuilderType_BVH2;
@@ -6634,17 +6631,6 @@ bool EffectsRenderer::DCReplaceTextures(const SceneCompData* scene)
 				uvfloat4 uv_src;
 				uv_src.x0 = src_box->coords.x0; uv_src.y0 = src_box->coords.y0;
 				uv_src.x1 = src_box->coords.x1; uv_src.y1 = src_box->coords.y1;
-
-				const bool bReplaceUVs = (src_slot == MISSILES_DC_ELEM_SRC_IDX && dc_element->coords.numCoords == 1);
-				if (bReplaceUVs)
-				{
-					// Use this when a single texture is used for missles-L:
-					uv_src.x0 = g_DCExtractedBox.x0 / g_fCurScreenWidth;
-					uv_src.y0 = g_DCExtractedBox.y0 / g_fCurScreenHeight;
-					uv_src.x1 = g_DCExtractedBox.x1 / g_fCurScreenWidth;
-					uv_src.y1 = g_DCExtractedBox.y1 / g_fCurScreenHeight;
-				}
-
 				g_DCPSCBuffer.src[numCoords] = uv_src;
 				g_DCPSCBuffer.dst[numCoords] = dc_element->coords.dst[i];
 				g_DCPSCBuffer.noisy_holo = _bIsNoisyHolo;

--- a/impl11/ddraw/EffectsRenderer.h
+++ b/impl11/ddraw/EffectsRenderer.h
@@ -201,8 +201,9 @@ public:
 	void ApplyMeshTransform();
 	void ApplyActiveCockpit(const SceneCompData* scene);
 	void DCCaptureMiniature();
+	void GetUVsForCurrentTexture(const SceneCompData* scene);
 	// Returns true if the current draw call needs to be skipped
-	bool DCReplaceTextures();
+	bool DCReplaceTextures(const SceneCompData* scene);
 	virtual void ExtraPreprocessing();
 	void AddLaserLights(const SceneCompData* scene);
 	void ApplyProceduralLava();

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -12892,9 +12892,10 @@ void PrimarySurface::ExtractDCText()
 		//const float y1 = (float)xwaText.positionY + (float)s_rowSize;
 		const float y1 = (float)xwaText.positionY + g_inGameFontHeights[fontIndex];
 
-		// We don't care about any text appearing on the bottom half of the screen: there's
-		// no DC content in that area.
-		if (y1 > 0.5f * g_fCurInGameHeight)
+		// We don't care about any text appearing on the text boxes: it's not used neither by the
+		// Enhanced HUD, nor the DC Autosize.
+		if (y1 > 0.5f * g_fCurInGameHeight &&
+			(x1 < 0.333f * g_fCurInGameWidth || x1 > 0.666f * g_fCurInGameWidth))
 			continue;
 
 		for (int dcCurRegion = 0; dcCurRegion < MAX_IDX; dcCurRegion++)

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -13415,7 +13415,7 @@ void PrimarySurface::RenderText(bool earlyExit)
 	rtv->BeginDraw();
 
 	// DEBUG: Display the coords of one of the DC boxes:
-	if (g_bEnableDCDebug)
+	if (g_bEnableDCDebug && !g_bUseSteamVR)
 	{
 		float width = 3.0f;
 		if (g_iDCDebugSrcIndex != -1)
@@ -13427,8 +13427,24 @@ void PrimarySurface::RenderText(bool earlyExit)
 			g_DCDebugBox.y1 = g_fCurScreenHeight * src_box->coords.y1;
 			width = 1.0f;
 		}
-		s_brush->SetColor(D2D1::ColorF(0xFF3030));
+		s_brush->SetColor(D2D1::ColorF(0xFFFFFF));
 		rtv->DrawRectangle(D2D1::RectF(g_DCDebugBox.x0, g_DCDebugBox.y0, g_DCDebugBox.x1, g_DCDebugBox.y1), s_brush, width);
+		if (g_bDCDebugDisplayLabels)
+		{
+			char* str = (char*)g_DCDebugLabel.c_str();
+			int width = ComputeMsgWidth(str, FONT_LARGE_IDX);
+
+			float x = (g_DCDebugBox.x0 + g_DCDebugBox.x1) / 2;
+			float y = g_DCDebugBox.y1 + 20;
+			float ix, iy;
+			// Don't put labels below the end of the screen:
+			if (y >= g_fCurScreenHeight)
+				y = g_DCDebugBox.y0 - 60;
+			ScreenCoordsToInGame(x, y, &ix, &iy);
+			ix = ix - width / 2;
+
+			DisplayText(str, FONT_LARGE_IDX, (int)ix, (int)iy, 0xFFFFFF);
+		}
 	}
 
 	unsigned int brushColor = 0;

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -12671,11 +12671,6 @@ uint32_t EnhanceTextColor(uint32_t col)
 	return col;
 }
 
-#define DEBUG_DC_BOX 0
-#if DEBUG_DC_BOX == 1
-Box g_DCDebugBox = { 0 };
-#endif
-
 /// <summary>
 /// Extract DC strings from the contents of g_xwa_text by comparing the coords of each char
 /// against the DC source regions. The output is stored in g_EnhancedHUDData.
@@ -13420,12 +13415,21 @@ void PrimarySurface::RenderText(bool earlyExit)
 	rtv->BeginDraw();
 
 	// DEBUG: Display the coords of one of the DC boxes:
-#if DEBUG_DC_BOX == 1
+	if (g_bEnableDCDebug)
 	{
+		float width = 3.0f;
+		if (g_iDCDebugSrcIndex != -1)
+		{
+			DCElemSrcBox* src_box = &g_DCElemSrcBoxes.src_boxes[g_iDCDebugSrcIndex];
+			g_DCDebugBox.x0 = g_fCurScreenWidth  * src_box->coords.x0;
+			g_DCDebugBox.y0 = g_fCurScreenHeight * src_box->coords.y0;
+			g_DCDebugBox.x1 = g_fCurScreenWidth  * src_box->coords.x1;
+			g_DCDebugBox.y1 = g_fCurScreenHeight * src_box->coords.y1;
+			width = 1.0f;
+		}
 		s_brush->SetColor(D2D1::ColorF(0xFF3030));
-		rtv->DrawRectangle(D2D1::RectF(g_DCDebugBox.x0, g_DCDebugBox.y0, g_DCDebugBox.x1, g_DCDebugBox.y1), s_brush, 3.0f);
+		rtv->DrawRectangle(D2D1::RectF(g_DCDebugBox.x0, g_DCDebugBox.y0, g_DCDebugBox.x1, g_DCDebugBox.y1), s_brush, width);
 	}
-#endif
 
 	unsigned int brushColor = 0;
 	s_brush->SetColor(D2D1::ColorF(brushColor));

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -13443,7 +13443,21 @@ void PrimarySurface::RenderText(bool earlyExit)
 			ScreenCoordsToInGame(x, y, &ix, &iy);
 			ix = ix - width / 2;
 
-			DisplayText(str, FONT_LARGE_IDX, (int)ix, (int)iy, 0xFFFFFF);
+			const short ix1 = DisplayText(str, FONT_LARGE_IDX, (int)ix, (int)iy, 0xFFFFFF);
+
+			// Render a rectangle under the text (the reason it appears under the text is that
+			// DisplayText() renders the text later.
+#if 0
+			{
+				float sx0, sy0, sx1, dummy;
+				InGameToScreenCoords(ix, iy, &sx0, &sy0);
+				InGameToScreenCoords(ix1, 0, &sx1, &dummy);
+				s_brush->SetColor(D2D1::ColorF(0x3080F0, 0.75f));
+				const float margin = 18.0f;
+				rtv->FillRectangle(D2D1::RectF(sx0 - margin, sy0 - margin,
+					sx1 + margin, sy0 + g_screenFontHeights[FONT_LARGE_IDX] + margin), s_brush);
+			}
+#endif
 		}
 	}
 

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -12671,7 +12671,7 @@ uint32_t EnhanceTextColor(uint32_t col)
 	return col;
 }
 
-#define DEBUG_DC_BOX 1
+#define DEBUG_DC_BOX 0
 #if DEBUG_DC_BOX == 1
 Box g_DCDebugBox = { 0 };
 #endif
@@ -12785,6 +12785,11 @@ void PrimarySurface::ExtractDCText()
 		&g_EnhancedHUDData.sTime
 	};
 	int rows[MAX_IDX] = { -1, -1, -1,   -1, -1, -1,   -1,   -1, -1, -1,  -1, -1, -1,  -1 };
+	constexpr int MAX_TGT_BOXES = 7;
+	Box* tgtBoxes[MAX_TGT_BOXES] = { &g_tgtNameBox, &g_tgtShdBox, &g_tgtHullBox,
+		&g_tgtSysBox, &g_tgtDistBox, &g_tgtSubCmpBox,
+		&g_tgtCargoBox
+	};
 
 	// Detect when the in-game screen resolution has changed so that we can recompute the
 	// DC boxes.
@@ -12879,6 +12884,11 @@ void PrimarySurface::ExtractDCText()
 	g_EnhancedHUDData.shdFwdNumChars = 0;
 	g_EnhancedHUDData.shdBckNumChars = 0;
 	g_EnhancedHUDData.shipNameNumChars = 0;
+	// The following DC components can shrink:
+	// ... eh, the text looks quite wide and distorted when the string is short, like "hull" or "junk"
+	//g_tgtNameBox.Invalidate();
+	//g_tgtCargoBox.Invalidate();
+	//g_tgtSubCmpBox.Invalidate();
 	for (const auto& xwaText : g_xwa_text)
 	{
 		int fontIndex = 0;
@@ -12909,6 +12919,35 @@ void PrimarySurface::ExtractDCText()
 			if (IsOverlapping(box.x0, box.y0, box.x1, box.y1,
 				x0, y0, x1, y1))
 			{
+				// Update the boxes for the target areas (shields, hull, sys, etc)
+				if (dcCurRegion < MAX_TGT_BOXES)
+				{
+					Box* tgtBox = tgtBoxes[dcCurRegion];
+					tgtBox->x0 = min(tgtBox->x0, x0);
+					tgtBox->y0 = min(tgtBox->y0, y0);
+					tgtBox->x1 = max(tgtBox->x1, x1);
+					tgtBox->y1 = max(tgtBox->y1, y1);
+
+					DCElemSrcBox* box = &(g_DCElemSrcBoxes.src_boxes[dcSrcRegions[dcCurRegion]]);
+					InGameToScreenCoords(tgtBox->x0, tgtBox->y0, &(box->coords.x0), &(box->coords.y0));
+					InGameToScreenCoords(tgtBox->x1, tgtBox->y1, &(box->coords.x1), &(box->coords.y1));
+
+					// Normalize to uv coords:
+					box->coords.x0 *= g_fCurScreenWidthRcp;
+					box->coords.y0 *= g_fCurScreenHeightRcp;
+					box->coords.x1 *= g_fCurScreenWidthRcp;
+					box->coords.y1 *= g_fCurScreenHeightRcp;
+					box->bComputed = true;
+
+#if DEBUG_DC_BOX == 1
+					if (dcSrcRegions[dcCurRegion] == TARGETED_OBJ_SUBCMP_SRC_IDX)
+					{
+						//InGameToScreenCoords(tgtBox->x0, tgtBox->y0, &g_DCDebugBox.x0, &g_DCDebugBox.y0);
+						//InGameToScreenCoords(tgtBox->x1, tgtBox->y1, &g_DCDebugBox.x1, &g_DCDebugBox.y1);
+					}
+#endif
+				}
+
 				// The name field sometimes has two colors on the first row. We want to capture the second color:
 				if (dcCurRegion == TGT_NAME_IDX)
 				{

--- a/impl11/ddraw/VRConfig.cpp
+++ b/impl11/ddraw/VRConfig.cpp
@@ -1594,10 +1594,14 @@ bool LoadDCParams() {
 				g_bEnableDCDebug = (bool)fValue;
 			}
 			else if (_stricmp(param, "display_dc_index") == 0) {
+				g_DCDebugLabel = svalue;
 				g_iDCDebugSrcIndex = DCSrcElemNameToIndex(svalue);
 				if (g_iDCDebugSrcIndex >= MAX_DC_SRC_ELEMENTS)
 					g_iDCDebugSrcIndex = -1;
 				log_debug("[DBG] [DC] Debug src index: %d", g_iDCDebugSrcIndex);
+			}
+			else if (_stricmp(param, "display_dc_labels") == 0) {
+				g_bDCDebugDisplayLabels = (bool)fValue;
 			}
 		}
 	}

--- a/impl11/ddraw/VRConfig.cpp
+++ b/impl11/ddraw/VRConfig.cpp
@@ -1590,6 +1590,15 @@ bool LoadDCParams() {
 			else if (_stricmp(param, "reset_cockpit_damage_in_hangar") == 0) {
 				g_bResetCockpitDamageInHangar = (bool)fValue;
 			}
+			else if (_stricmp(param, "enable_developer_mode") == 0) {
+				g_bEnableDCDebug = (bool)fValue;
+			}
+			else if (_stricmp(param, "display_dc_index") == 0) {
+				g_iDCDebugSrcIndex = DCSrcElemNameToIndex(svalue);
+				if (g_iDCDebugSrcIndex >= MAX_DC_SRC_ELEMENTS)
+					g_iDCDebugSrcIndex = -1;
+				log_debug("[DBG] [DC] Debug src index: %d", g_iDCDebugSrcIndex);
+			}
 		}
 	}
 	fclose(file);

--- a/impl11/ddraw/dllmain.cpp
+++ b/impl11/ddraw/dllmain.cpp
@@ -313,10 +313,24 @@ LRESULT CALLBACK MyWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 		if (AltKey && CtrlKey && ShiftKey) {
 			switch (wParam) {
 			case 0xbb:
-				IncreaseZoomOutScale(0.1f);
+				if (g_bDCDebugDisplayLabels)
+				{
+					g_iDCDebugSrcIndex = (g_iDCDebugSrcIndex + 1) % MAX_DC_SRC_ELEMENTS;
+					g_DCDebugLabel = g_DCElemSrcNames[g_iDCDebugSrcIndex];
+				}
+				else
+					IncreaseZoomOutScale(0.1f);
 				return 0;
 			case 0xbd:
-				IncreaseZoomOutScale(-0.1f);
+				if (g_bDCDebugDisplayLabels)
+				{
+					g_iDCDebugSrcIndex--;
+					if (g_iDCDebugSrcIndex < 0)
+						g_iDCDebugSrcIndex = MAX_DC_SRC_ELEMENTS - 1;
+					g_DCDebugLabel = g_DCElemSrcNames[g_iDCDebugSrcIndex];
+				}
+				else
+					IncreaseZoomOutScale(-0.1f);
 				return 0;
 
 			case VK_RIGHT:

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -356,6 +356,7 @@ struct EnhancedHUDData
 	uint32_t nameColor, statsColor, subCmpColor;
 	int   tgtShds, tgtHull, tgtSys;
 	float tgtDist;
+	int   primMsls[2];
 	uint32_t shieldsCol = 0xFF2080FF;
 	uint32_t overShdCol = 0xFF7DF9FF; // Electric blue
 	uint32_t sysCol     = 0xFFCCC0FF; // Periwinkle!
@@ -375,7 +376,7 @@ struct EnhancedHUDData
 	Box    subCmpBox;
 	Box    barsBox;
 
-	std::string sShieldsFwd, sShieldsBck, sShipName;
+	std::string sShieldsFwd, sShieldsBck, sShipName, sMissiles;
 	//std::string sThrottle, sSpeed;
 	DCChar shdFwdChars[MAX_DC_SHIELDS_CHARS];
 	DCChar shdBckChars[MAX_DC_SHIELDS_CHARS];

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -376,7 +376,7 @@ struct EnhancedHUDData
 	Box    subCmpBox;
 	Box    barsBox;
 
-	std::string sShieldsFwd, sShieldsBck, sShipName, sMissiles, sSpeed;
+	std::string sShieldsFwd, sShieldsBck, sShipName, sMissiles, sSpeed, sChaff;
 	//std::string sThrottle, sSpeed;
 	DCChar shdFwdChars[MAX_DC_SHIELDS_CHARS];
 	DCChar shdBckChars[MAX_DC_SHIELDS_CHARS];

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -351,7 +351,7 @@ struct EnhancedHUDData
 	int  MinBracketSize;
 	int  MaxBracketSize;
 	int  fontIdx;
-	std::string sName, sTgtShds, sTgtHull, sTgtSys;
+	std::string sName, sTime, sTgtShds, sTgtHull, sTgtSys;
 	std::string sTgtDist, sCargo, sSubCmp, sTmp;
 	uint32_t nameColor, statsColor, subCmpColor;
 	int   tgtShds, tgtHull, tgtSys;

--- a/impl11/ddraw/globals.h
+++ b/impl11/ddraw/globals.h
@@ -376,7 +376,7 @@ struct EnhancedHUDData
 	Box    subCmpBox;
 	Box    barsBox;
 
-	std::string sShieldsFwd, sShieldsBck, sShipName, sMissiles;
+	std::string sShieldsFwd, sShieldsBck, sShipName, sMissiles, sSpeed;
 	//std::string sThrottle, sSpeed;
 	DCChar shdFwdChars[MAX_DC_SHIELDS_CHARS];
 	DCChar shdBckChars[MAX_DC_SHIELDS_CHARS];


### PR DESCRIPTION
New AUTOSIZE DC source boxes have been added to fix DC elements with text. Using these elements, the text should now appear properly aligned for a wide variety of font sizes and screen resolutions.