### PR TITLE
Reimplementation of 2D HUD displacement in VR

### DIFF
--- a/impl11/ddraw/Effects.cpp
+++ b/impl11/ddraw/Effects.cpp
@@ -213,6 +213,8 @@ D3DTLVERTEX g_SpeedParticles2D[MAX_SPEED_PARTICLES * 12];
 Vector3 g_CockpitPOVOffset = { 0, 0, 0 };
 Vector3 g_GunnerTurretPOVOffset = { 0, 0, 0 };
 Vector3 g_HologramDisp = { 0, 0, 0 };
+Vector3 g_HUDDisp = { 0, 0, 0 }; // Independent 2D HUD displacement (OPT coords)
+bool g_bApply2DHudDisp = true; // Toggle to enable applying the 2D HUD displacement during compositing
 
 // **************************
 // DATReader global vars and function pointers
@@ -965,6 +967,120 @@ bool SaveHoloOffsetToIniFile()
 	remove(sFileName);
 	rename(sTempFileName, sFileName);
 	return true;
+}
+
+/*
+ * Saves the independent 2D HUD Offset to the current .ini file.
+ * We'll store it in the same section as the hologram offsets under keys HUDOffsetX/Y/Z
+ */
+bool SaveHUDOffsetToIniFile()
+{
+    // Reuse the same file/section handling as SaveHoloOffsetToIniFile but write HUDOffset keys
+    char sFileName[256], *sTempFileName = "./TempIniFile.txt";
+    char sCraftName[128];
+    FILE* in_file, *out_file;
+    int error = 0, line = 0, len = 0;
+    char buf[256];
+    enum FSM { INIT_ST, IN_TAG_ST } fsm = INIT_ST;
+
+    const bool bGunnerTurret = (g_iPresentCounter > PLAYERDATATABLE_MIN_SAFE_FRAME) ?
+        PlayerDataTable[*g_playerIndex].gunnerTurretActive : false;
+    const char* sectionName = bGunnerTurret ? "GunnerTurretHoloOffsets" : "CockpitHoloOffsets";
+
+    if (strlen(g_sCurrentCockpit) <= 0) {
+        log_debug("[DBG] [HUD] Cockpit name hasn't been captured, will not write HUD Offset");
+        return false;
+    }
+
+    strncpy_s(sCraftName, 128, g_sCurrentCockpit, 128);
+    len = strlen(sCraftName);
+    sCraftName[len - 7] = 0;
+
+    snprintf(sFileName, 256, ".\\FlightModels\\%s.ini", sCraftName);
+    // Open sFileName for reading
+    try { error = fopen_s(&in_file, sFileName, "rt"); } catch (...) { log_debug("[DBG] Could not read [%s]", sFileName); }
+    if (error != 0) return false;
+    try { error = fopen_s(&out_file, sTempFileName, "wt"); } catch (...) { log_debug("[DBG] Could not create temporary file: [%s]", sTempFileName); }
+    if (error != 0) { fclose(in_file); return false; }
+
+    bool bWritten = false;
+    bool bPrevLineBlank = false;
+    int prevLineLen = 0;
+    while (fgets(buf, 256, in_file) != NULL) {
+        line++;
+        if (buf[0] == ';') { fprintf(out_file, buf); continue; }
+        if (buf[0] == '[') {
+            if (strstr(buf, sectionName) != NULL) {
+                fsm = IN_TAG_ST;
+            }
+            else {
+                if (fsm == IN_TAG_ST) {
+                    fsm = INIT_ST;
+                    if (!bPrevLineBlank) fprintf(out_file, "\n");
+                    fprintf(out_file, "[%s]\n", sectionName);
+                    // write HUD offset keys
+                    fprintf(out_file, "HUDOffsetX = %0.3f\n", g_HUDDisp.x);
+                    fprintf(out_file, "HUDOffsetY = %0.3f\n", g_HUDDisp.y);
+                    fprintf(out_file, "HUDOffsetZ = %0.3f\n", g_HUDDisp.z);
+                    fprintf(out_file, "\n");
+                    bWritten = true;
+                }
+            }
+        }
+        if (fsm != IN_TAG_ST) { prevLineLen = strlen(buf); bPrevLineBlank = (prevLineLen == 1) && buf[prevLineLen - 1] == '\n'; fprintf(out_file, buf); }
+    }
+    if (!bWritten) {
+        if (!bPrevLineBlank) fprintf(out_file, "\n");
+        fprintf(out_file, "[%s]\n", sectionName);
+        fprintf(out_file, "HUDOffsetX = %0.3f\n", g_HUDDisp.x);
+        fprintf(out_file, "HUDOffsetY = %0.3f\n", g_HUDDisp.y);
+        fprintf(out_file, "HUDOffsetZ = %0.3f\n", g_HUDDisp.z);
+        bWritten = true;
+    }
+
+    fclose(out_file); fclose(in_file);
+    remove(sFileName); rename(sTempFileName, sFileName);
+    return true;
+}
+
+/*
+ * Loads the independent 2D HUD Offset from the current .ini file.
+ */
+bool LoadHUDOffsetFromIniFile()
+{
+    char sFileName[256], sCraftName[128];
+    char buf[256], param[128], svalue[128];
+    FILE* in_file;
+    int error = 0, line = 0, len = 0;
+    float fValue;
+    enum FSM { OUT_OF_TAG_ST, IN_CP_TAG_ST, IN_GT_TAG_ST } fsm = OUT_OF_TAG_ST;
+
+    g_HUDDisp = { 0, 0, 0 };
+    if (strlen(g_sCurrentCockpit) <= 0) return false;
+    strncpy_s(sCraftName, 128, g_sCurrentCockpit, 128);
+    len = strlen(sCraftName);
+    sCraftName[len - 7] = 0;
+    snprintf(sFileName, 256, ".\\FlightModels\\%s.ini", sCraftName);
+    try { error = fopen_s(&in_file, sFileName, "rt"); } catch (...) { return false; }
+    if (error != 0) return false;
+    while (fgets(buf, 256, in_file) != NULL) {
+        line++; if (buf[0] == ';' || buf[0] == '#') continue; if (strlen(buf) == 0) continue;
+        if (buf[0] == '[') {
+            if (strstr(buf, "CockpitHoloOffsets") != NULL) fsm = IN_CP_TAG_ST;
+            else if (strstr(buf, "GunnerTurretHoloOffsets") != NULL) fsm = IN_GT_TAG_ST;
+            else fsm = OUT_OF_TAG_ST;
+        }
+        if (fsm == IN_CP_TAG_ST || fsm == IN_GT_TAG_ST) {
+            if (sscanf_s(buf, "%s = %s", param, 128, svalue, 128) > 0) {
+                fValue = (float)atof(svalue);
+                if (_stricmp(param, "HUDOffsetX") == 0) g_HUDDisp.x = fValue;
+                if (_stricmp(param, "HUDOffsetY") == 0) g_HUDDisp.y = fValue;
+                if (_stricmp(param, "HUDOffsetZ") == 0) g_HUDDisp.z = fValue;
+            }
+        }
+    }
+    fclose(in_file);
+    return true;
 }
 
 /*

--- a/impl11/ddraw/Effects.h
+++ b/impl11/ddraw/Effects.h
@@ -126,6 +126,9 @@ extern bool g_bMetricParamsNeedReapply;
 extern Vector3 g_CockpitPOVOffset;
 extern Vector3 g_GunnerTurretPOVOffset;
 extern Vector3 g_HologramDisp;
+// Independent displacement for the classic 2D HUD (in OPT coords)
+extern Vector3 g_HUDDisp;
+extern bool g_bApply2DHudDisp;
 
 bool isInVector(uint32_t crc, std::vector<uint32_t>& vector);
 bool isInVector(const char* name, std::vector<char*>& vector);

--- a/impl11/ddraw/EffectsCommon.h
+++ b/impl11/ddraw/EffectsCommon.h
@@ -579,6 +579,9 @@ bool SavePOVOffsetToIniFile();
 bool LoadPOVOffsetFromIniFile();
 bool SaveHoloOffsetToIniFile();
 bool LoadHoloOffsetFromIniFile();
+// Independent 2D HUD offset persistence
+bool SaveHUDOffsetToIniFile();
+bool LoadHUDOffsetFromIniFile();
 void EulerAnglesToRUF(
 	float angX, float angY, float angZ,
 	Vector4& R, Vector4& U, Vector4& F);

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -9577,6 +9577,15 @@ void ProcessKeyboard()
 	bool LtKey    = (GetAsyncKeyState(VK_LEFT)    & 0x8000) == 0x8000;
 	bool RtKey    = (GetAsyncKeyState(VK_RIGHT)   & 0x8000) == 0x8000;
 
+	// Numpad keys for 2D HUD displacement
+    bool Np4Key   = (GetAsyncKeyState(VK_NUMPAD4) & 0x8000) == 0x8000;
+    bool Np6Key   = (GetAsyncKeyState(VK_NUMPAD6) & 0x8000) == 0x8000;
+    bool Np8Key   = (GetAsyncKeyState(VK_NUMPAD8) & 0x8000) == 0x8000;
+    bool Np2Key   = (GetAsyncKeyState(VK_NUMPAD2) & 0x8000) == 0x8000;
+    bool Np9Key   = (GetAsyncKeyState(VK_NUMPAD9) & 0x8000) == 0x8000;
+    bool Np3Key   = (GetAsyncKeyState(VK_NUMPAD3) & 0x8000) == 0x8000;
+	bool Np5Key   = (GetAsyncKeyState(VK_NUMPAD5) & 0x8000) == 0x8000;
+
 	static bool prevHKey  = false;
 	static bool prevRKey  = false;
 	static bool prevUpKey = false;
@@ -9586,7 +9595,7 @@ void ProcessKeyboard()
 
 	// Alt Key
 	if (AltKey && !ShiftKey && !CtrlKey)
-	{
+{
 		/*if (HKey && !prevHKey)
 		{
 			g_bSkipHUD = !g_bSkipHUD;
@@ -9628,7 +9637,7 @@ void ProcessKeyboard()
 
 	// Alt + Shift Key
 	if (AltKey && ShiftKey && !CtrlKey)
-	{
+{
 		if (LtKey && !prevLtKey)
 		{
 			g_HologramDisp.y += HOLO_DISP_Y;
@@ -9641,6 +9650,71 @@ void ProcessKeyboard()
 			SaveHoloOffsetToIniFile();
 		}
 	}
+
+	// Ctrl + Numpad4/6: move independent 2D HUD displacement left/right
+	static bool prevNp4Key = false;
+	static bool prevNp6Key = false;
+	static bool prevNp8Key = false;
+	static bool prevNp2Key = false;
+	static bool prevNp9Key = false;
+	static bool prevNp3Key = false;
+	static bool prevNp5Key = false;
+	if (CtrlKey)
+	{
+		if (Np4Key && !prevNp4Key)
+		{
+			// Adjust in OPT coords: move left
+			g_HUDDisp.x -= HOLO_DISP_X; // reuse step size constant
+			// Persist to INI alongside hologram offsets (create/save function later)
+			SaveHUDOffsetToIniFile();
+		}
+		if (Np6Key && !prevNp6Key)
+		{
+			// Adjust in OPT coords: move right
+			g_HUDDisp.x += HOLO_DISP_X; // reuse step size constant
+			SaveHUDOffsetToIniFile();
+		}
+
+		// Depth controls: Ctrl + Numpad8 (up), Ctrl + Numpad2 (down)
+		if (Np8Key && !prevNp8Key)
+		{
+			g_HUDDisp.z += HOLO_DISP_Z;
+			SaveHUDOffsetToIniFile();
+		}
+		if (Np2Key && !prevNp2Key)
+		{
+			g_HUDDisp.z -= HOLO_DISP_Z;
+			SaveHUDOffsetToIniFile();
+		}
+
+		// Vertical controls: Ctrl + Numpad9 (push further from the camera), Ctrl + Numpad3 (pull closer to the camera)
+		if (Np9Key && !prevNp9Key)
+		{
+			g_HUDDisp.y -= HOLO_DISP_Y;
+			SaveHUDOffsetToIniFile();
+		}
+		if (Np3Key && !prevNp3Key)
+		{
+			g_HUDDisp.y += HOLO_DISP_Y;
+			SaveHUDOffsetToIniFile();
+		}
+		// Reset to default: Ctrl + Numpad5
+		if (Np5Key && !prevNp5Key)
+		{
+			g_HUDDisp.x = 0.0f;
+			g_HUDDisp.y = 0.0f;
+			g_HUDDisp.z = 0.0f;			
+			SaveHUDOffsetToIniFile();
+		}
+	}
+
+	prevNp4Key = Np4Key;
+	prevNp6Key = Np6Key;
+	prevNp8Key = Np8Key;
+	prevNp2Key = Np2Key;
+	prevNp9Key = Np9Key;
+	prevNp3Key = Np3Key;
+	prevNp5Key = Np5Key;
 
 	prevHKey  = HKey;
 	prevRKey  = RKey;

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -2145,28 +2145,6 @@ void PrimarySurface::DrawHUDVertices() {
 	// Apply view transform to the HUD to fix it in space. It needs the inverse of the fullViewMat that contains the headtracking pose.
 	g_VSMatrixCB.fullViewMat.invert();
 
-	// Applying g_HologramDisp to the HUD causes some issues in some cockpits.
-	// The problem here is that an offset that looks good in pancake mode sometimes
-	// makes the holograms appear too close in VR. Since this displacement is also
-	// applied to the HUD, this may cause the HUD to be rendered _behind_ the user in
-	// VR (this is what happens in the A-Wing and B-Wing).
-	// One solution would be to have an independent displacement just for the HUD;
-	// but we'd need yet another set of hotkeys for that, and we don't have that many
-	// left. Maybe a better solution would be to use the VR controllers to move the HUD,
-	// say, while parked in the hangar; but that would be a new feature.
-	// Note that if this code is re-enabled, then curMat must also be re-enabled below,
-	// in the "out:" case to restore the original g_VSMatrixCB.fullViewMat transform.
-#if 0
-	Matrix4 hudTransform;
-	// g_HologramDisp is in OPT coords, but here we need SteamVR/meters, so we swap
-	// Y and Z and reduce the scale a bit:
-	hudTransform.translate(0.1f * g_HologramDisp.x,
-	                       0.1f * g_HologramDisp.z,
-	                       0.1f * g_HologramDisp.y);
-	Matrix4 curMat = g_VSMatrixCB.fullViewMat;
-	g_VSMatrixCB.fullViewMat = g_VSMatrixCB.fullViewMat * hudTransform;
-#endif
-
     // Apply independent 2D HUD displacement if present. This uses g_HUDDisp (OPT coords)
     // and converts it to the HUD composite space. Guard behind a toggle in case of issues.
     extern Vector3 g_HUDDisp; // declared in Effects.h

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -2167,6 +2167,25 @@ void PrimarySurface::DrawHUDVertices() {
 	g_VSMatrixCB.fullViewMat = g_VSMatrixCB.fullViewMat * hudTransform;
 #endif
 
+    // Apply independent 2D HUD displacement if present. This uses g_HUDDisp (OPT coords)
+    // and converts it to the HUD composite space. Guard behind a toggle in case of issues.
+    extern Vector3 g_HUDDisp; // declared in Effects.h
+    extern bool g_bApply2DHudDisp;
+    Matrix4 savedFullViewMat; // saved only if we modify it
+    bool bHudDispApplied = false;
+    if (g_bApply2DHudDisp)
+    {
+        Matrix4 hudTransform2D;
+        // Convert OPT coords to HUD composite space: swap Y/Z and scale down (same heuristic as hologram)
+        hudTransform2D.translate(0.1f * g_HUDDisp.x,
+                                 0.1f * g_HUDDisp.z,
+                                 0.1f * g_HUDDisp.y);
+        // Save and apply
+        savedFullViewMat = g_VSMatrixCB.fullViewMat;
+        g_VSMatrixCB.fullViewMat = g_VSMatrixCB.fullViewMat * hudTransform2D;
+        bHudDispApplied = true;
+    }
+
 	// Since the HUD is all rendered on a flat surface, we lose the vrparams that make the 3D object
 	// and text float
 	g_VSCBuffer.z_override     = g_fFloatingGUIDepth;
@@ -2291,10 +2310,10 @@ void PrimarySurface::DrawHUDVertices() {
 		DirectX::SaveDDSTextureToFile(context, resources->_offscreenBuffer, L"C:\\Temp\\_mapVR.dds");
 	}
 
-	if (!g_bEnableVR || g_bUseSteamVR) // Shortcut for the SteamVR and non-VR path
-	{
-		goto out;
-	}
+    if (!g_bEnableVR || g_bUseSteamVR) // Shortcut for the SteamVR and non-VR path
+    {
+        goto out;
+    }
 
 	// Render the right image in SBS mode
 	context->OMSetRenderTargets(1, resources->_renderTargetView.GetAddressOf(), NULL);
@@ -2315,10 +2334,9 @@ void PrimarySurface::DrawHUDVertices() {
 		context->Draw(6, 0);
 
 out:
-#if 0
-	// Restore the old view matrix
-	g_VSMatrixCB.fullViewMat = curMat;
-#endif
+    // Restore the old view matrix if we applied the HUD displacement earlier so other draws are unaffected
+    if (bHudDispApplied)
+        g_VSMatrixCB.fullViewMat = savedFullViewMat;
 	this->_deviceResources->EndAnnotatedEvent();
 }
 

--- a/impl11/ddraw/XwaTextureData.cpp
+++ b/impl11/ddraw/XwaTextureData.cpp
@@ -599,10 +599,14 @@ void XwaTextureData::TagTexture()
 					{
 						LoadPOVOffsetFromIniFile();
 					}
-					// Load the Holo Offset from the current INI file
-					{
-						LoadHoloOffsetFromIniFile();
-					}
+			// Load the Holo Offset from the current INI file
+			{
+				LoadHoloOffsetFromIniFile();
+			}
+			// Load the independent 2D HUD offset
+			{
+				LoadHUDOffsetFromIniFile();
+			}
 					// Load the HUD color from the current INI file
 					{
 						LoadHUDColorFromIniFile();


### PR DESCRIPTION
keyboard shortcuts to be added to the Readme:

Ctrl + Numpad4 — move HUD left
Ctrl + Numpad6 — move HUD right
Ctrl + Numpad8 — move HUD up
Ctrl + Numpad2 — move HUD down
Ctrl + Numpad9 — push HUD further from camera
Ctrl + Numpad3 — pull HUD closer to camera
Ctrl + Numpad5 — reset HUD offsets