### PR TITLE
WineD2DEffectShim: working HD concourse + 30fps movie present under wine (no-op on Windows)

### DIFF
--- a/impl11/ddraw/DeviceResources.h
+++ b/impl11/ddraw/DeviceResources.h
@@ -92,7 +92,7 @@ public:
 		return this->msg[0] == 0;
 	}
 
-	inline void SetMsg(char *msg, time_t seconds, short y, short font_size_idx, uint32_t color) {
+	inline void SetMsg(const char *msg, time_t seconds, short y, short font_size_idx, uint32_t color) {
 		strcpy_s(this->msg, 128, msg);
 		this->t_exp = time(NULL) + seconds;
 		this->y = y;
@@ -111,7 +111,7 @@ const int MAX_TIMED_MESSAGES = 3;
 /*
   Only rows 0..2 are available
  */
-void DisplayTimedMessage(uint32_t seconds, int row, char *msg);
+void DisplayTimedMessage(uint32_t seconds, int row, const char *msg);
 
 class DeviceResources
 {

--- a/impl11/ddraw/Direct3DDevice.cpp
+++ b/impl11/ddraw/Direct3DDevice.cpp
@@ -509,10 +509,10 @@ float RealVertFOVToRawFocalLength(float real_FOV);
 
 void GetCraftViewMatrix(Matrix4 *result);
 
-inline void backProjectMetric(float sx, float sy, float rhw, Vector3 *P);
+void backProjectMetric(float sx, float sy, float rhw, Vector3 *P);
 inline void backProjectMetric(UINT index, Vector3 *P);
 Vector3 projectMetric(Vector3 pos3D, Matrix4 viewMatrix, Matrix4 projEyeMatrix, bool bForceNonVR);
-inline Vector3 projectToInGameOrPostProcCoordsMetric(Vector3 pos3D, Matrix4 viewMatrix, Matrix4 projEyeMatrix, bool bForceNonVR = false);
+Vector3 projectToInGameOrPostProcCoordsMetric(Vector3 pos3D, Matrix4 viewMatrix, Matrix4 projEyeMatrix, bool bForceNonVR = false);
 float3 InverseTransformProjectionScreen(float4 pos);
 
 void ResetObjectIndexMap();
@@ -1341,7 +1341,7 @@ HRESULT Direct3DDevice::QuickSetZWriteEnabled(BOOL Enabled) {
 	return hr;
 }
 
-inline float lerp(float x, float y, float s) {
+float lerp(float x, float y, float s) { // Linux/clang-cl: de-inlined, used cross-TU (MSVC LTCG resolved this)
 	return x + s * (y - x);
 }
 
@@ -1755,7 +1755,7 @@ float ClosestPointOnTriangle(
  *		OPT-scale metric 3D centered on the current camera.
  *	    VR path: same as non-VR but with Y flipped
  */
-inline void backProjectMetric(float sx, float sy, float rhw, Vector3 *P) {
+void backProjectMetric(float sx, float sy, float rhw, Vector3 *P) { // Linux/clang-cl: de-inlined, used cross-TU (MSVC LTCG resolved this)
 	float3 temp;
 	float FOVscaleZ;
 	float sm_FOVscale = g_MetricRecCBuffer.mr_FOVscale;
@@ -1926,7 +1926,7 @@ Vector3 projectMetric(Vector3 pos3D, Matrix4 viewMatrix, Matrix4 projEyeMatrix, 
  *		Regular path: in-game 2D coords (sx, sy)
  *	    VR path: Post-proc coords
  */
-inline Vector3 projectToInGameOrPostProcCoordsMetric(Vector3 pos3D, Matrix4 viewMatrix, Matrix4 projEyeMatrix, bool bForceNonVR)
+Vector3 projectToInGameOrPostProcCoordsMetric(Vector3 pos3D, Matrix4 viewMatrix, Matrix4 projEyeMatrix, bool bForceNonVR)
 {
 	Vector3 P = pos3D;
 	//float w;
@@ -5578,12 +5578,12 @@ HRESULT Direct3DDevice::Execute(
 				}
 				*/
 				if (g_bDumpSSAOBuffers && g_bDumpOBJEnabled && (bIsEngineGlow || bIsMapIcon)) {
-					log_debug("[DBG] Dumping OBJ (bIsEngineGlow|bIsMapIcon): obj_%d, %s", g_iDumpOBJIdx, lastTextureSelected->_name);
+					log_debug("[DBG] Dumping OBJ (bIsEngineGlow|bIsMapIcon): obj_%d, %s", g_iDumpOBJIdx, lastTextureSelected->_name.c_str()); // Linux/clang-cl: std::string through varargs
 					DumpVerticesToOBJ(g_DumpOBJFile, instruction, currentIndexLocation,
 						g_iDumpOBJIdx, lastTextureSelected->_name.c_str(), bIsMapIcon);
 				}
 				if (g_bDumpSSAOBuffers && g_bDumpOBJEnabled && bIsExplosion) {
-					log_debug("[DBG] Dumping OBJ (bIsExplosion): obj_%d, %s", g_iDumpLaserOBJIdx, lastTextureSelected->_name);
+					log_debug("[DBG] Dumping OBJ (bIsExplosion): obj_%d, %s", g_iDumpLaserOBJIdx, lastTextureSelected->_name.c_str()); // Linux/clang-cl: std::string through varargs
 					DumpVerticesToOBJ(g_DumpLaserFile, instruction, currentIndexLocation,
 						g_iDumpLaserOBJIdx, lastTextureSelected->_name.c_str());
 				}

--- a/impl11/ddraw/EffectsCommon.h
+++ b/impl11/ddraw/EffectsCommon.h
@@ -572,7 +572,7 @@ extern float g_fMetricMult;
 extern int g_WindowWidth, g_WindowHeight;
 extern D3D11_VIEWPORT g_nonVRViewport;
 
-void DisplayTimedMessage(uint32_t seconds, int row, char* msg);
+void DisplayTimedMessage(uint32_t seconds, int row, const char* msg);
 void DisplayTimedMessageV(uint32_t seconds, int row, const char* format, ...);
 
 bool SavePOVOffsetToIniFile();

--- a/impl11/ddraw/EffectsRenderer.cpp
+++ b/impl11/ddraw/EffectsRenderer.cpp
@@ -142,7 +142,7 @@ constexpr float HOLO_DISP_Z = METERS_TO_OPT * 0.01f;
 
 float lerp(float x, float y, float s);
 
-inline float clamp(float val, float min, float max)
+float clamp(float val, float min, float max) // Linux/clang-cl: de-inlined, used cross-TU (MSVC LTCG resolved this)
 {
 	if (val < min) val = min;
 	if (val > max) val = max;
@@ -199,7 +199,7 @@ void CaptureBackdropTransform()
 	g_bBackdropTransformCaptured = true;
 }
 
-inline int MakeKeyFromGroupIdImageId(int groupId, int imageId)
+int MakeKeyFromGroupIdImageId(int groupId, int imageId) // Linux/clang-cl: de-inlined, used cross-TU (MSVC LTCG resolved this)
 {
 	return (groupId << 16) | (imageId);
 }
@@ -492,7 +492,7 @@ void OBJDump(XwaVector3 *vertices, int count)
 	fprintf(D3DDumpOBJFile, "\n");
 }
 
-inline Matrix4 XwaTransformToMatrix4(const XwaTransform &M)
+Matrix4 XwaTransformToMatrix4(const XwaTransform &M) // Linux/clang-cl: de-inlined, used cross-TU (MSVC LTCG resolved this)
 {
 	return Matrix4(
 		M.Rotation._11, M.Rotation._12, M.Rotation._13, 0.0f,
@@ -5376,7 +5376,7 @@ bool GetCurrentTargetStats(int* shields, int* hull, int* system, std::string &ca
 		(object->objectGenus == Genus_Utility);
 
 	// The default value is -1. When the craft is identified the value is 0. When the craft is inspected the value is >= 1.
-	char* FGName = (inspected >= 0) ?
+	const char* FGName = (inspected >= 0) ?
 		g_XwaTieFlightGroups[object->FGIndex].FlightGroup.Name : "Unknown";
 	name = (char*)s_ExeCraftTable[craftInstance->CraftType].pCraftShortName +
 		std::string(": ") + FGName;
@@ -5505,7 +5505,7 @@ InstanceEvent *EffectsRenderer::ObjectIDToInstanceEvent(int objectId, uint32_t m
 		log_debug("[DBG] [INST] New InstanceEvent added to objectId-matId: %d-%d",
 			objectId, materialId);
 		g_objectIdToInstanceEvent.insert(std::make_pair(Id, InstanceEvent()));
-		auto &new_it = g_objectIdToInstanceEvent.find(Id);
+		auto new_it = g_objectIdToInstanceEvent.find(Id);
 		if (new_it != g_objectIdToInstanceEvent.end())
 			return &new_it->second;
 		else
@@ -5530,7 +5530,7 @@ FixedInstanceData* EffectsRenderer::ObjectIDToFixedInstanceData(int objectId, ui
 		log_debug("[DBG] [UV] New FixedInstance added to objectId-matId: %d-%d",
 			objectId, materialId);
 		g_fixedInstanceDataMap.insert(std::make_pair(Id, FixedInstanceData()));
-		auto& new_it = g_fixedInstanceDataMap.find(Id);
+		auto new_it = g_fixedInstanceDataMap.find(Id);
 		if (new_it != g_fixedInstanceDataMap.end())
 			return &new_it->second;
 		else
@@ -6284,7 +6284,7 @@ void EffectsRenderer::MainSceneHook(const SceneCompData* scene)
 			// Find the LOD for this FaceGroup. We need this so that we can coalesce
 			// all the FGs belonging to the same LOD in one BVH. That improves performance.
 			int faceGroupId = MakeFaceGroupKey(scene);
-			auto& it = g_FGToLODMap.find(faceGroupId);
+			auto it = g_FGToLODMap.find(faceGroupId);
 			int LOD = -1;
 			if (it != g_FGToLODMap.end())
 			{
@@ -6456,7 +6456,7 @@ out:
  If the game is rendering the hyperspace effect, this function will select shaderToyBuf
  when rendering the cockpit. Otherwise it will select the regular offscreenBuffer
  */
-inline ID3D11RenderTargetView *EffectsRenderer::SelectOffscreenBuffer() {
+ID3D11RenderTargetView *EffectsRenderer::SelectOffscreenBuffer() { // Linux/clang-cl: de-inlined, used cross-TU (MSVC LTCG resolved this)
 	auto& resources = this->_deviceResources;
 
 	ID3D11RenderTargetView *regularRTV = resources->_renderTargetView.Get();

--- a/impl11/ddraw/EffectsRenderer.h
+++ b/impl11/ddraw/EffectsRenderer.h
@@ -161,7 +161,7 @@ protected:
 	HRESULT QuickSetZWriteEnabled(BOOL Enabled);
 	void EnableTransparency();
 	void EnableHoloTransparency();
-	inline ID3D11RenderTargetView *SelectOffscreenBuffer();
+	ID3D11RenderTargetView *SelectOffscreenBuffer();
 	void RenderToDC();
 	Matrix4 GetShadowMapLimits(Matrix4 L, float *OBJrange, float *OBJminZ);
 	Matrix4 GetShadowMapLimits(const AABB &aabb, float *OBJrange, float *OBJminZ);

--- a/impl11/ddraw/FrontbufferSurface.cpp
+++ b/impl11/ddraw/FrontbufferSurface.cpp
@@ -6,6 +6,7 @@
 #include "FrontbufferSurface.h"
 #include "BackbufferSurface.h"
 #include "SurfaceDC.h"
+#include "WineD2DEffectShim.h"
 
 FrontbufferSurface::FrontbufferSurface(DeviceResources* deviceResources)
 {
@@ -488,7 +489,9 @@ HRESULT FrontbufferSurface::GetDC(
 			pDC->callback = &this->_deviceResources->_surfaceDcCallback;
 
 			// FX ddraw version:
-			pDC->d2d1RenderTarget = this->_deviceResources->_d2d1OffscreenRenderTarget;
+			// Under wine, hand out a shim that covers d2d's unimplemented
+			// custom-effect path (raw target unchanged on Windows).
+			pDC->d2d1RenderTarget = WineShim_GetRenderTarget(this->_deviceResources);
 			// Golden ddraw version:
 			//pDC->d2d1RenderTarget = this->_deviceResources->_d2d1RenderTarget;
 

--- a/impl11/ddraw/LBVH.cpp
+++ b/impl11/ddraw/LBVH.cpp
@@ -7329,7 +7329,7 @@ void DirectBVH4BuilderGPU(AABB centroidBox, std::vector<T>& leafItems,
 	const XwaVector3* vertices, const int* indices, BVHNode *QBVHBuffer)
 {
 	DBVH4BuildData<T> data;
-	data.isTopLevelBuild = constexpr (std::is_same_v<T, TLASLeafItem>);
+	data.isTopLevelBuild = std::is_same_v<T, TLASLeafItem>; // Linux/clang-cl: invalid `constexpr (expr)` removed
 	data.leafItems     = leafItems;
 	data.numPrimitives = leafItems.size();
 #ifdef BVH_REPROCESS_SPLITS

--- a/impl11/ddraw/LBVH.h
+++ b/impl11/ddraw/LBVH.h
@@ -230,7 +230,7 @@ public:
 
 	inline void Expand(const std::vector<Vector4> &Limits)
 	{
-		for each (Vector4 v in Limits)
+		for (Vector4 v : Limits) // Linux/clang-cl: MSVC-only `for each` -> range-for (identical semantics)
 			Expand(v);
 	}
 

--- a/impl11/ddraw/Materials.cpp
+++ b/impl11/ddraw/Materials.cpp
@@ -1095,7 +1095,7 @@ bool LoadFrameSequence(char* buf, std::vector<TexSeqElem>& tex_sequence,
 			log_debug("[DBG] Group %d has %d images", GroupId, ImageList.size());
 		}
 		// Iterate over the list of Images and add one TexSeqElem for each one of them
-		for each (short ImageId in ImageList)
+		for (short ImageId : ImageList) // Linux/clang-cl: MSVC `for each` -> range-for
 		{
 			// Store the DAT filename in texname and set the appropriate flag. texname contains
 			// the path and filename.
@@ -1208,7 +1208,7 @@ bool LoadSimpleFrames(char *buf, std::vector<TexSeqElem> &tex_sequence)
 			ImageList = ReadZIPImageListFromGroup(sDATZIPFileName.c_str(), GroupId);
 		log_debug("[DBG] [MAT] Frame-by-Frame data. Group %d has %d images", GroupId, ImageList.size());
 		// Iterate over the list of Images and add one TexSeqElem for each one of them
-		for each (short ImageId in ImageList)
+		for (short ImageId : ImageList) // Linux/clang-cl: MSVC `for each` -> range-for
 		{
 			// Store the DAT filename in texname and set the appropriate flag. texname contains
 			// the path and filename.
@@ -2353,7 +2353,7 @@ void AnimateMaterials() {
 			continue;
 		}
 		uint64_t Id = InstEventIdFromObjectMaterialId(atc->objectId, atc->materialId);
-		auto& it = g_objectIdToInstanceEvent.find(Id);
+		auto it = g_objectIdToInstanceEvent.find(Id);
 		if (it != g_objectIdToInstanceEvent.end()) {
 			if (it->second.EventFired(atc->InstEvent))
 				atc->ResetAnimation();

--- a/impl11/ddraw/OffscreenSurface.cpp
+++ b/impl11/ddraw/OffscreenSurface.cpp
@@ -5,6 +5,7 @@
 #include "DeviceResources.h"
 #include "OffscreenSurface.h"
 #include "SurfaceDC.h"
+#include "WineD2DEffectShim.h"
 
 OffscreenSurface::OffscreenSurface(DeviceResources* deviceResources)
 {
@@ -427,7 +428,9 @@ HRESULT OffscreenSurface::GetDC(
 			pDC->callback = &this->_deviceResources->_surfaceDcCallback;
 
 			// FX ddraw version:
-			pDC->d2d1RenderTarget = this->_deviceResources->_d2d1OffscreenRenderTarget;
+			// Under wine, hand out a shim that covers d2d's unimplemented
+			// custom-effect path (raw target unchanged on Windows).
+			pDC->d2d1RenderTarget = WineShim_GetRenderTarget(this->_deviceResources);
 			// Golden ddraw version:
 			//pDC->d2d1RenderTarget = this->_deviceResources->_d2d1RenderTarget;
 

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -25,6 +25,7 @@
 #include "commonVR.h"
 #include "VRConfig.h"
 #include "SharedMem.h"
+#include "WineD2DEffectShim.h"
 #include "D3dRenderer.h"
 #include "EffectsRenderer.h"
 #include "LBVH.h"
@@ -13108,7 +13109,45 @@ HRESULT PrimarySurface::UpdateOverlayDisplay(
 			g_pVROverlay->SetOverlayTexelAspect(g_VR2Doverlay, 1.0f);
 		}
 		return DD_OK;
-	}		
+	}
+
+	// Non-VR: present TgSmush movie frames through the D3D11 swapchain
+	// (ddraw.cfg TgSmushSwapchainPresentEnabled=1, pairs with TgSmush.cfg
+	// MFD3DPresent=1). The MF pipeline delivers 30fps into shared memory,
+	// but under wine TgSmush's GDI StretchDIBits present is throttled to
+	// ~5-10fps visible by the window-surface -> X11 flush.
+	if (g_config.TgSmushSwapchainPresentEnabled &&
+		!g_bUseSteamVR && WineShim_TgSmushMoviePlaying())
+	{
+		resources->CreateTgSmushTexture(g_pSharedDataTgSmush->videoFrameWidth, g_pSharedDataTgSmush->videoFrameHeight);
+
+		if (resources->_tgSmushTex != nullptr)
+		{
+			static int lastFrameRendered = -1;
+			if (lastFrameRendered != g_pSharedDataTgSmush->videoFrameIndex &&
+				g_pSharedDataTgSmush->videoDataPtr != nullptr)
+			{
+				D3D11_MAPPED_SUBRESOURCE map;
+				if (SUCCEEDED(context->Map(resources->_tgSmushTex, 0, D3D11_MAP_WRITE_DISCARD, 0, &map)))
+				{
+					const uint32_t w = g_pSharedDataTgSmush->videoFrameWidth;
+					const uint32_t h = g_pSharedDataTgSmush->videoFrameHeight;
+					const char* src = (const char*)g_pSharedDataTgSmush->videoDataPtr;
+					char* dst = (char*)map.pData;
+					if (map.RowPitch == w * 4)
+						memcpy(dst, src, (size_t)w * h * 4);
+					else
+						for (uint32_t y = 0; y < h; y++)
+							memcpy(dst + (size_t)y * map.RowPitch, src + (size_t)y * w * 4, (size_t)w * 4);
+					context->Unmap(resources->_tgSmushTex, 0);
+				}
+				lastFrameRendered = g_pSharedDataTgSmush->videoFrameIndex;
+
+				WineShim_PresentMovieFrame(resources);
+			}
+			return DD_OK;
+		}
+	}
 
 #if LOGGER
 	str.str("\tDDERR_UNSUPPORTED");

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -10707,8 +10707,7 @@ HRESULT PrimarySurface::Flip(
 	bool bHyperspaceFirstFrame = g_bHyperspaceFirstFrame; // Used to clear the shadowMap DSVs *after* they're used
 
 	/* Display VR movies */
-	if (g_bUseSteamVR && g_pSharedDataTgSmush != nullptr &&
-		g_pSharedDataTgSmush->videoFrameIndex > 0)
+	if (g_bUseSteamVR && WineShim_TgSmushMoviePlaying())
 	{
 		// Create or resize the TgSmush texture. If we already created this texture and there's
 		// no change in dimensions, CreateTgSmushTexture() will do nothing.
@@ -10745,8 +10744,12 @@ HRESULT PrimarySurface::Flip(
 		}
 	}
 
-	if (g_pSharedDataTgSmush != nullptr && g_pSharedDataTgSmush->videoFrameIndex > 0)
-		// Early exit in case Flip is being called from Tgsmush to avoid doing anything unnecessary that can cause crashes.
+	// Early exit in case Flip is being called from Tgsmush to avoid doing
+	// anything unnecessary that can cause crashes. MoviePlaying() also
+	// guards against a stale shared-mem flag (a TgSmush that died, or an
+	// MF session that never delivered the shutdown callback, would
+	// otherwise freeze the screen on the last presented frame forever).
+	if (WineShim_TgSmushMoviePlaying())
 		return DD_OK;
 
 	if (this->_deviceResources->sceneRenderedEmpty && this->_deviceResources->_frontbufferSurface != nullptr && this->_deviceResources->_frontbufferSurface->wasBltFastCalled)
@@ -13069,8 +13072,7 @@ HRESULT PrimarySurface::UpdateOverlayDisplay(
 	auto& context = resources->_d3dDeviceContext;
 
 	/* Display VR movies in SteamVR */
-	if (g_bUseSteamVR && g_pSharedDataTgSmush != nullptr &&
-		g_pSharedDataTgSmush->videoFrameIndex > 0)
+	if (g_bUseSteamVR && WineShim_TgSmushMoviePlaying())
 	{
 		// Create or resize the TgSmush texture. If we already created this texture and there's
 		// no change in dimensions, CreateTgSmushTexture() will do nothing.

--- a/impl11/ddraw/PrimarySurface.cpp
+++ b/impl11/ddraw/PrimarySurface.cpp
@@ -54,7 +54,7 @@ void GetGunnerTurretViewMatrixSpeedEffect(Matrix4 * result, bool applyHeadingInG
 void DisplayBox(char *name, Box box);
 Vector3 project(Vector3 pos3D, Matrix4 viewMatrix, Matrix4 projEyeMatrix /*, float *sx, float *sy */);
 inline void backProject(float sx, float sy, float rhw, Vector3 *P);
-inline void backProjectMetric(float sx, float sy, float rhw, Vector3 *P);
+void backProjectMetric(float sx, float sy, float rhw, Vector3 *P);
 
 // These are the actual functions for (back)-projection currently used as of Feb 2024:
 float4 TransformProjection(float3 input);
@@ -63,7 +63,7 @@ float3 InverseTransformProjectionScreen(float4 input);
 
 Vector3 projectMetric(Vector3 pos3D, Matrix4 viewMatrix, Matrix4 projEyeMatrix, bool bForceNonVR);
 inline Vector3 projectToInGameCoords(Vector3 pos3D, Matrix4 viewMatrix, Matrix4 projEyeMatrix);
-inline Vector3 projectToInGameOrPostProcCoordsMetric(Vector3 pos3D, Matrix4 viewMatrix, Matrix4 projEyeMatrix, bool bForceNonVR = false);
+Vector3 projectToInGameOrPostProcCoordsMetric(Vector3 pos3D, Matrix4 viewMatrix, Matrix4 projEyeMatrix, bool bForceNonVR = false);
 //void ComputeBaryCoords(const Vector3& v0, const Vector3& v1, const Vector3& v2, const Vector3& P,
 //	float& u, float& v);
 bool rayTriangleIntersect(
@@ -75,7 +75,7 @@ float ClosestPointOnTriangle(
 	Vector3& P, float& u, float& v, float margin);
 void ResetXWALightInfo();
 void DumpHyperspaceVertexBuffer(float width, float height);
-inline Matrix4 XwaTransformToMatrix4(const XwaTransform& M);
+Matrix4 XwaTransformToMatrix4(const XwaTransform& M);
 float4 TransformProjection(float3 input);
 float4 TransformProjectionScreen(float3 input);
 void EmulMouseWithVRControllers();
@@ -13232,7 +13232,7 @@ short DisplayCenteredText(char* str, int font_size_index, short y, uint32_t colo
   the timer on whatever is in that slot. The hard-coded values are screen-height
   relative and seem to work fine across different resolutions.
  */
-void DisplayTimedMessage(uint32_t seconds, int row, char* msg) {
+void DisplayTimedMessage(uint32_t seconds, int row, const char* msg) {
 	short y_pos = (short)(g_fCurInGameHeight * (0.189f + 0.05f * row));
 	g_TimedMessages[row].SetMsg(msg, seconds, y_pos, FONT_LARGE_IDX, FONT_BLUE_COLOR);
 }

--- a/impl11/ddraw/ShadowMapping.cpp
+++ b/impl11/ddraw/ShadowMapping.cpp
@@ -26,7 +26,7 @@ int g_iNumSunCentroids = 0;
 
 /*********************************************************/
 
-void DisplayTimedMessage(uint32_t seconds, int row, char* msg);
+void DisplayTimedMessage(uint32_t seconds, int row, const char* msg);
 
 void ToggleCSM()
 {

--- a/impl11/ddraw/WineD2DEffectShim.cpp
+++ b/impl11/ddraw/WineD2DEffectShim.cpp
@@ -1,0 +1,1048 @@
+// Copyright (c) 2026 Peter Soetens
+// Licensed under the MIT license. See LICENSE.txt
+//
+// WineD2DEffectShim implementation -- see WineD2DEffectShim.h for the design.
+#include "common.h"
+#include "DeviceResources.h"
+#include "utils.h"
+#include "SharedMem.h"
+#include "WineD2DEffectShim.h"
+#include <d2d1_1.h>
+#include <initguid.h>
+
+// hook_concourse's effect CLSID (BitmapEffect.h in xwa_hook_concourse)
+DEFINE_GUID(CLSID_HookBitmapEffect, 0xB7B36C92, 0x3498, 0x4A94, 0x9E, 0x95, 0x9F, 0x24, 0x6F, 0x92, 0x45, 0xBF);
+// Private marker IIDs to recognize our own objects through QueryInterface
+DEFINE_GUID(IID_ShimEffectMarker, 0x7E1A1F2B, 0x4C3D, 0x4E5F, 0x8A, 0x9B, 0x0C, 0x1D, 0x2E, 0x3F, 0x4A, 0x5B);
+DEFINE_GUID(IID_ShimBitmapMarker, 0xA2B3C4D5, 0xE6F7, 0x4081, 0x92, 0xA3, 0xB4, 0xC5, 0xD6, 0xE7, 0xF8, 0x09);
+
+#include "../Release/ShimBitmapVS.h"
+#include "../Release/ShimBitmapPS.h"
+
+// ===========================================================================
+// ShimBitmap: an ID2D1Bitmap backed by a plain D3D11 texture+SRV.
+// Only the surface hook_concourse uses is functional (CopyFromMemory,
+// GetSize/GetPixelSize); the rest are honest stubs.
+// ===========================================================================
+class ShimBitmap : public ID2D1Bitmap
+{
+public:
+	LONG _ref;
+	mutable ComPtr<ID3D11Texture2D> _tex;
+	mutable ComPtr<ID3D11ShaderResourceView> _srv;
+	mutable ComPtr<ID2D1Factory> _factory;
+	UINT _width, _height;
+	DXGI_FORMAT _format;
+
+	// NB: the project ComPtr has NO assignment operators — `member = ptr;`
+	// routes through a converting temporary whose dtor Release()s the pointer
+	// (use-after-free). Always initializer-list + explicit AddRef, or
+	// .Release() + *GetAddressOf() for transferring an owned reference.
+	ShimBitmap(ID2D1Factory* factory) : _ref(1), _factory(factory), _width(0), _height(0), _format(DXGI_FORMAT_UNKNOWN)
+	{
+		if (factory) factory->AddRef();
+	}
+
+	static HRESULT Create(DeviceResources* res, ID2D1Factory* factory,
+		D2D1_SIZE_U size, const void* srcData, UINT32 pitch,
+		const D2D1_BITMAP_PROPERTIES* props, ShimBitmap** out)
+	{
+		*out = nullptr;
+		DXGI_FORMAT fmt = props ? props->pixelFormat.format : DXGI_FORMAT_B8G8R8A8_UNORM;
+		if (fmt == DXGI_FORMAT_UNKNOWN) fmt = DXGI_FORMAT_B8G8R8A8_UNORM;
+
+		ShimBitmap* bmp = new ShimBitmap(factory);
+		bmp->_width = size.width;
+		bmp->_height = size.height;
+		bmp->_format = fmt;
+
+		D3D11_TEXTURE2D_DESC td = {};
+		td.Width = size.width;
+		td.Height = size.height;
+		td.MipLevels = 1;
+		td.ArraySize = 1;
+		td.Format = fmt;
+		td.SampleDesc.Count = 1;
+		td.Usage = D3D11_USAGE_DEFAULT;
+		td.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+
+		D3D11_SUBRESOURCE_DATA init = {};
+		init.pSysMem = srcData;
+		init.SysMemPitch = pitch;
+
+		HRESULT hr = res->_d3dDevice->CreateTexture2D(&td, srcData ? &init : nullptr, &bmp->_tex);
+		if (SUCCEEDED(hr))
+			hr = res->_d3dDevice->CreateShaderResourceView(bmp->_tex, nullptr, &bmp->_srv);
+		if (FAILED(hr))
+		{
+			log_debug("[DBG] [SHIM] ShimBitmap::Create %ux%u fmt=%d FAILED 0x%08X", size.width, size.height, fmt, hr);
+			bmp->Release();
+			return hr;
+		}
+		*out = bmp;
+		return S_OK;
+	}
+
+	// IUnknown
+	STDMETHOD(QueryInterface)(REFIID riid, void** ppv) override
+	{
+		if (!ppv) return E_POINTER;
+		if (riid == __uuidof(IUnknown) || riid == __uuidof(ID2D1Resource) ||
+			riid == __uuidof(ID2D1Image) || riid == __uuidof(ID2D1Bitmap) ||
+			riid == IID_ShimBitmapMarker)
+		{
+			*ppv = this; AddRef(); return S_OK;
+		}
+		*ppv = nullptr;
+		return E_NOINTERFACE;
+	}
+	STDMETHOD_(ULONG, AddRef)() override { return (ULONG)InterlockedIncrement(&_ref); }
+	STDMETHOD_(ULONG, Release)() override
+	{
+		ULONG r = (ULONG)InterlockedDecrement(&_ref);
+		if (r == 0) delete this;
+		return r;
+	}
+
+	// ID2D1Resource
+	STDMETHOD_(void, GetFactory)(ID2D1Factory** factory) const override
+	{
+		*factory = _factory; if (_factory) ((ID2D1Factory*)_factory)->AddRef();
+	}
+
+	// ID2D1Bitmap
+	STDMETHOD_(D2D1_SIZE_F, GetSize)() const override
+	{
+		return D2D1::SizeF((FLOAT)_width, (FLOAT)_height);
+	}
+	STDMETHOD_(D2D1_SIZE_U, GetPixelSize)() const override
+	{
+		return D2D1::SizeU(_width, _height);
+	}
+	STDMETHOD_(D2D1_PIXEL_FORMAT, GetPixelFormat)() const override
+	{
+		return D2D1::PixelFormat(_format, D2D1_ALPHA_MODE_PREMULTIPLIED);
+	}
+	STDMETHOD_(void, GetDpi)(FLOAT* dpiX, FLOAT* dpiY) const override
+	{
+		if (dpiX) *dpiX = 96.0f; if (dpiY) *dpiY = 96.0f;
+	}
+	STDMETHOD(CopyFromBitmap)(CONST D2D1_POINT_2U*, ID2D1Bitmap*, CONST D2D1_RECT_U*) override { return E_NOTIMPL; }
+	STDMETHOD(CopyFromRenderTarget)(CONST D2D1_POINT_2U*, ID2D1RenderTarget*, CONST D2D1_RECT_U*) override { return E_NOTIMPL; }
+	STDMETHOD(CopyFromMemory)(CONST D2D1_RECT_U* dstRect, CONST void* srcData, UINT32 pitch) override
+	{
+		if (!_tex || !srcData) return E_FAIL;
+		ID3D11DeviceContext* ctx = nullptr;
+		ID3D11Device* dev = nullptr;
+		_tex->GetDevice(&dev);
+		dev->GetImmediateContext(&ctx);
+		if (dstRect)
+		{
+			D3D11_BOX box = { dstRect->left, dstRect->top, 0, dstRect->right, dstRect->bottom, 1 };
+			ctx->UpdateSubresource(_tex, 0, &box, srcData, pitch, 0);
+		}
+		else
+		{
+			ctx->UpdateSubresource(_tex, 0, nullptr, srcData, pitch, 0);
+		}
+		ctx->Release();
+		dev->Release();
+		return S_OK;
+	}
+};
+
+// ===========================================================================
+// ShimEffect: stands in for the hook's BitmapEffect when the real d2d
+// CreateEffect fails. Stores the input bitmap and the BlendColor value.
+// GetOutput() returns its own ID2D1Image identity; the shim context
+// recognizes it in DrawImage via IID_ShimEffectMarker.
+// ===========================================================================
+class ShimEffect : public ID2D1Effect, public ID2D1Image
+{
+public:
+	LONG _ref;
+	mutable ComPtr<ShimBitmap> _input;
+	mutable ComPtr<ID2D1Factory> _factory;
+	UINT32 _blendColor;
+
+	ShimEffect(ID2D1Factory* factory) : _ref(1), _factory(factory), _blendColor(0)
+	{
+		if (factory) factory->AddRef();
+	}
+
+	// IUnknown (shared by both branches; disambiguate via ID2D1Effect side)
+	STDMETHOD(QueryInterface)(REFIID riid, void** ppv) override
+	{
+		if (!ppv) return E_POINTER;
+		if (riid == __uuidof(IUnknown) || riid == __uuidof(ID2D1Properties) || riid == __uuidof(ID2D1Effect))
+		{
+			*ppv = static_cast<ID2D1Effect*>(this); AddRef(); return S_OK;
+		}
+		if (riid == IID_ShimEffectMarker)
+		{
+			// private marker: must return the OBJECT BASE (callers cast to
+			// ShimEffect*), NOT the ID2D1Image branch (this+vtable offset)!
+			*ppv = this; AddRef(); return S_OK;
+		}
+		if (riid == __uuidof(ID2D1Resource) || riid == __uuidof(ID2D1Image))
+		{
+			*ppv = static_cast<ID2D1Image*>(this); AddRef(); return S_OK;
+		}
+		*ppv = nullptr;
+		return E_NOINTERFACE;
+	}
+	STDMETHOD_(ULONG, AddRef)() override { return (ULONG)InterlockedIncrement(&_ref); }
+	STDMETHOD_(ULONG, Release)() override
+	{
+		ULONG r = (ULONG)InterlockedDecrement(&_ref);
+		if (r == 0) delete this;
+		return r;
+	}
+
+	// ID2D1Resource (ID2D1Image branch)
+	STDMETHOD_(void, GetFactory)(ID2D1Factory** factory) const override
+	{
+		*factory = _factory; if (_factory) ((ID2D1Factory*)_factory)->AddRef();
+	}
+
+	// ID2D1Properties -- only BlendColor (index 0) is real
+	STDMETHOD_(UINT32, GetPropertyCount)() const override { return 1; }
+	STDMETHOD(GetPropertyName)(UINT32 index, PWSTR name, UINT32 nameCount) const override
+	{
+		if (index != 0) return D2DERR_INVALID_PROPERTY;
+		wcsncpy_s(name, nameCount, L"BlendColor", _TRUNCATE);
+		return S_OK;
+	}
+	STDMETHOD_(UINT32, GetPropertyNameLength)(UINT32 index) const override { return index == 0 ? 10 : 0; }
+	STDMETHOD_(D2D1_PROPERTY_TYPE, GetType)(UINT32 index) const override
+	{
+		return index == 0 ? D2D1_PROPERTY_TYPE_UINT32 : D2D1_PROPERTY_TYPE_UNKNOWN;
+	}
+	STDMETHOD_(UINT32, GetPropertyIndex)(PCWSTR name) const override
+	{
+		return (name && _wcsicmp(name, L"BlendColor") == 0) ? 0 : D2D1_INVALID_PROPERTY_INDEX;
+	}
+	STDMETHOD(SetValueByName)(PCWSTR name, D2D1_PROPERTY_TYPE type, CONST BYTE* data, UINT32 dataSize) override
+	{
+		return SetValue(GetPropertyIndex(name), type, data, dataSize);
+	}
+	STDMETHOD(SetValue)(UINT32 index, D2D1_PROPERTY_TYPE type, CONST BYTE* data, UINT32 dataSize) override
+	{
+		if (index != 0 || !data || dataSize != sizeof(UINT32)) return D2DERR_INVALID_PROPERTY;
+		memcpy(&_blendColor, data, sizeof(UINT32));
+		return S_OK;
+	}
+	STDMETHOD(GetValueByName)(PCWSTR name, D2D1_PROPERTY_TYPE type, BYTE* data, UINT32 dataSize) const override
+	{
+		return GetValue(GetPropertyIndex(name), type, data, dataSize);
+	}
+	STDMETHOD(GetValue)(UINT32 index, D2D1_PROPERTY_TYPE type, BYTE* data, UINT32 dataSize) const override
+	{
+		if (index != 0 || !data || dataSize < sizeof(UINT32)) return D2DERR_INVALID_PROPERTY;
+		memcpy(data, &_blendColor, sizeof(UINT32));
+		return S_OK;
+	}
+	STDMETHOD_(UINT32, GetValueSize)(UINT32 index) const override { return index == 0 ? sizeof(UINT32) : 0; }
+	STDMETHOD(GetSubProperties)(UINT32, ID2D1Properties**) const override { return D2DERR_NO_SUBPROPERTIES; }
+
+	// ID2D1Effect
+	STDMETHOD_(void, SetInput)(UINT32 index, ID2D1Image* input, BOOL) override
+	{
+		if (index != 0) return;
+		_input.Release();
+		if (input)
+		{
+			ShimBitmap* bmp = nullptr;
+			HRESULT qi = input->QueryInterface(IID_ShimBitmapMarker, (void**)&bmp);
+			if (SUCCEEDED(qi))
+				*_input.GetAddressOf() = bmp; // store the QI reference directly (no ComPtr temp!)
+#if LOGGER
+			static int s_siN = 0;
+			const int n = s_siN++;
+			if ((n < 30) || (n % 256) == 0)
+				log_debug("[DBG] [SHIM] SetInput #%d: in=%p qi=0x%08X -> %s", n, input,
+					qi, SUCCEEDED(qi) ? "shim bitmap" : "NON-SHIM (ignored)");
+#endif
+		}
+	}
+	STDMETHOD(SetInputCount)(UINT32) override { return S_OK; }
+	STDMETHOD_(void, GetInput)(UINT32 index, ID2D1Image** input) const override
+	{
+		*input = nullptr;
+		if (index == 0 && _input) { *input = (ShimBitmap*)_input; (*input)->AddRef(); }
+	}
+	STDMETHOD_(UINT32, GetInputCount)() const override { return 1; }
+	STDMETHOD_(void, GetOutput)(ID2D1Image** output) const override
+	{
+		*output = (ID2D1Image*)this;
+		(*output)->AddRef();
+	}
+};
+
+// ===========================================================================
+// ShimContext: ID2D1DeviceContext proxy. Forwards everything to the real
+// device context; intercepts CreateEffect / CreateBitmap / DrawImage /
+// clip push-pop (for the scissor rect of the native draw).
+// ===========================================================================
+#define FWD _real
+
+class ShimContext : public ID2D1DeviceContext
+{
+public:
+	LONG _ref;
+	DeviceResources* _res;
+	mutable ComPtr<ID2D1RenderTarget> _realRT;
+	mutable ComPtr<ID2D1DeviceContext> _real;
+	// STICKY + GLOBAL: the render target (and thus this proxy) is recreated
+	// when missions resize buffers, but hook_concourse caches its effect
+	// object forever and never calls CreateEffect again -- a fresh instance
+	// flag would silently revert to the (broken) real-d2d bitmap path and
+	// icons stop drawing after the first mission.
+	static bool s_shimMode;
+
+	struct ClipEntry { D2D1_RECT_F rect; D2D1_MATRIX_3X2_F xform; };
+	ClipEntry _clips[16];
+	int _clipCount;
+
+	// native draw pipeline (lazy)
+	bool _pipeTried, _pipeOk;
+	ComPtr<ID3D11VertexShader> _vs;
+	ComPtr<ID3D11PixelShader> _ps;
+	ComPtr<ID3D11Buffer> _cb;
+	ComPtr<ID3D11BlendState> _blend;
+	ComPtr<ID3D11RasterizerState> _raster;
+	ComPtr<ID3D11DepthStencilState> _depth;
+	ComPtr<ID3D11SamplerState> _sampLinear;
+	ComPtr<ID3D11SamplerState> _sampPoint;
+
+	struct ShimCB
+	{
+		float dstRect[4];
+		float uvRect[4];
+		float xformRow0[4];
+		float xformRow1[4];
+		float blendColor[4];
+	};
+
+	ShimContext(DeviceResources* res, ID2D1RenderTarget* realRT, ID2D1DeviceContext* realDC)
+		: _ref(1), _res(res), _realRT(realRT), _real(realDC),
+		_clipCount(0), _pipeTried(false), _pipeOk(false)
+	{
+		realRT->AddRef();
+		realDC->AddRef();
+	}
+
+	// ---------------- IUnknown ----------------
+	STDMETHOD(QueryInterface)(REFIID riid, void** ppv) override
+	{
+		if (!ppv) return E_POINTER;
+		if (riid == __uuidof(IUnknown) || riid == __uuidof(ID2D1Resource) ||
+			riid == __uuidof(ID2D1RenderTarget) || riid == __uuidof(ID2D1DeviceContext))
+		{
+			*ppv = this; AddRef(); return S_OK;
+		}
+		// Unknown interfaces fall through to the real object (e.g. future
+		// ID2D1DeviceContext1+ requests) -- the caller then talks to the
+		// real context directly, losing only the shim interceptions.
+		return _real->QueryInterface(riid, ppv);
+	}
+	STDMETHOD_(ULONG, AddRef)() override { return (ULONG)InterlockedIncrement(&_ref); }
+	STDMETHOD_(ULONG, Release)() override
+	{
+		ULONG r = (ULONG)InterlockedDecrement(&_ref);
+		if (r == 0) delete this;
+		return r;
+	}
+
+	// ---------------- ID2D1Resource ----------------
+	STDMETHOD_(void, GetFactory)(ID2D1Factory** factory) const override { FWD->GetFactory(factory); }
+
+	// ---------------- ID2D1RenderTarget: interceptions ----------------
+	STDMETHOD(CreateBitmap)(D2D1_SIZE_U size, CONST void* srcData, UINT32 pitch,
+		CONST D2D1_BITMAP_PROPERTIES* props, ID2D1Bitmap** bitmap) override
+	{
+		// NB: hook_concourse ignores this HRESULT and caches the out-pointer
+		// UNINITIALIZED on failure -- null it and never let the call fail
+		// without trying the shim path too.
+		if (bitmap) *bitmap = nullptr;
+		HRESULT hr = E_FAIL;
+		if (!s_shimMode)
+		{
+			hr = FWD->CreateBitmap(size, srcData, pitch, props, bitmap);
+			if (SUCCEEDED(hr))
+				return hr;
+		}
+		ComPtr<ID2D1Factory> factory;
+		FWD->GetFactory(&factory);
+		HRESULT hr2 = ShimBitmap::Create(_res, factory, size, srcData, pitch, props, (ShimBitmap**)bitmap);
+#if LOGGER
+		static int s_cbN = 0;
+		const int n = s_cbN++;
+		if ((n < 30) || (n % 256) == 0)
+			log_debug("[DBG] [SHIM] CreateBitmap #%d: %ux%u fmt=%d pitch=%u shimMode=%d realHr=0x%08X shimHr=0x%08X out=%p",
+				n, size.width, size.height, props ? (int)props->pixelFormat.format : -1, pitch,
+				(int)s_shimMode, hr, hr2, bitmap ? *bitmap : nullptr);
+#endif
+		return hr2;
+	}
+	STDMETHOD_(void, PushAxisAlignedClip)(CONST D2D1_RECT_F* rect, D2D1_ANTIALIAS_MODE mode) override
+	{
+		if (_clipCount < 16 && rect)
+		{
+			_clips[_clipCount].rect = *rect;
+			FWD->GetTransform(&_clips[_clipCount].xform);
+			_clipCount++;
+		}
+		FWD->PushAxisAlignedClip(rect, mode);
+	}
+	STDMETHOD_(void, PopAxisAlignedClip)() override
+	{
+		if (_clipCount > 0) _clipCount--;
+		FWD->PopAxisAlignedClip();
+	}
+
+	// ---------------- ID2D1DeviceContext: interceptions ----------------
+	STDMETHOD(CreateEffect)(REFCLSID effectId, ID2D1Effect** effect) override
+	{
+		HRESULT hr = FWD->CreateEffect(effectId, effect);
+		if (SUCCEEDED(hr))
+			return hr;
+		if (effectId == CLSID_HookBitmapEffect)
+		{
+			static bool logged = false;
+			if (!logged)
+			{
+				log_debug("[DBG] [SHIM] real CreateEffect(BitmapEffect) failed 0x%08X -> using D3D11 shim effect", hr);
+				logged = true;
+			}
+			s_shimMode = true;
+			ComPtr<ID2D1Factory> factory;
+			FWD->GetFactory(&factory);
+			*effect = new ShimEffect(factory);
+			return S_OK;
+		}
+		return hr;
+	}
+	STDMETHOD_(void, DrawImage)(ID2D1Image* image, CONST D2D1_POINT_2F* targetOffset,
+		CONST D2D1_RECT_F* imageRect, D2D1_INTERPOLATION_MODE interp, D2D1_COMPOSITE_MODE composite) override
+	{
+		ShimEffect* eff = nullptr;
+		if (image && SUCCEEDED(image->QueryInterface(IID_ShimEffectMarker, (void**)&eff)))
+		{
+			ShimDraw(eff, targetOffset, imageRect, interp);
+			eff->Release();
+			return;
+		}
+		FWD->DrawImage(image, targetOffset, imageRect, interp, composite);
+	}
+
+	// ---------------- the native D3D11 draw ----------------
+	bool EnsurePipeline()
+	{
+		if (_pipeTried) return _pipeOk;
+		_pipeTried = true;
+
+		ID3D11Device* dev = _res->_d3dDevice;
+		HRESULT hr = dev->CreateVertexShader(g_ShimBitmapVS, sizeof(g_ShimBitmapVS), nullptr, &_vs);
+		if (SUCCEEDED(hr)) hr = dev->CreatePixelShader(g_ShimBitmapPS, sizeof(g_ShimBitmapPS), nullptr, &_ps);
+
+		if (SUCCEEDED(hr))
+		{
+			D3D11_BUFFER_DESC bd = {};
+			bd.ByteWidth = sizeof(ShimCB);
+			bd.Usage = D3D11_USAGE_DEFAULT;
+			bd.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+			hr = dev->CreateBuffer(&bd, nullptr, &_cb);
+		}
+		if (SUCCEEDED(hr))
+		{
+			// premultiplied-alpha SOURCE_OVER
+			D3D11_BLEND_DESC bd = {};
+			bd.RenderTarget[0].BlendEnable = TRUE;
+			bd.RenderTarget[0].SrcBlend = D3D11_BLEND_ONE;
+			bd.RenderTarget[0].DestBlend = D3D11_BLEND_INV_SRC_ALPHA;
+			bd.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;
+			bd.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ONE;
+			bd.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_INV_SRC_ALPHA;
+			bd.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
+			bd.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
+			hr = dev->CreateBlendState(&bd, &_blend);
+		}
+		if (SUCCEEDED(hr))
+		{
+			D3D11_RASTERIZER_DESC rd = {};
+			rd.FillMode = D3D11_FILL_SOLID;
+			rd.CullMode = D3D11_CULL_NONE;
+			rd.ScissorEnable = TRUE;
+			rd.DepthClipEnable = TRUE;
+			hr = dev->CreateRasterizerState(&rd, &_raster);
+		}
+		if (SUCCEEDED(hr))
+		{
+			D3D11_DEPTH_STENCIL_DESC dd = {};
+			dd.DepthEnable = FALSE;
+			dd.StencilEnable = FALSE;
+			hr = dev->CreateDepthStencilState(&dd, &_depth);
+		}
+		if (SUCCEEDED(hr))
+		{
+			D3D11_SAMPLER_DESC sd = {};
+			sd.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+			sd.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
+			sd.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
+			sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+			sd.MaxLOD = D3D11_FLOAT32_MAX;
+			hr = dev->CreateSamplerState(&sd, &_sampLinear);
+			if (SUCCEEDED(hr))
+			{
+				sd.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
+				hr = dev->CreateSamplerState(&sd, &_sampPoint);
+			}
+		}
+
+		_pipeOk = SUCCEEDED(hr);
+		log_debug("[DBG] [SHIM] pipeline init: %s (0x%08X)", _pipeOk ? "OK" : "FAILED", hr);
+		return _pipeOk;
+	}
+
+	void ShimDraw(ShimEffect* eff, CONST D2D1_POINT_2F* targetOffset,
+		CONST D2D1_RECT_F* imageRect, D2D1_INTERPOLATION_MODE interp)
+	{
+		if (!eff->_input) return;
+		if (!EnsurePipeline()) return;
+
+		ShimBitmap* bmp = (ShimBitmap*)eff->_input;
+		D2D1_SIZE_U targetPx = _realRT->GetPixelSize();
+		if (targetPx.width == 0 || targetPx.height == 0) return;
+
+		D2D1_RECT_F src = imageRect ? *imageRect
+			: D2D1::RectF(0, 0, (FLOAT)bmp->_width, (FLOAT)bmp->_height);
+		D2D1_POINT_2F off = targetOffset ? *targetOffset : D2D1::Point2F(0, 0);
+
+		D2D1_MATRIX_3X2_F m;
+		FWD->GetTransform(&m);
+
+		ShimCB cb;
+		cb.dstRect[0] = off.x;
+		cb.dstRect[1] = off.y;
+		cb.dstRect[2] = off.x + (src.right - src.left);
+		cb.dstRect[3] = off.y + (src.bottom - src.top);
+		cb.uvRect[0] = src.left / (FLOAT)bmp->_width;
+		cb.uvRect[1] = src.top / (FLOAT)bmp->_height;
+		cb.uvRect[2] = src.right / (FLOAT)bmp->_width;
+		cb.uvRect[3] = src.bottom / (FLOAT)bmp->_height;
+		cb.xformRow0[0] = m._11; cb.xformRow0[1] = m._12;
+		cb.xformRow0[2] = m._21; cb.xformRow0[3] = m._22;
+		cb.xformRow1[0] = m._31; cb.xformRow1[1] = m._32;
+		cb.xformRow1[2] = (FLOAT)targetPx.width;
+		cb.xformRow1[3] = (FLOAT)targetPx.height;
+		// BitmapEffect::SetBlendColor packing: LSB-first bytes / 255
+		cb.blendColor[0] = (float)((eff->_blendColor) & 0xFF) / 255.0f;
+		cb.blendColor[1] = (float)((eff->_blendColor >> 8) & 0xFF) / 255.0f;
+		cb.blendColor[2] = (float)((eff->_blendColor >> 16) & 0xFF) / 255.0f;
+		cb.blendColor[3] = (float)((eff->_blendColor >> 24) & 0xFF) / 255.0f;
+
+		// scissor = intersection of the tracked clip stack (transformed AABBs)
+		LONG sx0 = 0, sy0 = 0, sx1 = (LONG)targetPx.width, sy1 = (LONG)targetPx.height;
+		for (int i = 0; i < _clipCount; i++)
+		{
+			const D2D1_RECT_F& r = _clips[i].rect;
+			const D2D1_MATRIX_3X2_F& cm = _clips[i].xform;
+			D2D1_POINT_2F pts[4] = {
+				{ r.left, r.top }, { r.right, r.top }, { r.left, r.bottom }, { r.right, r.bottom } };
+			FLOAT minX = 1e9f, minY = 1e9f, maxX = -1e9f, maxY = -1e9f;
+			for (int k = 0; k < 4; k++)
+			{
+				FLOAT tx = pts[k].x * cm._11 + pts[k].y * cm._21 + cm._31;
+				FLOAT ty = pts[k].x * cm._12 + pts[k].y * cm._22 + cm._32;
+				if (tx < minX) minX = tx; if (tx > maxX) maxX = tx;
+				if (ty < minY) minY = ty; if (ty > maxY) maxY = ty;
+			}
+			if ((LONG)minX > sx0) sx0 = (LONG)minX;
+			if ((LONG)minY > sy0) sy0 = (LONG)minY;
+			if ((LONG)maxX < sx1) sx1 = (LONG)maxX;
+			if ((LONG)maxY < sy1) sy1 = (LONG)maxY;
+		}
+		if (sx0 >= sx1 || sy0 >= sy1) return; // fully clipped
+
+		// order the pending d2d commands before our native draw
+		_realRT->Flush(nullptr, nullptr);
+
+		ID3D11DeviceContext* ctx = _res->_d3dDeviceContext;
+		ID3D11RenderTargetView* rtv = _res->_renderTargetView;
+		if (!ctx || !rtv) return;
+
+		// ---- save the state we touch ----
+		ID3D11RenderTargetView* oldRTV = nullptr; ID3D11DepthStencilView* oldDSV = nullptr;
+		ctx->OMGetRenderTargets(1, &oldRTV, &oldDSV);
+		D3D11_VIEWPORT oldVP[D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE];
+		UINT oldVPCount = D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE;
+		ctx->RSGetViewports(&oldVPCount, oldVP);
+		D3D11_RECT oldSc[D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE];
+		UINT oldScCount = D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE;
+		ctx->RSGetScissorRects(&oldScCount, oldSc);
+		ID3D11BlendState* oldBlend = nullptr; FLOAT oldBf[4]; UINT oldMask = 0;
+		ctx->OMGetBlendState(&oldBlend, oldBf, &oldMask);
+		ID3D11DepthStencilState* oldDepth = nullptr; UINT oldSref = 0;
+		ctx->OMGetDepthStencilState(&oldDepth, &oldSref);
+		ID3D11RasterizerState* oldRaster = nullptr;
+		ctx->RSGetState(&oldRaster);
+		ID3D11VertexShader* oldVS = nullptr; ctx->VSGetShader(&oldVS, nullptr, nullptr);
+		ID3D11PixelShader* oldPS = nullptr; ctx->PSGetShader(&oldPS, nullptr, nullptr);
+		ID3D11GeometryShader* oldGS = nullptr; ctx->GSGetShader(&oldGS, nullptr, nullptr);
+		ID3D11InputLayout* oldLayout = nullptr; ctx->IAGetInputLayout(&oldLayout);
+		D3D11_PRIMITIVE_TOPOLOGY oldTopo; ctx->IAGetPrimitiveTopology(&oldTopo);
+		ID3D11ShaderResourceView* oldSRV = nullptr; ctx->PSGetShaderResources(0, 1, &oldSRV);
+		ID3D11SamplerState* oldSamp = nullptr; ctx->PSGetSamplers(0, 1, &oldSamp);
+		ID3D11Buffer* oldVSCB = nullptr; ctx->VSGetConstantBuffers(0, 1, &oldVSCB);
+		ID3D11Buffer* oldPSCB = nullptr; ctx->PSGetConstantBuffers(0, 1, &oldPSCB);
+
+		// ---- our draw ----
+		ctx->UpdateSubresource(_cb, 0, nullptr, &cb, 0, 0);
+		ctx->OMSetRenderTargets(1, &rtv, nullptr);
+		D3D11_VIEWPORT vp = { 0.0f, 0.0f, (FLOAT)targetPx.width, (FLOAT)targetPx.height, 0.0f, 1.0f };
+		ctx->RSSetViewports(1, &vp);
+		D3D11_RECT sc = { sx0, sy0, sx1, sy1 };
+		ctx->RSSetScissorRects(1, &sc);
+		FLOAT bf[4] = { 1, 1, 1, 1 };
+		ctx->OMSetBlendState(_blend, bf, 0xFFFFFFFF);
+		ctx->OMSetDepthStencilState(_depth, 0);
+		ctx->RSSetState(_raster);
+		ctx->VSSetShader(_vs, nullptr, 0);
+		ctx->PSSetShader(_ps, nullptr, 0);
+		ctx->GSSetShader(nullptr, nullptr, 0);
+		ctx->IASetInputLayout(nullptr);
+		ctx->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+		ID3D11ShaderResourceView* srv = bmp->_srv;
+		ctx->PSSetShaderResources(0, 1, &srv);
+		ID3D11SamplerState* samp = (interp == D2D1_INTERPOLATION_MODE_NEAREST_NEIGHBOR) ? _sampPoint : _sampLinear;
+		ctx->PSSetSamplers(0, 1, &samp);
+		ID3D11Buffer* cbuf = _cb;
+		ctx->VSSetConstantBuffers(0, 1, &cbuf);
+		ctx->PSSetConstantBuffers(0, 1, &cbuf);
+		ctx->Draw(4, 0);
+
+		// ---- restore ----
+		ctx->OMSetRenderTargets(1, &oldRTV, oldDSV);
+		if (oldVPCount) ctx->RSSetViewports(oldVPCount, oldVP);
+		if (oldScCount) ctx->RSSetScissorRects(oldScCount, oldSc);
+		ctx->OMSetBlendState(oldBlend, oldBf, oldMask);
+		ctx->OMSetDepthStencilState(oldDepth, oldSref);
+		ctx->RSSetState(oldRaster);
+		ctx->VSSetShader(oldVS, nullptr, 0);
+		ctx->PSSetShader(oldPS, nullptr, 0);
+		ctx->GSSetShader(oldGS, nullptr, 0);
+		ctx->IASetInputLayout(oldLayout);
+		ctx->IASetPrimitiveTopology(oldTopo);
+		ctx->PSSetShaderResources(0, 1, &oldSRV);
+		ctx->PSSetSamplers(0, 1, &oldSamp);
+		ctx->VSSetConstantBuffers(0, 1, &oldVSCB);
+		ctx->PSSetConstantBuffers(0, 1, &oldPSCB);
+		if (oldRTV) oldRTV->Release();
+		if (oldDSV) oldDSV->Release();
+		if (oldBlend) oldBlend->Release();
+		if (oldDepth) oldDepth->Release();
+		if (oldRaster) oldRaster->Release();
+		if (oldVS) oldVS->Release();
+		if (oldPS) oldPS->Release();
+		if (oldGS) oldGS->Release();
+		if (oldLayout) oldLayout->Release();
+		if (oldSRV) oldSRV->Release();
+		if (oldSamp) oldSamp->Release();
+		if (oldVSCB) oldVSCB->Release();
+		if (oldPSCB) oldPSCB->Release();
+
+#if LOGGER
+		static int s_drawCount = 0;
+		const int n = s_drawCount++;
+		if ((n < 20) || (n % 512) == 0)
+			log_debug("[DBG] [SHIM] draw #%d: %ux%u fmt=%d dst=(%.0f,%.0f-%.0f,%.0f) blend=%08X sc=(%ld,%ld-%ld,%ld)",
+				n, bmp->_width, bmp->_height, bmp->_format,
+				cb.dstRect[0], cb.dstRect[1], cb.dstRect[2], cb.dstRect[3],
+				eff->_blendColor, sx0, sy0, sx1, sy1);
+#endif
+	}
+
+	// ---------------- pure forwards: ID2D1RenderTarget ----------------
+	STDMETHOD(CreateBitmapFromWicBitmap)(IWICBitmapSource* s, CONST D2D1_BITMAP_PROPERTIES* p, ID2D1Bitmap** b) override { return FWD->CreateBitmapFromWicBitmap(s, p, b); }
+	STDMETHOD(CreateSharedBitmap)(REFIID riid, void* data, CONST D2D1_BITMAP_PROPERTIES* p, ID2D1Bitmap** b) override { return FWD->CreateSharedBitmap(riid, data, p, b); }
+	STDMETHOD(CreateBitmapBrush)(ID2D1Bitmap* b, CONST D2D1_BITMAP_BRUSH_PROPERTIES* bp, CONST D2D1_BRUSH_PROPERTIES* p, ID2D1BitmapBrush** brush) override { return FWD->CreateBitmapBrush(b, bp, p, brush); }
+	STDMETHOD(CreateSolidColorBrush)(CONST D2D1_COLOR_F* color, CONST D2D1_BRUSH_PROPERTIES* p, ID2D1SolidColorBrush** brush) override { return FWD->CreateSolidColorBrush(color, p, brush); }
+	STDMETHOD(CreateGradientStopCollection)(CONST D2D1_GRADIENT_STOP* stops, UINT32 count, D2D1_GAMMA gamma, D2D1_EXTEND_MODE mode, ID2D1GradientStopCollection** coll) override { return FWD->CreateGradientStopCollection(stops, count, gamma, mode, coll); }
+	STDMETHOD(CreateLinearGradientBrush)(CONST D2D1_LINEAR_GRADIENT_BRUSH_PROPERTIES* gp, CONST D2D1_BRUSH_PROPERTIES* p, ID2D1GradientStopCollection* coll, ID2D1LinearGradientBrush** brush) override { return FWD->CreateLinearGradientBrush(gp, p, coll, brush); }
+	STDMETHOD(CreateRadialGradientBrush)(CONST D2D1_RADIAL_GRADIENT_BRUSH_PROPERTIES* gp, CONST D2D1_BRUSH_PROPERTIES* p, ID2D1GradientStopCollection* coll, ID2D1RadialGradientBrush** brush) override { return FWD->CreateRadialGradientBrush(gp, p, coll, brush); }
+	STDMETHOD(CreateCompatibleRenderTarget)(CONST D2D1_SIZE_F* size, CONST D2D1_SIZE_U* pxSize, CONST D2D1_PIXEL_FORMAT* fmt, D2D1_COMPATIBLE_RENDER_TARGET_OPTIONS opts, ID2D1BitmapRenderTarget** rt) override { return FWD->CreateCompatibleRenderTarget(size, pxSize, fmt, opts, rt); }
+	STDMETHOD(CreateLayer)(CONST D2D1_SIZE_F* size, ID2D1Layer** layer) override { return FWD->CreateLayer(size, layer); }
+	STDMETHOD(CreateMesh)(ID2D1Mesh** mesh) override { return FWD->CreateMesh(mesh); }
+	STDMETHOD_(void, DrawLine)(D2D1_POINT_2F p0, D2D1_POINT_2F p1, ID2D1Brush* brush, FLOAT w, ID2D1StrokeStyle* ss) override { FWD->DrawLine(p0, p1, brush, w, ss); }
+	STDMETHOD_(void, DrawRectangle)(CONST D2D1_RECT_F* r, ID2D1Brush* brush, FLOAT w, ID2D1StrokeStyle* ss) override { FWD->DrawRectangle(r, brush, w, ss); }
+	STDMETHOD_(void, FillRectangle)(CONST D2D1_RECT_F* r, ID2D1Brush* brush) override { FWD->FillRectangle(r, brush); }
+	STDMETHOD_(void, DrawRoundedRectangle)(CONST D2D1_ROUNDED_RECT* r, ID2D1Brush* brush, FLOAT w, ID2D1StrokeStyle* ss) override { FWD->DrawRoundedRectangle(r, brush, w, ss); }
+	STDMETHOD_(void, FillRoundedRectangle)(CONST D2D1_ROUNDED_RECT* r, ID2D1Brush* brush) override { FWD->FillRoundedRectangle(r, brush); }
+	STDMETHOD_(void, DrawEllipse)(CONST D2D1_ELLIPSE* e, ID2D1Brush* brush, FLOAT w, ID2D1StrokeStyle* ss) override { FWD->DrawEllipse(e, brush, w, ss); }
+	STDMETHOD_(void, FillEllipse)(CONST D2D1_ELLIPSE* e, ID2D1Brush* brush) override { FWD->FillEllipse(e, brush); }
+	STDMETHOD_(void, DrawGeometry)(ID2D1Geometry* g, ID2D1Brush* brush, FLOAT w, ID2D1StrokeStyle* ss) override { FWD->DrawGeometry(g, brush, w, ss); }
+	STDMETHOD_(void, FillGeometry)(ID2D1Geometry* g, ID2D1Brush* brush, ID2D1Brush* opacity) override { FWD->FillGeometry(g, brush, opacity); }
+	STDMETHOD_(void, FillMesh)(ID2D1Mesh* mesh, ID2D1Brush* brush) override { FWD->FillMesh(mesh, brush); }
+	STDMETHOD_(void, FillOpacityMask)(ID2D1Bitmap* mask, ID2D1Brush* brush, D2D1_OPACITY_MASK_CONTENT content, CONST D2D1_RECT_F* dst, CONST D2D1_RECT_F* src) override { FWD->FillOpacityMask(mask, brush, content, dst, src); }
+	STDMETHOD_(void, DrawBitmap)(ID2D1Bitmap* bmp, CONST D2D1_RECT_F* dst, FLOAT opacity, D2D1_BITMAP_INTERPOLATION_MODE mode, CONST D2D1_RECT_F* src) override { FWD->DrawBitmap(bmp, dst, opacity, mode, src); }
+	STDMETHOD_(void, DrawText)(CONST WCHAR* text, UINT32 len, IDWriteTextFormat* fmt, CONST D2D1_RECT_F* rect, ID2D1Brush* brush, D2D1_DRAW_TEXT_OPTIONS opts, DWRITE_MEASURING_MODE mm) override { FWD->DrawText(text, len, fmt, rect, brush, opts, mm); }
+	STDMETHOD_(void, DrawTextLayout)(D2D1_POINT_2F origin, IDWriteTextLayout* layout, ID2D1Brush* brush, D2D1_DRAW_TEXT_OPTIONS opts) override { FWD->DrawTextLayout(origin, layout, brush, opts); }
+	STDMETHOD_(void, DrawGlyphRun)(D2D1_POINT_2F origin, CONST DWRITE_GLYPH_RUN* run, ID2D1Brush* brush, DWRITE_MEASURING_MODE mm) override { FWD->DrawGlyphRun(origin, run, brush, mm); }
+	STDMETHOD_(void, SetTransform)(CONST D2D1_MATRIX_3X2_F* m) override { FWD->SetTransform(m); }
+	STDMETHOD_(void, GetTransform)(D2D1_MATRIX_3X2_F* m) const override { FWD->GetTransform(m); }
+	STDMETHOD_(void, SetAntialiasMode)(D2D1_ANTIALIAS_MODE mode) override { FWD->SetAntialiasMode(mode); }
+	STDMETHOD_(D2D1_ANTIALIAS_MODE, GetAntialiasMode)() const override { return FWD->GetAntialiasMode(); }
+	STDMETHOD_(void, SetTextAntialiasMode)(D2D1_TEXT_ANTIALIAS_MODE mode) override { FWD->SetTextAntialiasMode(mode); }
+	STDMETHOD_(D2D1_TEXT_ANTIALIAS_MODE, GetTextAntialiasMode)() const override { return FWD->GetTextAntialiasMode(); }
+	STDMETHOD_(void, SetTextRenderingParams)(IDWriteRenderingParams* params) override { FWD->SetTextRenderingParams(params); }
+	STDMETHOD_(void, GetTextRenderingParams)(IDWriteRenderingParams** params) const override { FWD->GetTextRenderingParams(params); }
+	STDMETHOD_(void, SetTags)(D2D1_TAG tag1, D2D1_TAG tag2) override { FWD->SetTags(tag1, tag2); }
+	STDMETHOD_(void, GetTags)(D2D1_TAG* tag1, D2D1_TAG* tag2) const override { FWD->GetTags(tag1, tag2); }
+	STDMETHOD_(void, PushLayer)(CONST D2D1_LAYER_PARAMETERS* params, ID2D1Layer* layer) override { FWD->PushLayer(params, layer); }
+	STDMETHOD_(void, PopLayer)() override { FWD->PopLayer(); }
+	STDMETHOD(Flush)(D2D1_TAG* tag1, D2D1_TAG* tag2) override { return FWD->Flush(tag1, tag2); }
+	STDMETHOD_(void, SaveDrawingState)(ID2D1DrawingStateBlock* block) const override { FWD->SaveDrawingState(block); }
+	STDMETHOD_(void, RestoreDrawingState)(ID2D1DrawingStateBlock* block) override { FWD->RestoreDrawingState(block); }
+	STDMETHOD_(void, Clear)(CONST D2D1_COLOR_F* color) override { FWD->Clear(color); }
+	STDMETHOD_(void, BeginDraw)() override { FWD->BeginDraw(); }
+	STDMETHOD(EndDraw)(D2D1_TAG* tag1, D2D1_TAG* tag2) override { return FWD->EndDraw(tag1, tag2); }
+	STDMETHOD_(D2D1_PIXEL_FORMAT, GetPixelFormat)() const override { return FWD->GetPixelFormat(); }
+	STDMETHOD_(void, SetDpi)(FLOAT x, FLOAT y) override { FWD->SetDpi(x, y); }
+	STDMETHOD_(void, GetDpi)(FLOAT* x, FLOAT* y) const override { FWD->GetDpi(x, y); }
+	STDMETHOD_(D2D1_SIZE_F, GetSize)() const override { return FWD->GetSize(); }
+	STDMETHOD_(D2D1_SIZE_U, GetPixelSize)() const override { return FWD->GetPixelSize(); }
+	STDMETHOD_(UINT32, GetMaximumBitmapSize)() const override { return FWD->GetMaximumBitmapSize(); }
+	STDMETHOD_(BOOL, IsSupported)(CONST D2D1_RENDER_TARGET_PROPERTIES* props) const override { return FWD->IsSupported(props); }
+
+	// ---------------- pure forwards: ID2D1DeviceContext ----------------
+	STDMETHOD(CreateBitmap)(D2D1_SIZE_U size, CONST void* data, UINT32 pitch, CONST D2D1_BITMAP_PROPERTIES1* props, ID2D1Bitmap1** bmp) override { return FWD->CreateBitmap(size, data, pitch, props, bmp); }
+	STDMETHOD(CreateBitmapFromWicBitmap)(IWICBitmapSource* src, CONST D2D1_BITMAP_PROPERTIES1* props, ID2D1Bitmap1** bmp) override { return FWD->CreateBitmapFromWicBitmap(src, props, bmp); }
+	STDMETHOD(CreateColorContext)(D2D1_COLOR_SPACE space, CONST BYTE* profile, UINT32 size, ID2D1ColorContext** cc) override { return FWD->CreateColorContext(space, profile, size, cc); }
+	STDMETHOD(CreateColorContextFromFilename)(PCWSTR filename, ID2D1ColorContext** cc) override { return FWD->CreateColorContextFromFilename(filename, cc); }
+	STDMETHOD(CreateColorContextFromWicColorContext)(IWICColorContext* wic, ID2D1ColorContext** cc) override { return FWD->CreateColorContextFromWicColorContext(wic, cc); }
+	STDMETHOD(CreateBitmapFromDxgiSurface)(IDXGISurface* surface, CONST D2D1_BITMAP_PROPERTIES1* props, ID2D1Bitmap1** bmp) override { return FWD->CreateBitmapFromDxgiSurface(surface, props, bmp); }
+	STDMETHOD(CreateGradientStopCollection)(CONST D2D1_GRADIENT_STOP* stops, UINT32 count, D2D1_COLOR_SPACE pre, D2D1_COLOR_SPACE post, D2D1_BUFFER_PRECISION prec, D2D1_EXTEND_MODE mode, D2D1_COLOR_INTERPOLATION_MODE cim, ID2D1GradientStopCollection1** coll) override { return FWD->CreateGradientStopCollection(stops, count, pre, post, prec, mode, cim, coll); }
+	STDMETHOD(CreateImageBrush)(ID2D1Image* image, CONST D2D1_IMAGE_BRUSH_PROPERTIES* ip, CONST D2D1_BRUSH_PROPERTIES* bp, ID2D1ImageBrush** brush) override { return FWD->CreateImageBrush(image, ip, bp, brush); }
+	STDMETHOD(CreateBitmapBrush)(ID2D1Bitmap* bmp, CONST D2D1_BITMAP_BRUSH_PROPERTIES1* bp, CONST D2D1_BRUSH_PROPERTIES* p, ID2D1BitmapBrush1** brush) override { return FWD->CreateBitmapBrush(bmp, bp, p, brush); }
+	STDMETHOD(CreateCommandList)(ID2D1CommandList** list) override { return FWD->CreateCommandList(list); }
+	STDMETHOD_(BOOL, IsDxgiFormatSupported)(DXGI_FORMAT fmt) const override { return FWD->IsDxgiFormatSupported(fmt); }
+	STDMETHOD_(BOOL, IsBufferPrecisionSupported)(D2D1_BUFFER_PRECISION prec) const override { return FWD->IsBufferPrecisionSupported(prec); }
+	STDMETHOD(GetImageLocalBounds)(ID2D1Image* image, D2D1_RECT_F* bounds) const override { return FWD->GetImageLocalBounds(image, bounds); }
+	STDMETHOD(GetImageWorldBounds)(ID2D1Image* image, D2D1_RECT_F* bounds) const override { return FWD->GetImageWorldBounds(image, bounds); }
+	STDMETHOD(GetGlyphRunWorldBounds)(D2D1_POINT_2F origin, CONST DWRITE_GLYPH_RUN* run, DWRITE_MEASURING_MODE mm, D2D1_RECT_F* bounds) const override { return FWD->GetGlyphRunWorldBounds(origin, run, mm, bounds); }
+	STDMETHOD_(void, GetDevice)(ID2D1Device** device) const override { FWD->GetDevice(device); }
+	STDMETHOD_(void, SetTarget)(ID2D1Image* image) override { FWD->SetTarget(image); }
+	STDMETHOD_(void, GetTarget)(ID2D1Image** image) const override { FWD->GetTarget(image); }
+	STDMETHOD_(void, SetRenderingControls)(CONST D2D1_RENDERING_CONTROLS* controls) override { FWD->SetRenderingControls(controls); }
+	STDMETHOD_(void, GetRenderingControls)(D2D1_RENDERING_CONTROLS* controls) const override { FWD->GetRenderingControls(controls); }
+	STDMETHOD_(void, SetPrimitiveBlend)(D2D1_PRIMITIVE_BLEND blend) override { FWD->SetPrimitiveBlend(blend); }
+	STDMETHOD_(D2D1_PRIMITIVE_BLEND, GetPrimitiveBlend)() const override { return FWD->GetPrimitiveBlend(); }
+	STDMETHOD_(void, SetUnitMode)(D2D1_UNIT_MODE mode) override { FWD->SetUnitMode(mode); }
+	STDMETHOD_(D2D1_UNIT_MODE, GetUnitMode)() const override { return FWD->GetUnitMode(); }
+	STDMETHOD_(void, DrawGlyphRun)(D2D1_POINT_2F origin, CONST DWRITE_GLYPH_RUN* run, CONST DWRITE_GLYPH_RUN_DESCRIPTION* desc, ID2D1Brush* brush, DWRITE_MEASURING_MODE mm) override { FWD->DrawGlyphRun(origin, run, desc, brush, mm); }
+	STDMETHOD_(void, DrawGdiMetafile)(ID2D1GdiMetafile* metafile, CONST D2D1_POINT_2F* offset) override { FWD->DrawGdiMetafile(metafile, offset); }
+	STDMETHOD_(void, DrawBitmap)(ID2D1Bitmap* bmp, CONST D2D1_RECT_F* dst, FLOAT opacity, D2D1_INTERPOLATION_MODE mode, CONST D2D1_RECT_F* src, CONST D2D1_MATRIX_4X4_F* xform) override { FWD->DrawBitmap(bmp, dst, opacity, mode, src, xform); }
+	STDMETHOD_(void, PushLayer)(CONST D2D1_LAYER_PARAMETERS1* params, ID2D1Layer* layer) override { FWD->PushLayer(params, layer); }
+	STDMETHOD(InvalidateEffectInputRectangle)(ID2D1Effect* effect, UINT32 input, CONST D2D1_RECT_F* rect) override { return FWD->InvalidateEffectInputRectangle(effect, input, rect); }
+	STDMETHOD(GetEffectInvalidRectangleCount)(ID2D1Effect* effect, UINT32* count) override { return FWD->GetEffectInvalidRectangleCount(effect, count); }
+	STDMETHOD(GetEffectInvalidRectangles)(ID2D1Effect* effect, D2D1_RECT_F* rects, UINT32 count) override { return FWD->GetEffectInvalidRectangles(effect, rects, count); }
+	STDMETHOD(GetEffectRequiredInputRectangles)(ID2D1Effect* effect, CONST D2D1_RECT_F* output, CONST D2D1_EFFECT_INPUT_DESCRIPTION* descs, D2D1_RECT_F* rects, UINT32 count) override { return FWD->GetEffectRequiredInputRectangles(effect, output, descs, rects, count); }
+	STDMETHOD_(void, FillOpacityMask)(ID2D1Bitmap* mask, ID2D1Brush* brush, CONST D2D1_RECT_F* dst, CONST D2D1_RECT_F* src) override { FWD->FillOpacityMask(mask, brush, dst, src); }
+};
+
+// ===========================================================================
+// Movie presentation (plan magical-jumping-pascal B1).
+//
+// TgSmush's MF pipeline delivers 2560x1440@30fps BGRA frames into shared
+// memory and presents via GDI StretchDIBits -- which runs in 0.4ms but the
+// visible result is throttled to ~5-10fps by wine's GDI window-surface ->
+// X11 flush cadence. This renders the shared-mem frame as a letterboxed
+// D3D11 quad (reusing the shim's BitmapEffect shaders with blend=0 =
+// passthrough) and presents through the game's DXVK swapchain instead.
+// Called from PrimarySurface::UpdateOverlayDisplay (non-VR branch) after the
+// frame has been uploaded into resources->_tgSmushTex.
+// ===========================================================================
+
+bool WineShim_TgSmushMoviePlaying()
+{
+	static int s_lastIndex = -1;
+	static DWORD s_lastAdvance = 0;
+
+	if (g_pSharedDataTgSmush == nullptr || g_pSharedDataTgSmush->videoFrameIndex <= 0)
+	{
+		s_lastIndex = -1;   // clean end-of-movie: rearm for the next one
+		return false;
+	}
+
+	// Staleness guard: TgSmush clears videoFrameIndex when playback ends, but
+	// if the player dies -- or its MF session never delivers the shutdown
+	// callback (seen on wine-staging) -- the flag stays set forever and every
+	// Flip would be dropped, freezing the screen on the last frame. Treat the
+	// movie as over when the index stops advancing.
+	const DWORD now = GetTickCount();
+	if (g_pSharedDataTgSmush->videoFrameIndex != s_lastIndex)
+	{
+		s_lastIndex = g_pSharedDataTgSmush->videoFrameIndex;
+		s_lastAdvance = now;
+		return true;
+	}
+	return (now - s_lastAdvance) < 2000;
+}
+
+bool WineShim_PresentMovieFrame(DeviceResources* res)
+{
+	struct MovieCB
+	{
+		float dstRect[4];
+		float uvRect[4];
+		float xformRow0[4];
+		float xformRow1[4];
+		float blendColor[4];
+	};
+
+	static bool s_tried = false, s_ok = false;
+	static ComPtr<ID3D11VertexShader> s_vs;
+	static ComPtr<ID3D11PixelShader> s_ps;
+	static ComPtr<ID3D11Buffer> s_cb;
+	static ComPtr<ID3D11BlendState> s_blendOff;
+	static ComPtr<ID3D11RasterizerState> s_raster;
+	static ComPtr<ID3D11DepthStencilState> s_depthOff;
+	static ComPtr<ID3D11SamplerState> s_sampLinear;
+	static ID3D11Texture2D* s_srvTex = nullptr;
+	static ComPtr<ID3D11ShaderResourceView> s_srv;
+
+	ID3D11Device* dev = res->_d3dDevice;
+	ID3D11DeviceContext* ctx = res->_d3dDeviceContext;
+	if (!dev || !ctx || !res->_tgSmushTex || !res->_renderTargetView ||
+		!res->_backBuffer || !res->_offscreenBuffer || !res->_swapChain)
+		return false;
+
+	if (!s_tried)
+	{
+		s_tried = true;
+		HRESULT hr = dev->CreateVertexShader(g_ShimBitmapVS, sizeof(g_ShimBitmapVS), nullptr, &s_vs);
+		if (SUCCEEDED(hr)) hr = dev->CreatePixelShader(g_ShimBitmapPS, sizeof(g_ShimBitmapPS), nullptr, &s_ps);
+		if (SUCCEEDED(hr))
+		{
+			D3D11_BUFFER_DESC bd = {};
+			bd.ByteWidth = sizeof(MovieCB);
+			bd.Usage = D3D11_USAGE_DEFAULT;
+			bd.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+			hr = dev->CreateBuffer(&bd, nullptr, &s_cb);
+		}
+		if (SUCCEEDED(hr))
+		{
+			D3D11_BLEND_DESC bd = {}; // opaque: blending off, all channels
+			bd.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
+			hr = dev->CreateBlendState(&bd, &s_blendOff);
+		}
+		if (SUCCEEDED(hr))
+		{
+			D3D11_RASTERIZER_DESC rd = {};
+			rd.FillMode = D3D11_FILL_SOLID;
+			rd.CullMode = D3D11_CULL_NONE;
+			rd.DepthClipEnable = TRUE;
+			hr = dev->CreateRasterizerState(&rd, &s_raster);
+		}
+		if (SUCCEEDED(hr))
+		{
+			D3D11_DEPTH_STENCIL_DESC dd = {};
+			hr = dev->CreateDepthStencilState(&dd, &s_depthOff);
+		}
+		if (SUCCEEDED(hr))
+		{
+			D3D11_SAMPLER_DESC sd = {};
+			sd.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+			sd.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
+			sd.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
+			sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+			sd.MaxLOD = D3D11_FLOAT32_MAX;
+			hr = dev->CreateSamplerState(&sd, &s_sampLinear);
+		}
+		s_ok = SUCCEEDED(hr);
+		log_debug("[DBG] [SHIM] movie-present pipeline init: %s (0x%08X)", s_ok ? "OK" : "FAILED", hr);
+	}
+	if (!s_ok) return false;
+
+	if (s_srvTex != (ID3D11Texture2D*)res->_tgSmushTex)
+	{
+		s_srv.Release();
+		if (FAILED(dev->CreateShaderResourceView(res->_tgSmushTex, nullptr, &s_srv)))
+		{
+			log_debug("[DBG] [SHIM] movie-present: CreateShaderResourceView FAILED");
+			s_srvTex = nullptr;
+			return false;
+		}
+		s_srvTex = res->_tgSmushTex;
+	}
+
+	const float bw = (float)res->_backbufferWidth;
+	const float bh = (float)res->_backbufferHeight;
+	const float vw = (float)res->_tgSmushTexWidth;
+	const float vh = (float)res->_tgSmushTexHeight;
+	if (bw <= 0 || bh <= 0 || vw <= 0 || vh <= 0) return false;
+
+	// letterbox, aspect preserved (TgSmush.cfg PreserveAspectRatio behavior)
+	const float scale = (bw / vw < bh / vh) ? bw / vw : bh / vh;
+	const float dw = vw * scale, dh = vh * scale;
+	const float dx = (bw - dw) * 0.5f, dy = (bh - dh) * 0.5f;
+
+	MovieCB cb;
+	cb.dstRect[0] = dx; cb.dstRect[1] = dy;
+	cb.dstRect[2] = dx + dw; cb.dstRect[3] = dy + dh;
+	cb.uvRect[0] = 0.0f; cb.uvRect[1] = 0.0f; cb.uvRect[2] = 1.0f; cb.uvRect[3] = 1.0f;
+	cb.xformRow0[0] = 1.0f; cb.xformRow0[1] = 0.0f; cb.xformRow0[2] = 0.0f; cb.xformRow0[3] = 1.0f;
+	cb.xformRow1[0] = 0.0f; cb.xformRow1[1] = 0.0f; cb.xformRow1[2] = bw; cb.xformRow1[3] = bh;
+	cb.blendColor[0] = cb.blendColor[1] = cb.blendColor[2] = cb.blendColor[3] = 0.0f;
+
+	// ---- save the state we touch ----
+	ID3D11RenderTargetView* oldRTV = nullptr; ID3D11DepthStencilView* oldDSV = nullptr;
+	ctx->OMGetRenderTargets(1, &oldRTV, &oldDSV);
+	D3D11_VIEWPORT oldVP[D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE];
+	UINT oldVPCount = D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE;
+	ctx->RSGetViewports(&oldVPCount, oldVP);
+	ID3D11BlendState* oldBlend = nullptr; FLOAT oldBf[4]; UINT oldMask = 0;
+	ctx->OMGetBlendState(&oldBlend, oldBf, &oldMask);
+	ID3D11DepthStencilState* oldDepth = nullptr; UINT oldSref = 0;
+	ctx->OMGetDepthStencilState(&oldDepth, &oldSref);
+	ID3D11RasterizerState* oldRaster = nullptr;
+	ctx->RSGetState(&oldRaster);
+	ID3D11VertexShader* oldVS = nullptr; ctx->VSGetShader(&oldVS, nullptr, nullptr);
+	ID3D11PixelShader* oldPS = nullptr; ctx->PSGetShader(&oldPS, nullptr, nullptr);
+	ID3D11GeometryShader* oldGS = nullptr; ctx->GSGetShader(&oldGS, nullptr, nullptr);
+	ID3D11InputLayout* oldLayout = nullptr; ctx->IAGetInputLayout(&oldLayout);
+	D3D11_PRIMITIVE_TOPOLOGY oldTopo; ctx->IAGetPrimitiveTopology(&oldTopo);
+	ID3D11ShaderResourceView* oldSRV = nullptr; ctx->PSGetShaderResources(0, 1, &oldSRV);
+	ID3D11SamplerState* oldSamp = nullptr; ctx->PSGetSamplers(0, 1, &oldSamp);
+	ID3D11Buffer* oldVSCB = nullptr; ctx->VSGetConstantBuffers(0, 1, &oldVSCB);
+	ID3D11Buffer* oldPSCB = nullptr; ctx->PSGetConstantBuffers(0, 1, &oldPSCB);
+
+	// ---- draw ----
+	ctx->UpdateSubresource(s_cb, 0, nullptr, &cb, 0, 0);
+	ID3D11RenderTargetView* rtv = res->_renderTargetView;
+	FLOAT black[4] = { 0, 0, 0, 1 };
+	ctx->ClearRenderTargetView(rtv, black);
+	ctx->OMSetRenderTargets(1, &rtv, nullptr);
+	D3D11_VIEWPORT vp = { 0.0f, 0.0f, bw, bh, 0.0f, 1.0f };
+	ctx->RSSetViewports(1, &vp);
+	FLOAT bf[4] = { 1, 1, 1, 1 };
+	ctx->OMSetBlendState(s_blendOff, bf, 0xFFFFFFFF);
+	ctx->OMSetDepthStencilState(s_depthOff, 0);
+	ctx->RSSetState(s_raster);
+	ctx->VSSetShader(s_vs, nullptr, 0);
+	ctx->PSSetShader(s_ps, nullptr, 0);
+	ctx->GSSetShader(nullptr, nullptr, 0);
+	ctx->IASetInputLayout(nullptr);
+	ctx->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+	ID3D11ShaderResourceView* srv = s_srv;
+	ctx->PSSetShaderResources(0, 1, &srv);
+	ID3D11SamplerState* samp = s_sampLinear;
+	ctx->PSSetSamplers(0, 1, &samp);
+	ID3D11Buffer* cbuf = s_cb;
+	ctx->VSSetConstantBuffers(0, 1, &cbuf);
+	ctx->PSSetConstantBuffers(0, 1, &cbuf);
+	ctx->Draw(4, 0);
+
+	// ---- to the swapchain ----
+	ctx->ResolveSubresource(res->_backBuffer, 0, res->_offscreenBuffer, 0, BACKBUFFER_FORMAT);
+	res->_swapChain->Present(1, 0);
+
+	// ---- restore ----
+	ctx->OMSetRenderTargets(1, &oldRTV, oldDSV);
+	if (oldVPCount) ctx->RSSetViewports(oldVPCount, oldVP);
+	ctx->OMSetBlendState(oldBlend, oldBf, oldMask);
+	ctx->OMSetDepthStencilState(oldDepth, oldSref);
+	ctx->RSSetState(oldRaster);
+	ctx->VSSetShader(oldVS, nullptr, 0);
+	ctx->PSSetShader(oldPS, nullptr, 0);
+	ctx->GSSetShader(oldGS, nullptr, 0);
+	ctx->IASetInputLayout(oldLayout);
+	ctx->IASetPrimitiveTopology(oldTopo);
+	ctx->PSSetShaderResources(0, 1, &oldSRV);
+	ctx->PSSetSamplers(0, 1, &oldSamp);
+	ctx->VSSetConstantBuffers(0, 1, &oldVSCB);
+	ctx->PSSetConstantBuffers(0, 1, &oldPSCB);
+	if (oldRTV) oldRTV->Release();
+	if (oldDSV) oldDSV->Release();
+	if (oldBlend) oldBlend->Release();
+	if (oldDepth) oldDepth->Release();
+	if (oldRaster) oldRaster->Release();
+	if (oldVS) oldVS->Release();
+	if (oldPS) oldPS->Release();
+	if (oldGS) oldGS->Release();
+	if (oldLayout) oldLayout->Release();
+	if (oldSRV) oldSRV->Release();
+	if (oldSamp) oldSamp->Release();
+	if (oldVSCB) oldVSCB->Release();
+	if (oldPSCB) oldPSCB->Release();
+
+#if LOGGER
+	static int s_presented = 0;
+	const int n = s_presented++;
+	if ((n < 5) || (n % 300) == 0)
+		log_debug("[DBG] [SHIM] movie present #%d: %dx%d -> (%.0f,%.0f-%.0f,%.0f) of %dx%d",
+			n, res->_tgSmushTexWidth, res->_tgSmushTexHeight, dx, dy, dx + dw, dy + dh,
+			(int)bw, (int)bh);
+#endif
+	return true;
+}
+
+// ===========================================================================
+// Cache + entry point
+// ===========================================================================
+bool ShimContext::s_shimMode = false;
+
+static ShimContext* g_shimContext = nullptr;
+static ID2D1RenderTarget* g_shimRealRT = nullptr;
+
+// True when running under wine (any version). On real Windows this is false
+// and the shim is never instantiated -- hook_concourse gets the raw render
+// target, making this change a literal no-op for Windows users. Under wine
+// the wrapper still tries every real d2d call first and only falls back when
+// the call fails, so a wine release that implements custom effects
+// automatically gets its native path back.
+static bool WineShim_RunningUnderWine()
+{
+	static int s_isWine = -1;
+	if (s_isWine < 0)
+	{
+		HMODULE ntdll = GetModuleHandleA("ntdll.dll");
+		s_isWine = (ntdll != nullptr &&
+			GetProcAddress(ntdll, "wine_get_version") != nullptr) ? 1 : 0;
+	}
+	return s_isWine == 1;
+}
+
+ID2D1RenderTarget* WineShim_GetRenderTarget(DeviceResources* resources)
+{
+	ID2D1RenderTarget* real = resources->_d2d1OffscreenRenderTarget;
+	if (real == nullptr)
+		return nullptr;
+
+	if (!WineShim_RunningUnderWine())
+		return real;
+
+	if (g_shimContext != nullptr && g_shimRealRT == real)
+		return g_shimContext;
+
+	// underlying target changed (resize/recreate): drop the old shim
+	if (g_shimContext != nullptr)
+	{
+		g_shimContext->Release();
+		g_shimContext = nullptr;
+		g_shimRealRT = nullptr;
+	}
+
+	ComPtr<ID2D1DeviceContext> realDC;
+	if (FAILED(real->QueryInterface(IID_PPV_ARGS(&realDC))))
+	{
+		log_debug("[DBG] [SHIM] QI(ID2D1DeviceContext) failed; passing real RT through");
+		return real;
+	}
+
+	g_shimContext = new ShimContext(resources, real, realDC);
+	g_shimRealRT = real;
+	log_debug("[DBG] [SHIM] wrapped d2d render target %p", real);
+	return g_shimContext;
+}

--- a/impl11/ddraw/WineD2DEffectShim.h
+++ b/impl11/ddraw/WineD2DEffectShim.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Peter Soetens
+// Licensed under the MIT license. See LICENSE.txt
+//
+// WineD2DEffectShim
+//
+// hook_concourse renders the whole HD concourse through a custom Direct2D
+// effect (BitmapEffect). wine-8's d2d1 returns E_NOTIMPL from
+// ID2D1DeviceContext::CreateEffect for custom registered effects; the hook
+// ignores the hr and silently skips every draw -> the HD concourse renders
+// black on Linux/wine.
+//
+// This shim wraps the ID2D1RenderTarget that ddraw hands to hook_concourse
+// via SurfaceDC (GetDC) -- ONLY when running under wine; on Windows the raw
+// render target is returned and none of this code is active. Under wine the
+// wrapper forwards everything to the real d2d objects, except:
+//   * CreateEffect(CLSID_BitmapEffect): tries the REAL call first; only when
+//     that fails (wine) it returns a shim effect object, so a wine release
+//     that implements custom effects gets its native path back automatically.
+//   * CreateBitmap (once in shim mode): wraps a plain D3D11 texture
+//     (B8G8R8A8 or BC3 -- BC3 is native to D3D11, dodging a second wine-d2d
+//     gap) instead of a d2d bitmap.
+//   * DrawImage(shim effect): Flush()es the real render target (preserves
+//     draw ordering), then renders the bitmap as a native D3D11 textured
+//     quad with a pixel shader replicating BitmapEffect's math
+//     (Release/ShimBitmap{VS,PS}.h, source shaders/ShimBitmap{VS,PS}.hlsl).
+#pragma once
+
+#include "DeviceResources.h"
+
+// Returns the render target to put into SurfaceDC::d2d1RenderTarget.
+// On Windows: returns resources->_d2d1OffscreenRenderTarget unchanged.
+// Under wine: wraps it; caches the wrapper and recreates it automatically
+// when the underlying target changes (resize). Returns the raw target
+// unwrapped only if wrapper creation fails.
+ID2D1RenderTarget* WineShim_GetRenderTarget(DeviceResources* resources);
+
+// True while TgSmush is actively delivering movie frames into shared memory:
+// videoFrameIndex > 0 AND the index advanced within the last ~2 seconds.
+// The staleness check guards against a TgSmush that died (or whose MF
+// session never delivered the shutdown callback, as seen on wine-staging)
+// without clearing the flag -- otherwise every Flip would be dropped
+// forever, freezing the screen on the last presented frame.
+bool WineShim_TgSmushMoviePlaying();
+
+// Presents the current TgSmush shared-memory movie frame as a letterboxed
+// quad through the D3D11 swapchain (gated by ddraw.cfg
+// TgSmushSwapchainPresentEnabled; pairs with TgSmush.cfg MFD3DPresent=1).
+bool WineShim_PresentMovieFrame(DeviceResources* resources);

--- a/impl11/ddraw/XwaD3dRendererHook.cpp
+++ b/impl11/ddraw/XwaD3dRendererHook.cpp
@@ -1988,7 +1988,7 @@ void ParseOptFaceGrouping(int meshKey, OptNode* outerNode)
 					// g_FGToLODMap is used to coalesce vertices that belong on the same LOD when building the BVH (RT)
 					g_FGToLODMap[faceGroupID] = lodID;
 
-					auto& it = g_meshToFGMap.find(meshKey);
+					auto it = g_meshToFGMap.find(meshKey);
 					if (it == g_meshToFGMap.end())
 					{
 						// Initialize this entry
@@ -2081,7 +2081,7 @@ void D3dRendererOptNodeHook(OptHeader* optHeader, int nodeIndex, SceneCompData* 
 				{
 					//int numVertices = subnode->Parameter1;
 					int meshKey = subnode->Parameter2;
-					auto& it = g_MeshTagMap.find(meshKey);
+					auto it = g_MeshTagMap.find(meshKey);
 					if (it == g_MeshTagMap.end())
 					{
 						// DEBUG: Dump the node hierarchy when a hotkey is pressed

--- a/impl11/ddraw/config.cpp
+++ b/impl11/ddraw/config.cpp
@@ -83,6 +83,7 @@ Config::Config()
 	this->FlipDATImages = false;
 
 	this->HDConcourseEnabled = false;
+	this->TgSmushSwapchainPresentEnabled = false;
 
 	this->ProjectionParameterA = 32.0f;
 	this->ProjectionParameterB = 256.0f;
@@ -290,6 +291,10 @@ Config::Config()
 			else if (name == "HDConcourseEnabled")
 			{
 				this->HDConcourseEnabled = stoi(value) != 0;
+			}
+			else if (name == "TgSmushSwapchainPresentEnabled")
+			{
+				this->TgSmushSwapchainPresentEnabled = stoi(value) != 0;
 			}
 			else if (name == "ProjectionParameterA")
 			{

--- a/impl11/ddraw/config.h
+++ b/impl11/ddraw/config.h
@@ -61,6 +61,12 @@ public:
 
 	bool HDConcourseEnabled;
 
+	// Present TgSmush shared-memory movie frames as a letterboxed quad
+	// through the D3D11 swapchain (pairs with TgSmush.cfg MFD3DPresent=1;
+	// for wine, where the GDI window present is throttled). Default off:
+	// stock TgSmush presents into its own window.
+	bool TgSmushSwapchainPresentEnabled;
+
 	float ProjectionParameterA;
 	float ProjectionParameterB;
 	float ProjectionParameterC;

--- a/impl11/ddraw/ddraw.cpp
+++ b/impl11/ddraw/ddraw.cpp
@@ -39,53 +39,50 @@ public:
 
 static LibraryWrapper ddraw("ddraw.dll");
 
+// Linux/clang-cl build fix (see ../../../linux-build-fixes.patch): clang forbids
+// non-ASM statements (the guarded local-static init) in naked functions, so the
+// GetProcAddress statics are hoisted to file scope (runs at DLL attach, ordered
+// after `ddraw` above in this TU) - behavior-equivalent to the lazy original.
+static void(*AcquireDDThreadLock_proc)() = (void(*)())GetProcAddress(ddraw._module, "AcquireDDThreadLock");
 extern "C" __declspec(naked) void AcquireDDThreadLock()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "AcquireDDThreadLock");
-
-	__asm jmp ddraw_proc;
+	__asm jmp AcquireDDThreadLock_proc;
 }
 
+static void(*CompleteCreateSysmemSurface_proc)() = (void(*)())GetProcAddress(ddraw._module, "CompleteCreateSysmemSurface");
 extern "C" __declspec(naked) void CompleteCreateSysmemSurface()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "CompleteCreateSysmemSurface");
-
-	__asm jmp ddraw_proc;
+	__asm jmp CompleteCreateSysmemSurface_proc;
 }
 
+static void(*D3DParseUnknownCommand_proc)() = (void(*)())GetProcAddress(ddraw._module, "D3DParseUnknownCommand");
 extern "C" __declspec(naked) void D3DParseUnknownCommand()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "D3DParseUnknownCommand");
-
-	__asm jmp ddraw_proc;
+	__asm jmp D3DParseUnknownCommand_proc;
 }
 
+static void(*DDGetAttachedSurfaceLcl_proc)() = (void(*)())GetProcAddress(ddraw._module, "DDGetAttachedSurfaceLcl");
 extern "C" __declspec(naked) void DDGetAttachedSurfaceLcl()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "DDGetAttachedSurfaceLcl");
-
-	__asm jmp ddraw_proc;
+	__asm jmp DDGetAttachedSurfaceLcl_proc;
 }
 
+static void(*DDInternalLock_proc)() = (void(*)())GetProcAddress(ddraw._module, "DDInternalLock");
 extern "C" __declspec(naked) void DDInternalLock()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "DDInternalLock");
-
-	__asm jmp ddraw_proc;
+	__asm jmp DDInternalLock_proc;
 }
 
+static void(*DDInternalUnlock_proc)() = (void(*)())GetProcAddress(ddraw._module, "DDInternalUnlock");
 extern "C" __declspec(naked) void DDInternalUnlock()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "DDInternalUnlock");
-
-	__asm jmp ddraw_proc;
+	__asm jmp DDInternalUnlock_proc;
 }
 
+static void(*DSoundHelp_proc)() = (void(*)())GetProcAddress(ddraw._module, "DSoundHelp");
 extern "C" __declspec(naked) void DSoundHelp()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "DSoundHelp");
-
-	__asm jmp ddraw_proc;
+	__asm jmp DSoundHelp_proc;
 }
 
 extern "C" HRESULT WINAPI DirectDrawCreate(
@@ -294,44 +291,38 @@ extern "C" HRESULT WINAPI DirectDrawEnumerateW(
 	return ddraw_proc(lpCallback, lpContext);
 }
 
+static void(*GetDDSurfaceLocal_proc)() = (void(*)())GetProcAddress(ddraw._module, "GetDDSurfaceLocal");
 extern "C" __declspec(naked) void GetDDSurfaceLocal()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "GetDDSurfaceLocal");
-
-	__asm jmp ddraw_proc;
+	__asm jmp GetDDSurfaceLocal_proc;
 }
 
+static void(*GetOLEThunkData_proc)() = (void(*)())GetProcAddress(ddraw._module, "GetOLEThunkData");
 extern "C" __declspec(naked) void GetOLEThunkData()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "GetOLEThunkData");
-
-	__asm jmp ddraw_proc;
+	__asm jmp GetOLEThunkData_proc;
 }
 
+static void(*GetSurfaceFromDC_proc)() = (void(*)())GetProcAddress(ddraw._module, "GetSurfaceFromDC");
 extern "C" __declspec(naked) void GetSurfaceFromDC()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "GetSurfaceFromDC");
-
-	__asm jmp ddraw_proc;
+	__asm jmp GetSurfaceFromDC_proc;
 }
 
+static void(*RegisterSpecialCase_proc)() = (void(*)())GetProcAddress(ddraw._module, "RegisterSpecialCase");
 extern "C" __declspec(naked) void RegisterSpecialCase()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "RegisterSpecialCase");
-
-	__asm jmp ddraw_proc;
+	__asm jmp RegisterSpecialCase_proc;
 }
 
+static void(*ReleaseDDThreadLock_proc)() = (void(*)())GetProcAddress(ddraw._module, "ReleaseDDThreadLock");
 extern "C" __declspec(naked) void ReleaseDDThreadLock()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "ReleaseDDThreadLock");
-
-	__asm jmp ddraw_proc;
+	__asm jmp ReleaseDDThreadLock_proc;
 }
 
+static void(*SetAppCompatData_proc)() = (void(*)())GetProcAddress(ddraw._module, "SetAppCompatData");
 extern "C" __declspec(naked) void SetAppCompatData()
 {
-	static void(*ddraw_proc)() = (void(*)())GetProcAddress(ddraw._module, "SetAppCompatData");
-
-	__asm jmp ddraw_proc;
+	__asm jmp SetAppCompatData_proc;
 }

--- a/impl11/ddraw/utils.cpp
+++ b/impl11/ddraw/utils.cpp
@@ -19,7 +19,7 @@
 using namespace Gdiplus;
 
 short DisplayCenteredText(char* str, int font_size_index, short y, uint32_t color);
-void DisplayTimedMessage(uint32_t seconds, int row, char* msg);
+void DisplayTimedMessage(uint32_t seconds, int row, const char* msg);
 
 std::string int_to_hex(int i)
 {

--- a/impl11/ddraw/utils.h
+++ b/impl11/ddraw/utils.h
@@ -18,7 +18,7 @@ short ComputeMsgWidth(char* str, int font_size_index);
 short DisplayText(char* str, int font_size_index, short x, short y, uint32_t color);
 short DisplayCenteredText(char* str, int font_size_index, short y, uint32_t color);
 // Only rows 0..2 are available
-void DisplayTimedMessage(uint32_t seconds, int row, char* msg);
+void DisplayTimedMessage(uint32_t seconds, int row, const char* msg);
 
 #if LOGGER
 

--- a/impl11/shaders/ShimBitmapPS.hlsl
+++ b/impl11/shaders/ShimBitmapPS.hlsl
@@ -1,0 +1,67 @@
+// WineD2DEffectShim pixel shader.
+// Byte-faithful port of BitmapPixelShader.hlsl from xwa_hook_concourse (the
+// hook's custom D2D BitmapEffect, author Jeremy Ansel): optional
+// black-keying, optional monochrome tint by max(r,g,b), and
+// premultiplied-alpha output. NOTE: xwa_hook_concourse carries no license
+// file; this port's redistribution terms follow the original author's --
+// see the pull-request discussion before reusing this file elsewhere.
+cbuffer ShimCB : register(b0)
+{
+    float4 dstRect;
+    float4 uvRect;
+    float4 xformRow0;
+    float4 xformRow1;
+    float4 blendColor; // packed from uint32 LSB-first /255 like BitmapEffect::SetBlendColor
+};
+
+Texture2D tex0 : register(t0);
+SamplerState samp0 : register(s0);
+
+struct VSOut
+{
+    float4 pos : SV_POSITION;
+    float2 uv : TEXCOORD0;
+};
+
+float4 main(VSOut i) : SV_TARGET
+{
+    float4 color = tex0.Sample(samp0, i.uv);
+
+    float blendB = blendColor.r;
+    float blendG = blendColor.g;
+    float blendR = blendColor.b;
+    bool hasBlendColor = blendB != 0 || blendG != 0 || blendR != 0;
+    bool isBlackTransparent = blendColor.a >= 0.5f;
+
+    float b = color.b;
+    float g = color.g;
+    float r = color.r;
+    float a = color.a;
+
+    if (isBlackTransparent)
+    {
+        if (b == 0 && g == 0 && r == 0)
+        {
+            a = 0;
+        }
+    }
+
+    if (a != 0 && hasBlendColor)
+    {
+        float s = max(b, max(g, r));
+
+        b = s * blendB;
+        g = s * blendG;
+        r = s * blendR;
+    }
+
+    if (a == 0)
+    {
+        b = 0;
+        g = 0;
+        r = 0;
+        a = 0;
+    }
+
+    return float4(r * a, g * a, b * a, a);
+}

--- a/impl11/shaders/ShimBitmapVS.hlsl
+++ b/impl11/shaders/ShimBitmapVS.hlsl
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Peter Soetens
+// Licensed under the MIT license. See LICENSE.txt
+//
+// WineD2DEffectShim quad vertex shader.
+// Draws hook_concourse's BitmapEffect images as a native D3D11 quad, bypassing
+// wine's unimplemented d2d custom-effect path. No vertex buffer: corners are
+// generated from SV_VertexID; the D2D 3x2 world transform is applied here.
+cbuffer ShimCB : register(b0)
+{
+    float4 dstRect;   // x0,y0,x1,y1 destination in target pixels (pre-transform)
+    float4 uvRect;    // u0,v0,u1,v1
+    float4 xformRow0; // D2D matrix m11, m12, m21, m22
+    float4 xformRow1; // D2D matrix dx, dy | target width, height (px)
+    float4 blendColor; // used by the pixel shader
+};
+
+struct VSOut
+{
+    float4 pos : SV_POSITION;
+    float2 uv : TEXCOORD0;
+};
+
+VSOut main(uint id : SV_VertexID)
+{
+    float2 c = float2((float)(id & 1), (float)(id >> 1)); // (0,0)(1,0)(0,1)(1,1) tristrip
+    float2 p = float2(lerp(dstRect.x, dstRect.z, c.x), lerp(dstRect.y, dstRect.w, c.y));
+    // D2D 3x2: x' = x*m11 + y*m21 + dx ; y' = x*m12 + y*m22 + dy
+    float2 t = float2(
+        p.x * xformRow0.x + p.y * xformRow0.z + xformRow1.x,
+        p.x * xformRow0.y + p.y * xformRow0.w + xformRow1.y);
+    VSOut o;
+    o.pos = float4(t.x / xformRow1.z * 2.0f - 1.0f, 1.0f - t.y / xformRow1.w * 2.0f, 0.5f, 1.0f);
+    o.uv = float2(lerp(uvRect.x, uvRect.z, c.x), lerp(uvRect.y, uvRect.w, c.y));
+    return o;
+}


### PR DESCRIPTION
**Stacked on #125** (the first commit here is that PR; review the last two commits).

This is the core of the **XWAU-2025-on-Linux** effort: under wine, the HD concourse renders black, because wine's d2d1 returns `E_NOTIMPL` from `ID2D1DeviceContext::CreateEffect` for custom registered effects — hook_concourse ignores the hr and silently skips every draw. With this PR (plus a TgSmush PR, JeremyAnsel/xwa_TgSmush#4), XWAU 2025 is fully playable on Linux: HD concourse, crisp DWrite text, 30fps HD cutscenes, missions and simulator.

### Design rule: zero new code in the Windows draw path

`WineShim_GetRenderTarget()` checks for wine once (`ntdll!wine_get_version`); **on real Windows it returns the raw `_d2d1OffscreenRenderTarget` unchanged** — no wrapper, no overhead, no behavior change. Under wine it hands hook_concourse a proxy `ID2D1DeviceContext` that forwards everything to the real d2d objects and tries the real call first everywhere:

- `CreateEffect`: real call first; only on failure (wine) returns a shim effect. A future wine that implements custom effects automatically gets its native path back.
- `CreateBitmap`: real call first; fallback wraps a plain D3D11 texture (B8G8R8A8 or BC3 — BC3 is native to D3D11, dodging a second wine-d2d gap: `CreateBitmap`-with-data on a DXGI-surface RT fails 0x80004005 on wine-8). Also defensively nulls the out-pointer on failure (hook_concourse caches it uninitialized otherwise).
- `DrawImage(shim effect)`: `Flush()` the real RT (preserves draw order), then draw the bitmap as a D3D11 quad with a pixel shader replicating BitmapEffect's math. Transform + axis-aligned clip honored via scissor.

### Second commit: movie present + stale-flag guard

- New `ddraw.cfg` key **`TgSmushSwapchainPresentEnabled` (default 0 = stock)**: presents TgSmush shared-memory movie frames as a letterboxed quad through the D3D11 swapchain (pairs with TgSmush's new `MFD3DPresent=1`). Reason: wine flush-throttles GDI window presents to ~5–10 visible fps while the MF pipeline delivers 30.
- The three existing sites keyed on `videoFrameIndex > 0` (the `Flip` early-exit and both VR movie branches) now go through `WineShim_TgSmushMoviePlaying()`, which additionally requires the index to have **advanced within ~2s**. During normal 30fps playback this is always true (no behavior change); it only engages when TgSmush died or never cleared the flag — where the alternative is a screen frozen on the last movie frame forever. We hit this for real on wine-staging (mfplat never delivers the sample-grabber `OnShutdown`).

### Provenance / licensing
- `WineD2DEffectShim.{h,cpp}` and `ShimBitmapVS.hlsl`: MIT, headers included.
- `ShimBitmapPS.hlsl` is a byte-faithful port of hook_concourse's `BitmapPixelShader.hlsl` (Jérémy Ansel; xwa_hooks has no license file) — the file header documents this. We're asking Jérémy for his blessing; if preferred we can reimplement it from the d2d effect's documented behavior instead.

### Testing
- In-game verified on Linux (win32 prefix, real .NET hooks): HD concourse + text, briefings with animated corner displays, full missions, simulator, 30fps cutscenes with skip — on Proton 8.0 wine and GE-Proton8-26 (wine-8.0 staging). This branch (at current master) is the binary running in that install.
- Chatty diagnostics are under `#if LOGGER`; one-shot mode-engagement lines use `log_debug` like the rest of the codebase.
- Caveat for review: a QI for `ID2D1DeviceContext1`+ on the proxy forwards to the real object (interceptions lost); hook_concourse only uses `ID2D1DeviceContext` today.
- Built with clang-cl cross-toolchain; an MSVC build check on your side would be appreciated (on Windows the new code compiles but never executes past the wine check).

Happy to adjust naming, split differently, or gate things another way. Thanks for the renderer — it's remarkable how well it runs on DXVK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
