### PR TITLE
Portability fixes for non-MSVC toolchains (no functional change for MSVC builds)

### DIFF
--- a/impl11/ddraw/DeviceResources.h
+++ b/impl11/ddraw/DeviceResources.h
@@ -92,7 +92,7 @@ public:
 		return this->msg[0] == 0;
 	}
 
-	inline void SetMsg(char *msg, time_t seconds, short y, short font_size_idx, uint32_t color) {
+	inline void SetMsg(const char *msg, time_t seconds, short y, short font_size_idx, uint32_t color) {
 		strcpy_s(this->msg, 128, msg);
 		this->t_exp = time(NULL) + seconds;
 		this->y = y;
@@ -111,7 +111,7 @@ const int MAX_TIMED_MESSAGES = 3;
 /*
   Only rows 0..2 are available
  */
-void DisplayTimedMessage(uint32_t seconds, int row, char *msg);
+void DisplayTimedMessage(uint32_t seconds, int row, const char *msg);
 
 class DeviceResources
 {

--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -509,10 +509,10 @@ float RealVertFOVToRawFocalLength(float real_FOV);
 
 void GetCraftViewMatrix(Matrix4 *result);
 
-inline void backProjectMetric(float sx, float sy, float rhw, Vector3 *P);
+void backProjectMetric(float sx, float sy, float rhw, Vector3 *P);
 inline void backProjectMetric(UINT index, Vector3 *P);
 Vector3 projectMetric(Vector3 pos3D, Matrix4 viewMatrix, Matrix4 projEyeMatrix, bool bForceNonVR);
-inline Vector3 projectToInGameOrPostProcCoordsMetric(Vector3 pos3D, Matrix4 viewMatrix, Matrix4 projEyeMatrix, bool bForceNonVR = false);
+Vector3 projectToInGameOrPostProcCoordsMetric(Vector3 pos3D, Matrix4 viewMatrix, Matrix4 projEyeMatrix, bool bForceNonVR = false);
 float3 InverseTransformProjectionScreen(float4 pos);
 
 void ResetObjectIndexMap();
@@ -1341,7 +1341,7 @@ HRESULT Direct3DDevice::QuickSetZWriteEnabled(BOOL Enabled) {
 	return hr;
 }
 
-inline float lerp(float x, float y, float s) {
+float lerp(float x, float y, float s) { // Linux/clang-cl: de-inlined, used cross-TU (MSVC LTCG resolved this)
 	return x + s * (y - x);
 }
 
@@ -1755,7 +1755,7 @@ float ClosestPointOnTriangle(
  *		OPT-scale metric 3D centered on the current camera.
  *	    VR path: same as non-VR but with Y flipped
  */
-inline void backProjectMetric(float sx, float sy, float rhw, Vector3 *P) {
+void backProjectMetric(float sx, float sy, float rhw, Vector3 *P) { // Linux/clang-cl: de-inlined, used cross-TU (MSVC LTCG resolved this)
 	float3 temp;
 	float FOVscaleZ;
 	float sm_FOVscale = g_MetricRecCBuffer.mr_FOVscale;
@@ -1926,7 +1926,7 @@ Vector3 projectMetric(Vector3 pos3D, Matrix4 viewMatrix, Matrix4 projEyeMatrix, 
  *		Regular path: in-game 2D coords (sx, sy)
  *	    VR path: Post-proc coords
  */
-inline Vector3 projectToInGameOrPostProcCoordsMetric(Vector3 pos3D, Matrix4 viewMatrix, Matrix4 projEyeMatrix, bool bForceNonVR)
+Vector3 projectToInGameOrPostProcCoordsMetric(Vector3 pos3D, Matrix4 viewMatrix, Matrix4 projEyeMatrix, bool bForceNonVR)
 {
 	Vector3 P = pos3D;
 	//float w;
@@ -5578,12 +5578,12 @@ HRESULT Direct3DDevice::Execute(
 				}
 				*/
 				if (g_bDumpSSAOBuffers && g_bDumpOBJEnabled && (bIsEngineGlow || bIsMapIcon)) {
-					log_debug("[DBG] Dumping OBJ (bIsEngineGlow|bIsMapIcon): obj_%d, %s", g_iDumpOBJIdx, lastTextureSelected->_name);
+					log_debug("[DBG] Dumping OBJ (bIsEngineGlow|bIsMapIcon): obj_%d, %s", g_iDumpOBJIdx, lastTextureSelected->_name.c_str()); // Linux/clang-cl: std::string through varargs
 					DumpVerticesToOBJ(g_DumpOBJFile, instruction, currentIndexLocation,
 						g_iDumpOBJIdx, lastTextureSelected->_name.c_str(), bIsMapIcon);
 				}
 				if (g_bDumpSSAOBuffers && g_bDumpOBJEnabled && bIsExplosion) {
-					log_debug("[DBG] Dumping OBJ (bIsExplosion): obj_%d, %s", g_iDumpLaserOBJIdx, lastTextureSelected->_name);
+					log_debug("[DBG] Dumping OBJ (bIsExplosion): obj_%d, %s", g_iDumpLaserOBJIdx, lastTextureSelected->_name.c_str()); // Linux/clang-cl: std::string through varargs
 					DumpVerticesToOBJ(g_DumpLaserFile, instruction, currentIndexLocation,
 						g_iDumpLaserOBJIdx, lastTextureSelected->_name.c_str());
 				}

--- a/impl11/ddraw/EffectsCommon.h
+++ b/impl11/ddraw/EffectsCommon.h
@@ -572,7 +572,7 @@ extern float g_fMetricMult;
 extern int g_WindowWidth, g_WindowHeight;
 extern D3D11_VIEWPORT g_nonVRViewport;
 
-void DisplayTimedMessage(uint32_t seconds, int row, char* msg);
+void DisplayTimedMessage(uint32_t seconds, int row, const char* msg);
 void DisplayTimedMessageV(uint32_t seconds, int row, const char* format, ...);
 
 bool SavePOVOffsetToIniFile();

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -142,7 +142,7 @@ constexpr float HOLO_DISP_Z = METERS_TO_OPT * 0.01f;
 
 float lerp(float x, float y, float s);
 
-inline float clamp(float val, float min, float max)
+float clamp(float val, float min, float max) // Linux/clang-cl: de-inlined, used cross-TU (MSVC LTCG resolved this)
 {
 	if (val < min) val = min;
 	if (val > max) val = max;
@@ -199,7 +199,7 @@ void CaptureBackdropTransform()
 	g_bBackdropTransformCaptured = true;
 }
 
-inline int MakeKeyFromGroupIdImageId(int groupId, int imageId)
+int MakeKeyFromGroupIdImageId(int groupId, int imageId) // Linux/clang-cl: de-inlined, used cross-TU (MSVC LTCG resolved this)
 {
 	return (groupId << 16) | (imageId);
 }
@@ -492,7 +492,7 @@ void OBJDump(XwaVector3 *vertices, int count)
 	fprintf(D3DDumpOBJFile, "\n");
 }
 
-inline Matrix4 XwaTransformToMatrix4(const XwaTransform &M)
+Matrix4 XwaTransformToMatrix4(const XwaTransform &M) // Linux/clang-cl: de-inlined, used cross-TU (MSVC LTCG resolved this)
 {
 	return Matrix4(
 		M.Rotation._11, M.Rotation._12, M.Rotation._13, 0.0f,
@@ -5376,7 +5376,7 @@ bool GetCurrentTargetStats(int* shields, int* hull, int* system, std::string &ca
 		(object->objectGenus == Genus_Utility);
 
 	// The default value is -1. When the craft is identified the value is 0. When the craft is inspected the value is >= 1.
-	char* FGName = (inspected >= 0) ?
+	const char* FGName = (inspected >= 0) ?
 		g_XwaTieFlightGroups[object->FGIndex].FlightGroup.Name : "Unknown";
 	name = (char*)s_ExeCraftTable[craftInstance->CraftType].pCraftShortName +
 		std::string(": ") + FGName;
@@ -5505,7 +5505,7 @@ InstanceEvent *EffectsRenderer::ObjectIDToInstanceEvent(int objectId, uint32_t m
 		log_debug("[DBG] [INST] New InstanceEvent added to objectId-matId: %d-%d",
 			objectId, materialId);
 		g_objectIdToInstanceEvent.insert(std::make_pair(Id, InstanceEvent()));
-		auto &new_it = g_objectIdToInstanceEvent.find(Id);
+		auto new_it = g_objectIdToInstanceEvent.find(Id);
 		if (new_it != g_objectIdToInstanceEvent.end())
 			return &new_it->second;
 		else
@@ -5530,7 +5530,7 @@ FixedInstanceData* EffectsRenderer::ObjectIDToFixedInstanceData(int objectId, ui
 		log_debug("[DBG] [UV] New FixedInstance added to objectId-matId: %d-%d",
 			objectId, materialId);
 		g_fixedInstanceDataMap.insert(std::make_pair(Id, FixedInstanceData()));
-		auto& new_it = g_fixedInstanceDataMap.find(Id);
+		auto new_it = g_fixedInstanceDataMap.find(Id);
 		if (new_it != g_fixedInstanceDataMap.end())
 			return &new_it->second;
 		else
@@ -6284,7 +6284,7 @@ void EffectsRenderer::MainSceneHook(const SceneCompData* scene)
 			// Find the LOD for this FaceGroup. We need this so that we can coalesce
 			// all the FGs belonging to the same LOD in one BVH. That improves performance.
 			int faceGroupId = MakeFaceGroupKey(scene);
-			auto& it = g_FGToLODMap.find(faceGroupId);
+			auto it = g_FGToLODMap.find(faceGroupId);
 			int LOD = -1;
 			if (it != g_FGToLODMap.end())
 			{
@@ -6456,7 +6456,7 @@ out:
  If the game is rendering the hyperspace effect, this function will select shaderToyBuf
  when rendering the cockpit. Otherwise it will select the regular offscreenBuffer
  */
-inline ID3D11RenderTargetView *EffectsRenderer::SelectOffscreenBuffer() {
+ID3D11RenderTargetView *EffectsRenderer::SelectOffscreenBuffer() { // Linux/clang-cl: de-inlined, used cross-TU (MSVC LTCG resolved this)
 	auto& resources = this->_deviceResources;
 
 	ID3D11RenderTargetView *regularRTV = resources->_renderTargetView.Get();

--- a/impl11/ddraw/EffectsRenderer.h
+++ b/impl11/ddraw/EffectsRenderer.h
@@ -161,7 +161,7 @@ protected:
 	HRESULT QuickSetZWriteEnabled(BOOL Enabled);
 	void EnableTransparency();
 	void EnableHoloTransparency();
-	inline ID3D11RenderTargetView *SelectOffscreenBuffer();
+	ID3D11RenderTargetView *SelectOffscreenBuffer();
 	void RenderToDC();
 	Matrix4 GetShadowMapLimits(Matrix4 L, float *OBJrange, float *OBJminZ);
 	Matrix4 GetShadowMapLimits(const AABB &aabb, float *OBJrange, float *OBJminZ);

--- a/impl11/ddraw/LBVH.cpp
+++ b/impl11/ddraw/LBVH.cpp
@@ -7329,7 +7329,7 @@ void DirectBVH4BuilderGPU(AABB centroidBox, std::vector<T>& leafItems,
 	const XwaVector3* vertices, const int* indices, BVHNode *QBVHBuffer)
 {
 	DBVH4BuildData<T> data;
-	data.isTopLevelBuild = constexpr (std::is_same_v<T, TLASLeafItem>);
+	data.isTopLevelBuild = std::is_same_v<T, TLASLeafItem>; // Linux/clang-cl: invalid `constexpr (expr)` removed
 	data.leafItems     = leafItems;
 	data.numPrimitives = leafItems.size();
 #ifdef BVH_REPROCESS_SPLITS

--- a/impl11/ddraw/LBVH.h
+++ b/impl11/ddraw/LBVH.h
@@ -230,7 +230,7 @@ public:
 
 	inline void Expand(const std::vector<Vector4> &Limits)
 	{
-		for each (Vector4 v in Limits)
+		for (Vector4 v : Limits) // Linux/clang-cl: MSVC-only `for each` -> range-for (identical semantics)
 			Expand(v);
 	}
 

--- a/impl11/ddraw/Materials.cpp
+++ b/impl11/ddraw/Materials.cpp
@@ -1095,7 +1095,7 @@ bool LoadFrameSequence(char* buf, std::vector<TexSeqElem>& tex_sequence,
 			log_debug("[DBG] Group %d has %d images", GroupId, ImageList.size());
 		}
 		// Iterate over the list of Images and add one TexSeqElem for each one of them
-		for each (short ImageId in ImageList)
+		for (short ImageId : ImageList) // Linux/clang-cl: MSVC `for each` -> range-for
 		{
 			// Store the DAT filename in texname and set the appropriate flag. texname contains
 			// the path and filename.
@@ -1208,7 +1208,7 @@ bool LoadSimpleFrames(char *buf, std::vector<TexSeqElem> &tex_sequence)
 			ImageList = ReadZIPImageListFromGroup(sDATZIPFileName.c_str(), GroupId);
 		log_debug("[DBG] [MAT] Frame-by-Frame data. Group %d has %d images", GroupId, ImageList.size());
 		// Iterate over the list of Images and add one TexSeqElem for each one of them
-		for each (short ImageId in ImageList)
+		for (short ImageId : ImageList) // Linux/clang-cl: MSVC `for each` -> range-for
 		{
 			// Store the DAT filename in texname and set the appropriate flag. texname contains
 			// the path and filename.
@@ -2353,7 +2353,7 @@ void AnimateMaterials() {
 			continue;
 		}
 		uint64_t Id = InstEventIdFromObjectMaterialId(atc->objectId, atc->materialId);
-		auto& it = g_objectIdToInstanceEvent.find(Id);
+		auto it = g_objectIdToInstanceEvent.find(Id);
 		if (it != g_objectIdToInstanceEvent.end()) {
 			if (it->second.EventFired(atc->InstEvent))
 				atc->ResetAnimation();

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -54,7 +54,7 @@ void GetGunnerTurretViewMatrixSpeedEffect(Matrix4 * result, bool applyHeadingInG
 void DisplayBox(char *name, Box box);
 Vector3 project(Vector3 pos3D, Matrix4 viewMatrix, Matrix4 projEyeMatrix /*, float *sx, float *sy */);
 inline void backProject(float sx, float sy, float rhw, Vector3 *P);
-inline void backProjectMetric(float sx, float sy, float rhw, Vector3 *P);
+void backProjectMetric(float sx, float sy, float rhw, Vector3 *P);
 
 // These are the actual functions for (back)-projection currently used as of Feb 2024:
 float4 TransformProjection(float3 input);
@@ -63,7 +63,7 @@ float3 InverseTransformProjectionScreen(float4 input);
 
 Vector3 projectMetric(Vector3 pos3D, Matrix4 viewMatrix, Matrix4 projEyeMatrix, bool bForceNonVR);
 inline Vector3 projectToInGameCoords(Vector3 pos3D, Matrix4 viewMatrix, Matrix4 projEyeMatrix);
-inline Vector3 projectToInGameOrPostProcCoordsMetric(Vector3 pos3D, Matrix4 viewMatrix, Matrix4 projEyeMatrix, bool bForceNonVR = false);
+Vector3 projectToInGameOrPostProcCoordsMetric(Vector3 pos3D, Matrix4 viewMatrix, Matrix4 projEyeMatrix, bool bForceNonVR = false);
 //void ComputeBaryCoords(const Vector3& v0, const Vector3& v1, const Vector3& v2, const Vector3& P,
 //	float& u, float& v);
 bool rayTriangleIntersect(
@@ -75,7 +75,7 @@ float ClosestPointOnTriangle(
 	Vector3& P, float& u, float& v, float margin);
 void ResetXWALightInfo();
 void DumpHyperspaceVertexBuffer(float width, float height);
-inline Matrix4 XwaTransformToMatrix4(const XwaTransform& M);
+Matrix4 XwaTransformToMatrix4(const XwaTransform& M);
 float4 TransformProjection(float3 input);
 float4 TransformProjectionScreen(float3 input);
 void EmulMouseWithVRControllers();
@@ -13232,7 +13232,7 @@ short DisplayCenteredText(char* str, int font_size_index, short y, uint32_t colo
   the timer on whatever is in that slot. The hard-coded values are screen-height
   relative and seem to work fine across different resolutions.
  */
-void DisplayTimedMessage(uint32_t seconds, int row, char* msg) {
+void DisplayTimedMessage(uint32_t seconds, int row, const char* msg) {
 	short y_pos = (short)(g_fCurInGameHeight * (0.189f + 0.05f * row));
 	g_TimedMessages[row].SetMsg(msg, seconds, y_pos, FONT_LARGE_IDX, FONT_BLUE_COLOR);
 }

--- a/impl11/ddraw/ShadowMapping.cpp
+++ b/impl11/ddraw/ShadowMapping.cpp
@@ -26,7 +26,7 @@ int g_iNumSunCentroids = 0;
 
 /*********************************************************/
 
-void DisplayTimedMessage(uint32_t seconds, int row, char* msg);
+void DisplayTimedMessage(uint32_t seconds, int row, const char* msg);
 
 void ToggleCSM()
 {

--- a/impl11/ddraw/XwaD3dRendererHook.cpp
+++ b/impl11/ddraw/XwaD3dRendererHook.cpp
@@ -1988,7 +1988,7 @@ void ParseOptFaceGrouping(int meshKey, OptNode* outerNode)
 					// g_FGToLODMap is used to coalesce vertices that belong on the same LOD when building the BVH (RT)
 					g_FGToLODMap[faceGroupID] = lodID;
 
-					auto& it = g_meshToFGMap.find(meshKey);
+					auto it = g_meshToFGMap.find(meshKey);
 					if (it == g_meshToFGMap.end())
 					{
 						// Initialize this entry
@@ -2081,7 +2081,7 @@ void D3dRendererOptNodeHook(OptHeader* optHeader, int nodeIndex, SceneCompData* 
 				{
 					//int numVertices = subnode->Parameter1;
 					int meshKey = subnode->Parameter2;
-					auto& it = g_MeshTagMap.find(meshKey);
+					auto it = g_MeshTagMap.find(meshKey);
 					if (it == g_MeshTagMap.end())
 					{
 						// DEBUG: Dump the node hierarchy when a hotkey is pressed

--- a/impl11/ddraw/ddraw.cpp
+++ b/impl11/ddraw/ddraw.cpp
@@ -39,53 +39,50 @@ public:
 
 static LibraryWrapper ddraw("ddraw.dll");
 
+// Linux/clang-cl build fix (see ../../../linux-build-fixes.patch): clang forbids
+// non-ASM statements (the guarded local-static init) in naked functions, so the
+// GetProcAddress statics are hoisted to file scope (runs at DLL attach, ordered
+// after `ddraw` above in this TU) - behavior-equivalent to the lazy original.
+static void(*AcquireDDThreadLock_proc)() = (void(*)())GetProcAddress(ddraw._module, "AcquireDDThreadLock");
 extern "C" __declspec(naked) void AcquireDDThreadLock()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "AcquireDDThreadLock");
-
-	__asm jmp ddraw_proc;
+	__asm jmp AcquireDDThreadLock_proc;
 }
 
+static void(*CompleteCreateSysmemSurface_proc)() = (void(*)())GetProcAddress(ddraw._module, "CompleteCreateSysmemSurface");
 extern "C" __declspec(naked) void CompleteCreateSysmemSurface()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "CompleteCreateSysmemSurface");
-
-	__asm jmp ddraw_proc;
+	__asm jmp CompleteCreateSysmemSurface_proc;
 }
 
+static void(*D3DParseUnknownCommand_proc)() = (void(*)())GetProcAddress(ddraw._module, "D3DParseUnknownCommand");
 extern "C" __declspec(naked) void D3DParseUnknownCommand()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "D3DParseUnknownCommand");
-
-	__asm jmp ddraw_proc;
+	__asm jmp D3DParseUnknownCommand_proc;
 }
 
+static void(*DDGetAttachedSurfaceLcl_proc)() = (void(*)())GetProcAddress(ddraw._module, "DDGetAttachedSurfaceLcl");
 extern "C" __declspec(naked) void DDGetAttachedSurfaceLcl()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "DDGetAttachedSurfaceLcl");
-
-	__asm jmp ddraw_proc;
+	__asm jmp DDGetAttachedSurfaceLcl_proc;
 }
 
+static void(*DDInternalLock_proc)() = (void(*)())GetProcAddress(ddraw._module, "DDInternalLock");
 extern "C" __declspec(naked) void DDInternalLock()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "DDInternalLock");
-
-	__asm jmp ddraw_proc;
+	__asm jmp DDInternalLock_proc;
 }
 
+static void(*DDInternalUnlock_proc)() = (void(*)())GetProcAddress(ddraw._module, "DDInternalUnlock");
 extern "C" __declspec(naked) void DDInternalUnlock()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "DDInternalUnlock");
-
-	__asm jmp ddraw_proc;
+	__asm jmp DDInternalUnlock_proc;
 }
 
+static void(*DSoundHelp_proc)() = (void(*)())GetProcAddress(ddraw._module, "DSoundHelp");
 extern "C" __declspec(naked) void DSoundHelp()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "DSoundHelp");
-
-	__asm jmp ddraw_proc;
+	__asm jmp DSoundHelp_proc;
 }
 
 extern "C" HRESULT WINAPI DirectDrawCreate(
@@ -294,44 +291,38 @@ extern "C" HRESULT WINAPI DirectDrawEnumerateW(
 	return ddraw_proc(lpCallback, lpContext);
 }
 
+static void(*GetDDSurfaceLocal_proc)() = (void(*)())GetProcAddress(ddraw._module, "GetDDSurfaceLocal");
 extern "C" __declspec(naked) void GetDDSurfaceLocal()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "GetDDSurfaceLocal");
-
-	__asm jmp ddraw_proc;
+	__asm jmp GetDDSurfaceLocal_proc;
 }
 
+static void(*GetOLEThunkData_proc)() = (void(*)())GetProcAddress(ddraw._module, "GetOLEThunkData");
 extern "C" __declspec(naked) void GetOLEThunkData()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "GetOLEThunkData");
-
-	__asm jmp ddraw_proc;
+	__asm jmp GetOLEThunkData_proc;
 }
 
+static void(*GetSurfaceFromDC_proc)() = (void(*)())GetProcAddress(ddraw._module, "GetSurfaceFromDC");
 extern "C" __declspec(naked) void GetSurfaceFromDC()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "GetSurfaceFromDC");
-
-	__asm jmp ddraw_proc;
+	__asm jmp GetSurfaceFromDC_proc;
 }
 
+static void(*RegisterSpecialCase_proc)() = (void(*)())GetProcAddress(ddraw._module, "RegisterSpecialCase");
 extern "C" __declspec(naked) void RegisterSpecialCase()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "RegisterSpecialCase");
-
-	__asm jmp ddraw_proc;
+	__asm jmp RegisterSpecialCase_proc;
 }
 
+static void(*ReleaseDDThreadLock_proc)() = (void(*)())GetProcAddress(ddraw._module, "ReleaseDDThreadLock");
 extern "C" __declspec(naked) void ReleaseDDThreadLock()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "ReleaseDDThreadLock");
-
-	__asm jmp ddraw_proc;
+	__asm jmp ReleaseDDThreadLock_proc;
 }
 
+static void(*SetAppCompatData_proc)() = (void(*)())GetProcAddress(ddraw._module, "SetAppCompatData");
 extern "C" __declspec(naked) void SetAppCompatData()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "SetAppCompatData");
-
-	__asm jmp ddraw_proc;
+	__asm jmp SetAppCompatData_proc;
 }

--- a/impl11/ddraw/utils.cpp
+++ b/impl11/ddraw/utils.cpp
@@ -19,7 +19,7 @@
 using namespace Gdiplus;
 
 short DisplayCenteredText(char* str, int font_size_index, short y, uint32_t color);
-void DisplayTimedMessage(uint32_t seconds, int row, char* msg);
+void DisplayTimedMessage(uint32_t seconds, int row, const char* msg);
 
 std::string int_to_hex(int i)
 {

--- a/impl11/ddraw/utils.h
+++ b/impl11/ddraw/utils.h
@@ -18,7 +18,7 @@ short ComputeMsgWidth(char* str, int font_size_index);
 short DisplayText(char* str, int font_size_index, short x, short y, uint32_t color);
 short DisplayCenteredText(char* str, int font_size_index, short y, uint32_t color);
 // Only rows 0..2 are available
-void DisplayTimedMessage(uint32_t seconds, int row, char* msg);
+void DisplayTimedMessage(uint32_t seconds, int row, const char* msg);
 
 #if LOGGER
 


### PR DESCRIPTION
This comes out of an effort to get **XWAU 2025 running on Linux under wine/Proton** (now fully working). To debug renderer issues that only reproduce under wine, we cross-build `ddraw_effects.dll` on Linux with clang-cl — this PR contains the source fixes that requires. They are all standard-C++ conformance changes with **no functional difference for MSVC builds**:

- MSVC-only `for each (x in y)` → standard range-`for` (`LBVH.h`, `Materials.cpp`)
- invalid parenthesized `constexpr(expr)` → plain expression (`LBVH.cpp`)
- `auto& it = map.find(...)` binds a non-const lvalue ref to a prvalue (MSVC extension) → `auto it = ...` (`EffectsRenderer.cpp`, `Materials.cpp`, `XwaD3dRendererHook.cpp`)
- functions defined `inline` in one TU but called extern from others only link via MSVC LTCG; gave them external linkage (`Direct3DDevice.cpp`, `EffectsRenderer.{cpp,h}`, `PrimarySurface.cpp`, …)
- `__declspec(naked)` thunks in `ddraw.cpp` contained guarded-static initializers (non-asm statements in naked functions are MSVC-only) — hoisted to file scope
- `std::string` passed through `log_debug` varargs (UB; clang rejects) → `.c_str()` (`Direct3DDevice.cpp`, debug-dump path)
- const-correctness on a few string-literal pointers

Verified:
- MSVC semantics preserved by design (no behavior change on any path; mostly syntax-level).
- The clang-cl build of this branch passed full in-game testing under wine (missions, briefings, concourse, simulator).
- Notes for anyone repeating a non-MSVC build: this codebase relies on MSVC's no-TBAA/wrapping-arithmetic semantics (`-fno-strict-aliasing -fwrapv /volatile:ms` on clang) and on whole-program codegen (`-flto=thin` for the cross-TU inlines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
