### PR TITLE
Display the Skirmish OPT in VR.

### DIFF
--- a/impl11/ddraw/DeviceResources.h
+++ b/impl11/ddraw/DeviceResources.h
@@ -423,8 +423,10 @@ public:
 
 	ComPtr<ID3D11Texture2D> _depthStencilL;
 	ComPtr<ID3D11Texture2D> _depthStencilR;
+	ComPtr<ID3D11Texture2D> _depthStencilHd = nullptr;
 	ComPtr<ID3D11DepthStencilView> _depthStencilViewL;
 	ComPtr<ID3D11DepthStencilView> _depthStencilViewR;
+	ComPtr<ID3D11DepthStencilView> _depthStencilViewHd = nullptr;
 	ComPtr<ID3D11DepthStencilView> _shadowMapDSV;
 	ComPtr<ID3D11DepthStencilView> _csmMapDSV;
 	//ComPtr<ID3D11DepthStencilView> _shadowMapDSV_R; // Do I really need a shadow map for the right eye? I don't think so...

--- a/impl11/ddraw/Effects.cpp
+++ b/impl11/ddraw/Effects.cpp
@@ -206,6 +206,7 @@ bool g_bRendering3D = false; // Set to true when the system is about to render i
 bool g_bPrevPlayerInHangar = false;
 bool g_bInTechRoom = false; // Set to true in PrimarySurface Present 2D (Flip)
 bool g_bInBriefingRoom = false;
+bool g_bInSkirmishShipScreen = false;
 
 D3DTLVERTEX g_SpeedParticles2D[MAX_SPEED_PARTICLES * 12];
 
@@ -1267,4 +1268,11 @@ bool InBriefingRoom()
 	const int XwaMissionBriefingGameStateUpdate = 0x00564E90;
 	g_bInBriefingRoom = (updateCallback == XwaMissionBriefingGameStateUpdate);
 	return g_bInBriefingRoom;
+}
+
+// Yup, Jeremy again :)
+bool InSkirmishShipScreen()
+{
+	g_bInSkirmishShipScreen = (*(int*)0x007838A0 != 0);
+	return g_bInSkirmishShipScreen;
 }

--- a/impl11/ddraw/Effects.h
+++ b/impl11/ddraw/Effects.h
@@ -298,3 +298,4 @@ CraftInstance* GetCraftInstanceForCurrentTargetSafe();
 // Also updates g_bInTechGlobe when called.
 bool InTechGlobe();
 bool InBriefingRoom();
+bool InSkirmishShipScreen();

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -6288,7 +6288,8 @@ void EffectsRenderer::MainSceneHook(const SceneCompData* scene)
 	// behind other geometry. We need to store those draw calls and render them later, near the end
 	// of the frame.
 	// TODO: Instead of storing draw calls, use a deferred context to record the calls and then execute it later
-	if (_bIsTransparentCall) {
+	if (_bIsTransparentCall && !g_bInSkirmishShipScreen)
+	{
 		DrawCommand command;
 		// Save the current draw command and skip. We'll render the transparency later
 

--- a/impl11/ddraw/Materials.cpp
+++ b/impl11/ddraw/Materials.cpp
@@ -1877,8 +1877,7 @@ void ReadMaterialLine(char* buf, Material* curMaterial, char *OPTname) {
 /// <returns>Returns true if the file could be loaded successfully</returns>
 bool LoadIndividualMATParams(char *OPTname, char *sFileName, bool verbose) {
 	// Do not load materials for OPTs while the Skirmish selection screen is displayed:
-	const bool isInSkirmishShipScreen = (*(int*)0x007838A0 != 0);
-	if (isInSkirmishShipScreen)
+	if (InSkirmishShipScreen())
 		return false;
 	// I may have to use std::array<char, DIM> and std::vector<std::array<char, Dim>> instead
 	// of TexnameType

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -1370,7 +1370,7 @@ void PrimarySurface::resizeForSteamVR(int iteration, bool is_2D) {
 	// bugs when displaying stuff. On the other hand, I don't want to touch this since it
 	// looks like it works (?) anyway...
 	const bool bIsInConcourseHD = resources->IsInConcourseHd();
-	const bool bInHdTechRoom = bIsInConcourseHD && g_bInTechRoom;
+	const bool bInHdTechRoom = bIsInConcourseHD && (g_bInTechRoom || InSkirmishShipScreen());
 
 	// Set the vertex buffer
 	UINT stride = sizeof(MainVertex);
@@ -10643,7 +10643,6 @@ HRESULT PrimarySurface::Flip(
 						//context->ClearRenderTargetView(resources->_renderTargetViewSteamVRResize, bgColor);
 					}
 				}
-
 			}
 			else
 			{

--- a/impl11/ddraw/SteamVRRenderer.h
+++ b/impl11/ddraw/SteamVRRenderer.h
@@ -7,6 +7,7 @@ public:
 	SteamVRRenderer();
 	virtual void SceneBegin(DeviceResources* deviceResources);
 	virtual void SceneEnd();
+	void RenderSkirmishOPT();
 	virtual void RenderScene(bool bBindTranspLyr1);
 	virtual void CreateShaders();
 

--- a/impl11/ddraw/XwaD3dRendererHook.cpp
+++ b/impl11/ddraw/XwaD3dRendererHook.cpp
@@ -304,6 +304,7 @@ void D3dRenderer::SceneBegin(DeviceResources* deviceResources)
 	// Update g_bInTechGlobe
 	InTechGlobe();
 	InBriefingRoom();
+	InSkirmishShipScreen();
 
 #if LOGGER_DUMP
 	DumpFrame();

--- a/impl11/ddraw/commonVR.h
+++ b/impl11/ddraw/commonVR.h
@@ -29,6 +29,7 @@ extern float g_fIPD;
 extern float g_fHalfIPD;
 extern bool g_bInTechRoom; // Set to true in PrimarySurface Present 2D (Flip)
 extern bool g_bInBriefingRoom;
+extern bool g_bInSkirmishShipScreen;
 
 extern float g_fPitchMultiplier, g_fYawMultiplier, g_fRollMultiplier;
 extern float g_fYawOffset, g_fPitchOffset;


### PR DESCRIPTION
Use RenderSkirmishOPT() to render the ship in the skirmish selection screen. We need to add a new path to render just this case because we use array textures in VR mode and _offscreenBufferHd is not an array texture. Consequently, we also need to add _depthStencilHd and _depthStencilViewHd (non-array depth stencil) to properly render the depth of the Skirmish OPT.